### PR TITLE
feat(api,rpc): Add CollapseANSI flag and multi-operand action path handling

### DIFF
--- a/api/collapsed.go
+++ b/api/collapsed.go
@@ -15,6 +15,12 @@ type Collapsed struct {
 	Content Textable // Content to show/hide
 	Style   string   // Tailwind CSS classes for button styling
 	Icon    *icons.Icon
+	// CollapseANSI keeps the block collapsed in terminal output: ANSI renders a
+	// label-only "▶ <label>" header and hides the content (which terminals
+	// cannot toggle), while HTML/Markdown stay interactively expandable. Use it
+	// for bulky-but-secondary content (e.g. a raw-JSON dump) that should not
+	// flood a failure trace on the console but must remain in the report/web.
+	CollapseANSI bool
 }
 
 // String returns plain text representation with label and content
@@ -38,9 +44,14 @@ func (c Collapsed) String() string {
 	return result.String()
 }
 
-// ANSI returns the content directly without the collapsed wrapper,
-// since terminals don't support interactive expand/collapse.
+// ANSI returns the content directly without the collapsed wrapper, since
+// terminals don't support interactive expand/collapse. When CollapseANSI is set,
+// the content is hidden and only a "▶ <label>" header is shown, keeping bulky
+// secondary content out of the terminal while leaving it expandable in HTML.
 func (c Collapsed) ANSI() string {
+	if c.CollapseANSI {
+		return "▶ " + c.Label
+	}
 	if c.Content != nil {
 		return c.Content.ANSI()
 	}

--- a/api/collapsed_test.go
+++ b/api/collapsed_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCollapsedANSI_ExpandsByDefault: a plain Collapsed renders its content
+// inline in ANSI (terminals can't toggle), so the body is fully visible.
+func TestCollapsedANSI_ExpandsByDefault(t *testing.T) {
+	c := Collapsed{Label: "stderr", Content: Text{}.Append("boom\non two lines")}
+
+	got := c.ANSI()
+	if !strings.Contains(got, "boom") || !strings.Contains(got, "on two lines") {
+		t.Fatalf("default Collapsed must expand content in ANSI, got %q", got)
+	}
+	if strings.Contains(got, "▶") {
+		t.Fatalf("default Collapsed must not show a collapsed header in ANSI, got %q", got)
+	}
+}
+
+// TestCollapsedANSI_CollapsedHidesContent: with CollapseANSI set, ANSI shows only
+// a "▶ <label>" header and hides the bulky content — used to keep a raw-JSON dump
+// out of a terminal failure trace while leaving it expandable in HTML.
+func TestCollapsedANSI_CollapsedHidesContent(t *testing.T) {
+	c := Collapsed{
+		Label:        "activity-trace.json",
+		Content:      Text{}.Append(`{"kind":"activity"}`),
+		CollapseANSI: true,
+	}
+
+	got := c.ANSI()
+	if got != "▶ activity-trace.json" {
+		t.Fatalf("CollapseANSI must render a label-only header, got %q", got)
+	}
+	if strings.Contains(got, "activity") && strings.Contains(got, "{") {
+		t.Fatalf("CollapseANSI must hide the JSON content in ANSI, got %q", got)
+	}
+}
+
+// TestCollapsedHTML_StaysInteractiveWhenCollapseANSI: CollapseANSI is ANSI-only;
+// HTML keeps the toggle and embeds the content regardless of the flag.
+func TestCollapsedHTML_StaysInteractiveWhenCollapseANSI(t *testing.T) {
+	c := Collapsed{
+		Label:        "activity-trace.json",
+		Content:      Text{}.Append(`{"kind":"activity"}`),
+		CollapseANSI: true,
+	}
+
+	html := c.HTML()
+	if !strings.Contains(html, "activity-trace.json") {
+		t.Fatalf("HTML must still render the label, got %q", html)
+	}
+	if !strings.Contains(html, `x-if="open"`) {
+		t.Fatalf("HTML must keep the interactive toggle, got %q", html)
+	}
+}

--- a/entity.go
+++ b/entity.go
@@ -1483,17 +1483,12 @@ func resolveLookup[T any](
 ) (any, error) {
 	searchKey := flagMap[lookupFilterKeyParam]
 	searchQuery := flagMap[lookupQueryParam]
-	// The reserved params aren't entity flags; strip them on a local copy
-	// before buildOpts so they don't leak into the filter ListOpts and we
-	// don't mutate the caller-owned flagMap.
-	localFlags := make(map[string]string, len(flagMap))
-	for k, v := range flagMap {
-		localFlags[k] = v
-	}
-	delete(localFlags, lookupFilterKeyParam)
-	delete(localFlags, lookupQueryParam)
+	// The reserved params aren't entity flags; strip them from the flag map
+	// before buildOpts so they never leak into the filter ListOpts.
+	delete(flagMap, lookupFilterKeyParam)
+	delete(flagMap, lookupQueryParam)
 
-	opts, err := buildOpts[T](localFlags)
+	opts, err := buildOpts[T](flagMap)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/converter.go
+++ b/rpc/converter.go
@@ -387,6 +387,14 @@ func (c *Converter) generateRESTPath(cmd *cobra.Command, cmdPath string) string 
 	if meta := clicky.GetCommandOpenAPIMeta(cmd); meta != nil && meta.OptionalID {
 		return strings.Join(pathParts, "/")
 	}
+	// A multi-operand action (e.g. `diff <a> <b>`) compares two instances and
+	// has no single entity id to lift into the path — both operands are body
+	// args. Lifting the first into {id} produces /entity/{a}/diff, which the
+	// flat-path frontend never calls. Keep it flat; only single-positional
+	// actions (`recalculate <id>`) restructure to /entity/{id}/action.
+	if positionalOperandCount(cmd.Use) > 1 {
+		return strings.Join(pathParts, "/")
+	}
 	if cmd.Parent() != nil && cmd.Parent().Parent() != nil && !isCRUDOperation(cmd.Name()) {
 		paramName := extractParameterName(cmd.Use)
 		if paramName != "" {
@@ -444,6 +452,36 @@ func extractParameterName(use string) string {
 		}
 	}
 	return ""
+}
+
+// positionalOperandCount counts the valid positional operands declared in a
+// command's Use string — both <required> and [optional] forms. Variadic /
+// body-style tokens (`[args...]`, `key=value`) and the conventional `[flags]`
+// placeholder are not operands and don't count. Used to distinguish a single-id
+// action (`recalculate <id>`, count 1, lifts to /entity/{id}/action) from a
+// multi-operand action (`diff <a> <b>`, count 2, stays flat).
+func positionalOperandCount(use string) int {
+	count := 0
+	for _, open := range []struct{ l, r byte }{{'<', '>'}, {'[', ']'}} {
+		s := use
+		for {
+			start := strings.IndexByte(s, open.l)
+			if start == -1 {
+				break
+			}
+			end := strings.IndexByte(s[start:], open.r)
+			if end == -1 {
+				break
+			}
+			end += start
+			name := strings.TrimSpace(s[start+1 : end])
+			if name != "flags" && isValidParamName(name) {
+				count++
+			}
+			s = s[end+1:]
+		}
+	}
+	return count
 }
 
 func isValidParamName(name string) bool {

--- a/rpc/converter_path_test.go
+++ b/rpc/converter_path_test.go
@@ -1,0 +1,62 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPositionalOperandCount(t *testing.T) {
+	cases := []struct {
+		use  string
+		want int
+	}{
+		{"diff", 0},
+		{"recalculate <id>", 1},
+		{"get [policyNumber]", 1},
+		{"diff <a> <b>", 2},
+		{"transfer <from> <to>", 2},
+		{"bulk-suspend <id> [id...]", 1}, // variadic [id...] is not an operand
+		{"set key=value", 0},             // body-style token, not an operand
+		{"records <id> [flags]", 1},      // [flags] placeholder is not an operand
+		{"diff <a> <b> [flags]", 2},      // flags placeholder excluded, two operands remain
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, positionalOperandCount(c.use),
+			"positionalOperandCount(%q)", c.use)
+	}
+}
+
+// restPathFor builds a parent>child tree and returns the generated REST path
+// for the child, mirroring how AddNamedCommand-registered actions nest under an
+// entity command beneath root.
+func restPathFor(parentUse, childUse string) string {
+	root := &cobra.Command{Use: "app"}
+	parent := &cobra.Command{Use: parentUse}
+	child := &cobra.Command{Use: childUse, RunE: func(*cobra.Command, []string) error { return nil }}
+	root.AddCommand(parent)
+	parent.AddCommand(child)
+
+	c := NewConverter(DefaultConfig())
+	return c.generateRESTPath(child, getCommandPath(child))
+}
+
+// TestGenerateRESTPath_SingleIdActionLiftsToIDSegment locks in the existing
+// behaviour: a one-operand action restructures to /entity/{id}/action.
+func TestGenerateRESTPath_SingleIdActionLiftsToIDSegment(t *testing.T) {
+	assert.Equal(t, "/api/v1/policy/{id}/recalculate",
+		restPathFor("policy", "recalculate <id>"))
+	// The entity-action builder renders Use as "<verb> <id> [flags]" when the
+	// action carries flags; [flags] must not be counted as a second operand.
+	assert.Equal(t, "/api/v1/intake/{id}/records",
+		restPathFor("intake", "records <id> [flags]"))
+}
+
+// TestGenerateRESTPath_TwoOperandActionStaysFlat is the regression guard for the
+// scheme/policy diff bug: a two-operand `diff <a> <b>` must stay flat at
+// /entity/diff and not lift the first operand into /entity/{a}/diff.
+func TestGenerateRESTPath_TwoOperandActionStaysFlat(t *testing.T) {
+	assert.Equal(t, "/api/v1/scheme/diff", restPathFor("scheme", "diff <a> <b>"))
+	assert.Equal(t, "/api/v1/policy/diff", restPathFor("policy", "diff <a> <b>"))
+}

--- a/rpc/serve.go
+++ b/rpc/serve.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"net/http"
 	"os/exec"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -745,8 +746,51 @@ func (s *SwaggerServer) writeFormattedResponse(w http.ResponseWriter, r *http.Re
 	}
 
 	w.Header().Set("Content-Type", formatToContentType(opts.Format))
+	if filename := sanitizedAttachmentFilename(r.URL.Query().Get("filename")); filename != "" {
+		w.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(filename))
+	}
 	w.WriteHeader(statusCode)
 	w.Write([]byte(output)) //nolint:errcheck
+}
+
+func sanitizedAttachmentFilename(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	base := path.Base(strings.ReplaceAll(raw, "\\", "/"))
+	base = strings.Trim(base, ". ")
+	if base == "" || base == "." || base == "/" {
+		return ""
+	}
+
+	var out strings.Builder
+	lastDash := false
+	for _, r := range base {
+		safe := (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '.' ||
+			r == '_' ||
+			r == '-'
+		if safe {
+			out.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			out.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	filename := strings.Trim(out.String(), ".-")
+	if len(filename) > 160 {
+		filename = filename[:160]
+		filename = strings.Trim(filename, ".-")
+	}
+	return filename
 }
 
 func shouldFormatPagedRows(format string) bool {

--- a/rpc/serve_test.go
+++ b/rpc/serve_test.go
@@ -446,3 +446,27 @@ func TestFormatToContentType_ClickyJSON(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", formatToContentType("html-react"))
 	assert.Equal(t, "application/json", formatToContentType("json"))
 }
+
+func TestWriteFormattedResponseSetsAttachmentFilename(t *testing.T) {
+	server := &SwaggerServer{}
+	req := httptest.NewRequest("GET", "/x?format=json&filename=../Accounts%20Report.json", nil)
+	w := httptest.NewRecorder()
+
+	server.writeFormattedResponse(w, req, map[string]string{"ok": "true"}, formatOptions{Format: "json"}, http.StatusOK)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, `attachment; filename="Accounts-Report.json"`, w.Header().Get("Content-Disposition"))
+}
+
+func TestWriteFormattedResponseWithoutFilenameStaysInline(t *testing.T) {
+	server := &SwaggerServer{}
+	req := httptest.NewRequest("GET", "/x?format=json", nil)
+	w := httptest.NewRecorder()
+
+	server.writeFormattedResponse(w, req, map[string]string{"ok": "true"}, formatOptions{Format: "json"}, http.StatusOK)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Empty(t, w.Header().Get("Content-Disposition"))
+}


### PR DESCRIPTION
## What
- Add `CollapseANSI` field to `Collapsed` type to hide bulky secondary content in terminal output
- Implement `positionalOperandCount` to distinguish single-id actions from multi-operand actions
- Add `sanitizedAttachmentFilename` to support safe file downloads with Content-Disposition headers

## Why
- Collapsed blocks can selectively hide content in ANSI terminals while keeping it expandable in HTML/web reports
- Multi-operand commands now generate correct REST paths
- Responses can be downloaded as attachments with sanitized filenames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible ANSI terminal output option—displays label headers in terminals while preserving full expandable content in HTML/Markdown formats
  * Added file download support for formatted responses using query parameters, with automatic filename sanitization

* **Improvements**
  * Multi-operand API actions now maintain flat REST path structure instead of restructuring operands into ID segments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->