### PR TITLE
fix(ci): trigger release directly on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Test"]
-    types: [completed]
+  push:
     branches: [main, master]
   workflow_dispatch:
     inputs:
@@ -29,7 +27,7 @@ env:
 jobs:
   semantic-release:
     name: Semantic Release
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}


### PR DESCRIPTION
## Summary
- Replace the `workflow_run` chain on `Test` with a direct `push` trigger on `main`/`master` in `.github/workflows/release.yml`.
- Guard the `semantic-release` job against its own `chore(release):` bot commit to prevent a release loop.

## Why
The `Test` workflow's `OpenAPI Integration` job (`make test:openapi`, `TestOpenAPIServe_E2E_WithBinary`) has been failing on `main` since at least 2026-03-26. Because Release was gated on `github.event.workflow_run.conclusion == 'success'`, every post-merge Release run was **silently skipped** — no red CI, no notification, no release. The last successful release was a manual `workflow_dispatch` on 2026-03-26.

Coupling Release to every job in a sibling workflow is brittle; this decouples them. Branch protection still requires `Test` to pass on PRs, and `goreleaser` itself runs `make test` before publishing (unit tests only — the failing OpenAPI suite is behind `//go:build integration` and runs via the separate `make test:openapi` target, so it won't falsely block the release).

The existing `.releaserc.json` catch-all rule (`{"type": "*", "release": "patch"}`) already ensures every commit type bumps a patch version, satisfying the "every merge to main must produce a release" requirement.

## Test plan
- [ ] After merge, `gh run list --workflow=release.yml --limit 3` shows a `push`-triggered run with `conclusion=success` (not `skipped`).
- [ ] `gh release list --limit 3` shows a new `vX.Y.Z` tag newer than the 2026-03-26 release.
- [ ] The release bot's own `chore(release): X.Y.Z [skip ci]` commit does not re-trigger Release (only one run per human merge).
- [ ] `gh workflow run Release -f dry-run=true` from `main` still works via `workflow_dispatch`.

## Follow-ups (not in this PR)
- Fix `TestOpenAPIServe_E2E_WithBinary` failures in `rpc/openapi_serve_integration_test.go` — real product bugs, currently red on `main`.
- Reconcile `GO_VERSION`: `release.yml` pins `1.25`, `test.yml`/`lint.yml` pin `1.26`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation by updating workflow triggers to run on direct branch pushes and manual dispatches, with enhanced filtering to prevent redundant release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->