### PR TITLE
fix(ci): use semantic-release-action so step outputs populate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,60 +47,20 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install semantic-release
-        run: |
-          npm install -g semantic-release@23 \
-            @semantic-release/git@10 \
-            @semantic-release/github@10 \
-            @semantic-release/changelog@6 \
-            @semantic-release/exec@6 \
-            conventional-changelog-conventionalcommits@7
-
-      - name: Semantic Release (Dry Run)
-        if: github.event.inputs.dry-run == 'true'
-        id: semantic-dry
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npx semantic-release --dry-run --no-ci
-
-      - name: Check for changes since last release
-        id: changes
-        run: |
-          # Get the last release tag
-          LAST_TAG=$(git tag --list --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          echo "last_tag=${LAST_TAG}" >> $GITHUB_OUTPUT
-
-          if [ -z "$LAST_TAG" ]; then
-            echo "No previous release found, this will be the first release"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "commits_since_last=0" >> $GITHUB_OUTPUT
-          else
-            # Count commits since last tag
-            COMMITS_SINCE=$(git rev-list --count ${LAST_TAG}..HEAD)
-            echo "commits_since_last=${COMMITS_SINCE}" >> $GITHUB_OUTPUT
-            echo "Found ${COMMITS_SINCE} commits since last release (${LAST_TAG})"
-
-            if [ "$COMMITS_SINCE" -gt 0 ]; then
-              echo "has_changes=true" >> $GITHUB_OUTPUT
-              echo "Changes detected since last release:"
-              git log --oneline ${LAST_TAG}..HEAD | head -10
-            else
-              echo "has_changes=false" >> $GITHUB_OUTPUT
-              echo "No changes since last release"
-            fi
-          fi
-
       - name: Semantic Release
-        if: github.event.inputs.dry-run != 'true'
         id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 23
+          dry_run: ${{ github.event.inputs.dry-run == 'true' }}
+          extra_plugins: |
+            @semantic-release/git@10
+            @semantic-release/github@10
+            @semantic-release/changelog@6
+            @semantic-release/exec@6
+            conventional-changelog-conventionalcommits@7
         env:
           GITHUB_TOKEN: ${{ secrets.FLANKBOT }}
-        run: |
-          echo "Running semantic-release with enhanced patch rules..."
-          echo "Last tag: ${{ steps.changes.outputs.last_tag }}"
-          echo "Commits since last release: ${{ steps.changes.outputs.commits_since_last }}"
-          npx semantic-release
 
       - name: Release Summary
         if: github.event.inputs.dry-run != 'true'


### PR DESCRIPTION
## Summary
- Replace the shell `npx semantic-release` invocation with `cycjimmy/semantic-release-action@v4`, which populates the `new_release_published` / `new_release_version` step outputs that `goreleaser` and `announce` jobs gate on.

## Why
Run [24336200468](https://github.com/flanksource/clicky/actions/runs/24336200468) shows `Semantic Release` succeeding and publishing **v1.21.2**, but the `GoReleaser` and `Announce Release` jobs both skipped because `needs.semantic-release.outputs.new_release_published == 'true'` was false.

Root cause: the previous workflow ran `npx semantic-release` directly in a shell step with `id: semantic`. That publishes the release fine, but it never writes anything to `$GITHUB_OUTPUT`, so `steps.semantic.outputs.*` are all empty — even though the job-level `outputs:` block references them.

Consequence: **v1.21.2 exists as an empty GitHub release with zero assets**. No binaries, no Homebrew tap, no Scoop, no Docker image were published.

`cycjimmy/semantic-release-action@v4` wraps semantic-release and explicitly writes the outputs the downstream jobs need. Same plugins (`@semantic-release/git`, `github`, `changelog`, `exec`, `conventional-changelog-conventionalcommits`) are passed via `extra_plugins`; `dry_run` is wired to the existing workflow_dispatch input.

## Test plan
- [ ] After merge, check `gh run view --job=<goreleaser-job-id>` — GoReleaser should run, not skip.
- [ ] `gh release view v1.21.3 --json assets` (or whatever the next tag is) should list Linux/macOS/Windows binaries, checksums, and archives.
- [ ] Homebrew tap + Scoop bucket PRs should open automatically.
- [ ] Docker image `ghcr.io/flanksource/clicky:v1.21.3` should be pushed.
- [ ] `gh workflow run Release -f dry-run=true` still works via workflow_dispatch.

## Follow-up
- **v1.21.2 is a broken empty release.** Decide whether to delete it (`gh release delete v1.21.2 --cleanup-tag`) or leave it in place and let v1.21.3 supersede it. Deleting and retagging is cleaner if anyone might `brew install` or `go install` at v1.21.2.