### PR TITLE
fix: Improve in-memory timeseries store write performance

### DIFF
--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Gavel test
         uses: flanksource/gavel@main
         with:
-          args: test
+          args: test --test-timeout 10m --timeout 20m
           comment-header: gavel-test
           artifact-name: gavel-test-results
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ dist/
 *.tar.gz
 *.zip
 
+*pprof
+
 # Note: task/ui/dist/taskui.js is committed (it is `//go:embed`-ed by
 # task/ui/assets.go so downstream modules can build). The un-ignore rule
 # lives in task/ui/.gitignore, which the broad dist/ rule there would

--- a/metrics/inmemory.go
+++ b/metrics/inmemory.go
@@ -55,16 +55,32 @@ func (m *memoryStore) Record(req RecordRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pts := append(m.series[req.ID], Point{At: at, Value: req.Value})
-	// Keep ascending by time; the appended point is usually already the
-	// latest, so this is a near-no-op in the common path.
-	sort.Slice(pts, func(i, j int) bool { return pts[i].At.Before(pts[j].At) })
+	pts, ok := m.series[req.ID]
+	if !ok {
+		pts = make([]Point, 0, min(1_000_000, m.maxPoints))
+	}
 
+	p := Point{At: at, Value: req.Value}
+	if len(pts) == 0 || !p.At.Before(pts[len(pts)-1].At) {
+		pts = append(pts, p)
+	} else {
+		// Out-of-order records are expected to be rare. Keep the common path as
+		// a cheap append and only pay insertion cost when a late point arrives.
+		i := sort.Search(len(pts), func(i int) bool { return !pts[i].At.Before(p.At) })
+		pts = append(pts, Point{})
+		copy(pts[i+1:], pts[i:])
+		pts[i] = p
+	}
+
+	// Retention management
 	cutoff := at.Add(-m.retention)
-	pts = dropBefore(pts, cutoff)
+	if len(pts) > 0 && pts[0].At.Before(cutoff) {
+		pts = dropBefore(pts, cutoff)
+	}
 	if len(pts) > m.maxPoints {
 		pts = pts[len(pts)-m.maxPoints:]
 	}
+
 	m.series[req.ID] = pts
 	return nil
 }

--- a/metrics/inmemory_benchmark_test.go
+++ b/metrics/inmemory_benchmark_test.go
@@ -1,0 +1,28 @@
+package metrics_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flanksource/clicky/metrics"
+)
+
+func BenchmarkMemoryRecordInOrderSingleSeries(b *testing.B) {
+	ts := metrics.NewMemory(metrics.MemoryConfig{
+		Retention: 365 * 24 * time.Hour,
+		MaxPoints: 1_000_000,
+	})
+	start := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	i := 0
+	for b.Loop() {
+		if err := ts.Record(metrics.RecordRequest{
+			ID:    "cpu",
+			At:    start.Add(time.Duration(i) * time.Millisecond),
+			Value: float64(i),
+		}); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}


### PR DESCRIPTION
Drastically improves write performance for happy path

Avoid sorting the entire series on every Record. Metrics are expected to arrive
mostly in timestamp order, so append directly on the happy path and only use
binary insertion for rare out-of-order records.

Also avoid running retention binary search on every write when the oldest point
is still within the retention window, and preallocate the per-series slice up to
the configured max.

## Before

```
goos: darwin
goarch: arm64
pkg: github.com/flanksource/clicky/metrics
cpu: Apple M4 Pro
BenchmarkMemoryRecordInOrderSingleSeries-12          85758       106286 ns/op        268 B/op          3 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12          96343       119096 ns/op        288 B/op          3 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12          97329       121221 ns/op        286 B/op          3 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12          86374       110169 ns/op        266 B/op          3 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12          88762       110456 ns/op        262 B/op          3 allocs/op
PASS
ok     github.com/flanksource/clicky/metrics   52.305s

Took 52.7s
```

## After

```
goos: darwin
goarch: arm64
pkg: github.com/flanksource/clicky/metrics
cpu: Apple M4 Pro
BenchmarkMemoryRecordInOrderSingleSeries-12     28185057                36.16 ns/op          155 B/op          0 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12     42450765                35.50 ns/op          157 B/op          0 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12     43180870                35.47 ns/op          157 B/op          0 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12     44103121                35.75 ns/op          157 B/op          0 allocs/op
BenchmarkMemoryRecordInOrderSingleSeries-12     42853507                35.08 ns/op          157 B/op          0 allocs/op
PASS
ok      github.com/flanksource/clicky/metrics   7.886s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized metrics recording performance for improved efficiency.

* **Tests**
  * Added benchmark for single-series metric recording.

* **Chores**
  * Updated CI/CD test timeouts and expanded gitignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->