### PR TITLE
feat(cache): add generic cache-browser API with valkey impl

### DIFF
--- a/cache/browser.go
+++ b/cache/browser.go
@@ -1,0 +1,148 @@
+// Package cache defines clicky's generic cache-browser contract: a read/admin
+// API over a key-value cache keyspace (valkey/redis or anything shaped like
+// it) that groups keys into a prefix tree, serves per-key detail, search,
+// whole-keyspace stats, and key/prefix deletion.
+//
+// The package mirrors the metrics split: the interface plus the HTTP handler
+// live here in the root module, while backend implementations live in their
+// own modules (github.com/flanksource/clicky/valkey) so the root module never
+// pulls in client dependencies.
+package cache
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrKeyNotFound is returned by Browser.Key when the key does not exist. The
+// HTTP handler maps it to a 404.
+var ErrKeyNotFound = errors.New("cache: key not found")
+
+// TreeRequest asks for one level of the key tree under Prefix. Keys are split
+// on the backend's separator (":" for valkey); each distinct next segment
+// becomes either a group node (more segments follow) or a leaf (an actual
+// key).
+type TreeRequest struct {
+	// Prefix is the logical prefix to expand, e.g. "tx:". Empty expands the
+	// root. It must include the trailing separator when pointing at a group.
+	Prefix string
+	// MaxChildren caps the number of nodes returned for the level. Zero uses
+	// the backend default.
+	MaxChildren int
+}
+
+// TreeNode is one entry in a tree level: either a group of keys sharing the
+// next path segment, or a single leaf key.
+type TreeNode struct {
+	// Name is the display segment: the next path segment for groups, the
+	// remaining key tail for leaves.
+	Name string `json:"name"`
+	// Prefix is set on group nodes only: the full logical prefix including
+	// the trailing separator, ready to feed back into TreeRequest.Prefix.
+	Prefix string `json:"prefix,omitempty"`
+	// Key is set on leaf nodes only: the full logical key.
+	Key string `json:"key,omitempty"`
+	// Keys is the total number of keys under this node (1 for a leaf).
+	Keys int `json:"keys"`
+	// Children is the number of distinct child segments under a group node.
+	Children int `json:"children,omitempty"`
+	// Type is the value type of a leaf: string|hash|list|set|zset|stream.
+	Type string `json:"type,omitempty"`
+	// TTLSeconds is the leaf's remaining TTL; -1 means no expiry.
+	TTLSeconds int64 `json:"ttlSeconds,omitempty"`
+	// Bytes is the MEMORY USAGE of the node when the server supports it: the
+	// leaf's own size, or for a group the aggregated size of every key
+	// beneath it.
+	Bytes int64 `json:"bytes,omitempty"`
+}
+
+// TreeResponse is one expanded tree level.
+type TreeResponse struct {
+	Prefix string     `json:"prefix"`
+	Nodes  []TreeNode `json:"nodes"`
+	// Keys is the total number of keys scanned under Prefix, including keys
+	// rolled up into group nodes.
+	Keys int `json:"keys"`
+	// Truncated is set when the node list or the underlying scan hit a cap;
+	// counts are then lower bounds.
+	Truncated bool `json:"truncated,omitempty"`
+	// BytesSupported reports whether per-key byte sizes were available
+	// (MEMORY USAGE); when false every Bytes field is absent, not zero.
+	BytesSupported bool `json:"bytesSupported"`
+}
+
+// ScoredMember is one zset member with its score.
+type ScoredMember struct {
+	Member string  `json:"member"`
+	Score  float64 `json:"score"`
+}
+
+// KeyDetail is the full detail for a single key. Exactly one of Value,
+// Fields, Items, Members is populated according to Type.
+type KeyDetail struct {
+	Key        string `json:"key"`
+	Type       string `json:"type"`
+	TTLSeconds int64  `json:"ttlSeconds"`
+	// Bytes is MEMORY USAGE when supported, otherwise omitted.
+	Bytes int64 `json:"bytes,omitempty"`
+	// Length is the full value length: STRLEN, HLEN, LLEN, SCARD or ZCARD.
+	Length  int64             `json:"length"`
+	Value   string            `json:"value,omitempty"`
+	Fields  map[string]string `json:"fields,omitempty"`
+	Items   []string          `json:"items,omitempty"`
+	Members []ScoredMember    `json:"members,omitempty"`
+	// Truncated is set when the returned value was capped (string bytes or
+	// collection items); Length still reports the full size.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// SearchRequest is a substring search over the whole keyspace.
+type SearchRequest struct {
+	Query string
+	// Limit caps the number of returned keys. Zero uses the backend default.
+	Limit int
+}
+
+// SearchResponse lists matching keys as leaf nodes.
+type SearchResponse struct {
+	Keys      []TreeNode `json:"keys"`
+	Truncated bool       `json:"truncated,omitempty"`
+}
+
+// Stats is a whole-keyspace overview. Keys is always populated; the
+// server-info fields are populated only when the backend's INFO command
+// succeeded — when it failed or is unsupported, InfoError carries the reason
+// so the caller can render the gap honestly instead of showing zeros.
+type Stats struct {
+	Keys int64 `json:"keys"`
+	// KeysTruncated is set when Keys was counted by a capped scan (namespaced
+	// keyspaces) and is therefore a lower bound.
+	KeysTruncated    bool   `json:"keysTruncated,omitempty"`
+	UsedMemoryBytes  int64  `json:"usedMemoryBytes,omitempty"`
+	MaxMemoryBytes   int64  `json:"maxMemoryBytes,omitempty"`
+	Hits             int64  `json:"hits,omitempty"`
+	Misses           int64  `json:"misses,omitempty"`
+	EvictedKeys      int64  `json:"evictedKeys,omitempty"`
+	ExpiredKeys      int64  `json:"expiredKeys,omitempty"`
+	ConnectedClients int64  `json:"connectedClients,omitempty"`
+	Version          string `json:"version,omitempty"`
+	UptimeSeconds    int64  `json:"uptimeSeconds,omitempty"`
+	InfoError        string `json:"infoError,omitempty"`
+}
+
+// DeleteResponse reports how many keys a delete removed.
+type DeleteResponse struct {
+	Deleted int64 `json:"deleted"`
+}
+
+// Browser is the backend contract the HTTP handler serves. All keys and
+// prefixes are logical: implementations strip any physical namespace prefix
+// before returning and re-apply it on lookups.
+type Browser interface {
+	Tree(ctx context.Context, req TreeRequest) (TreeResponse, error)
+	Key(ctx context.Context, key string) (KeyDetail, error)
+	Search(ctx context.Context, req SearchRequest) (SearchResponse, error)
+	Stats(ctx context.Context) (Stats, error)
+	DeleteKey(ctx context.Context, key string) (DeleteResponse, error)
+	DeletePrefix(ctx context.Context, prefix string) (DeleteResponse, error)
+}

--- a/cache/cache_suite_test.go
+++ b/cache/cache_suite_test.go
@@ -1,0 +1,13 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCache(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Cache Browser Suite")
+}

--- a/cache/handler.go
+++ b/cache/handler.go
@@ -1,0 +1,114 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+// RegisterRoutes mounts the cache-browser endpoints on mux under prefix:
+//
+//	GET    {prefix}/cache/tree?prefix=&max=
+//	GET    {prefix}/cache/key?key=
+//	GET    {prefix}/cache/search?q=&limit=
+//	GET    {prefix}/cache/stats
+//	DELETE {prefix}/cache/key?key=
+//	DELETE {prefix}/cache/prefix?prefix=
+//
+// Keys travel in query parameters, not path segments, because cache keys
+// routinely contain ":" and "/". prefix is the leading path segment shared
+// with the rest of the API (e.g. "/api/v1"); pass it without a trailing
+// slash.
+func RegisterRoutes(mux *http.ServeMux, b Browser, prefix string) {
+	mux.Handle(prefix+"/cache/", Handler(b, prefix))
+}
+
+// Handler returns the cache-browser endpoints as a standalone http.Handler
+// for callers that compose their own mux.
+func Handler(b Browser, prefix string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+prefix+"/cache/tree", func(w http.ResponseWriter, r *http.Request) {
+		max, err := intParam(r, "max")
+		if err != nil {
+			http.Error(w, "invalid max: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		v, err := b.Tree(r.Context(), TreeRequest{
+			Prefix:      r.URL.Query().Get("prefix"),
+			MaxChildren: max,
+		})
+		respond(w, v, err)
+	})
+	mux.HandleFunc("GET "+prefix+"/cache/key", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		if key == "" {
+			http.Error(w, "missing key", http.StatusBadRequest)
+			return
+		}
+		v, err := b.Key(r.Context(), key)
+		respond(w, v, err)
+	})
+	mux.HandleFunc("GET "+prefix+"/cache/search", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			http.Error(w, "missing q", http.StatusBadRequest)
+			return
+		}
+		limit, err := intParam(r, "limit")
+		if err != nil {
+			http.Error(w, "invalid limit: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		v, err := b.Search(r.Context(), SearchRequest{Query: q, Limit: limit})
+		respond(w, v, err)
+	})
+	mux.HandleFunc("GET "+prefix+"/cache/stats", func(w http.ResponseWriter, r *http.Request) {
+		v, err := b.Stats(r.Context())
+		respond(w, v, err)
+	})
+	mux.HandleFunc("DELETE "+prefix+"/cache/key", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		if key == "" {
+			http.Error(w, "missing key", http.StatusBadRequest)
+			return
+		}
+		v, err := b.DeleteKey(r.Context(), key)
+		respond(w, v, err)
+	})
+	mux.HandleFunc("DELETE "+prefix+"/cache/prefix", func(w http.ResponseWriter, r *http.Request) {
+		// An empty prefix would wipe the whole keyspace; that must never be
+		// reachable from a missing parameter.
+		p := r.URL.Query().Get("prefix")
+		if p == "" {
+			http.Error(w, "missing prefix", http.StatusBadRequest)
+			return
+		}
+		v, err := b.DeletePrefix(r.Context(), p)
+		respond(w, v, err)
+	})
+	return mux
+}
+
+// respond writes v as JSON, mapping ErrKeyNotFound to 404 and any other
+// error to 500.
+func respond[T any](w http.ResponseWriter, v T, err error) {
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, ErrKeyNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func intParam(r *http.Request, name string) (int, error) {
+	raw := r.URL.Query().Get(name)
+	if raw == "" {
+		return 0, nil
+	}
+	return strconv.Atoi(raw)
+}

--- a/cache/handler.go
+++ b/cache/handler.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 )
@@ -110,5 +111,12 @@ func intParam(r *http.Request, name string) (int, error) {
 	if raw == "" {
 		return 0, nil
 	}
-	return strconv.Atoi(raw)
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, err
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("%s must be >= 0, got %d", name, v)
+	}
+	return v, nil
 }

--- a/cache/handler_test.go
+++ b/cache/handler_test.go
@@ -117,6 +117,16 @@ var _ = Describe("Cache HTTP handler", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})
 
+	It("rejects a negative max", func() {
+		resp, _ := get("/api/v1/cache/tree?max=-1")
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
+	It("rejects a negative search limit", func() {
+		resp, _ := get("/api/v1/cache/search?q=tx&limit=-5")
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
 	It("serves key detail with the key taken from the query", func() {
 		resp, body := get("/api/v1/cache/key?key=tx%3Aabc%2Fdef")
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/cache/handler_test.go
+++ b/cache/handler_test.go
@@ -1,0 +1,172 @@
+package cache_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/flanksource/clicky/cache"
+)
+
+// fakeBrowser records the last request it saw and replies with canned data so
+// the specs can assert parameter plumbing and JSON encoding without a real
+// backend.
+type fakeBrowser struct {
+	lastTree   cache.TreeRequest
+	lastKey    string
+	lastSearch cache.SearchRequest
+	lastDelete string
+	keyErr     error
+}
+
+func (f *fakeBrowser) Tree(_ context.Context, req cache.TreeRequest) (cache.TreeResponse, error) {
+	f.lastTree = req
+	return cache.TreeResponse{
+		Prefix: req.Prefix,
+		Nodes: []cache.TreeNode{
+			{Name: "tx", Prefix: "tx:", Keys: 12, Children: 12},
+			{Name: "marker", Key: "marker", Keys: 1, Type: "string", TTLSeconds: -1},
+		},
+		Keys:           13,
+		BytesSupported: true,
+	}, nil
+}
+
+func (f *fakeBrowser) Key(_ context.Context, key string) (cache.KeyDetail, error) {
+	f.lastKey = key
+	if f.keyErr != nil {
+		return cache.KeyDetail{}, f.keyErr
+	}
+	return cache.KeyDetail{Key: key, Type: "string", TTLSeconds: -1, Length: 5, Value: "hello"}, nil
+}
+
+func (f *fakeBrowser) Search(_ context.Context, req cache.SearchRequest) (cache.SearchResponse, error) {
+	f.lastSearch = req
+	return cache.SearchResponse{Keys: []cache.TreeNode{{Name: "tx:1", Key: "tx:1", Keys: 1, Type: "string"}}}, nil
+}
+
+func (f *fakeBrowser) Stats(context.Context) (cache.Stats, error) {
+	return cache.Stats{Keys: 13, Version: "7.2.0"}, nil
+}
+
+func (f *fakeBrowser) DeleteKey(_ context.Context, key string) (cache.DeleteResponse, error) {
+	f.lastDelete = key
+	return cache.DeleteResponse{Deleted: 1}, nil
+}
+
+func (f *fakeBrowser) DeletePrefix(_ context.Context, prefix string) (cache.DeleteResponse, error) {
+	f.lastDelete = prefix
+	return cache.DeleteResponse{Deleted: 12}, nil
+}
+
+var _ = Describe("Cache HTTP handler", func() {
+	var (
+		browser *fakeBrowser
+		server  *httptest.Server
+	)
+
+	BeforeEach(func() {
+		browser = &fakeBrowser{}
+		mux := http.NewServeMux()
+		cache.RegisterRoutes(mux, browser, "/api/v1")
+		server = httptest.NewServer(mux)
+		DeferCleanup(server.Close)
+	})
+
+	get := func(path string) (*http.Response, map[string]any) {
+		GinkgoHelper()
+		resp, err := http.Get(server.URL + path)
+		Expect(err).NotTo(HaveOccurred())
+		var body map[string]any
+		if resp.Header.Get("Content-Type") == "application/json" {
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+		}
+		resp.Body.Close()
+		return resp, body
+	}
+
+	del := func(path string) (*http.Response, map[string]any) {
+		GinkgoHelper()
+		req, err := http.NewRequest(http.MethodDelete, server.URL+path, nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		var body map[string]any
+		if resp.Header.Get("Content-Type") == "application/json" {
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+		}
+		resp.Body.Close()
+		return resp, body
+	}
+
+	It("serves a tree level and threads prefix and max through", func() {
+		resp, body := get("/api/v1/cache/tree?prefix=tx%3A&max=50")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(browser.lastTree).To(Equal(cache.TreeRequest{Prefix: "tx:", MaxChildren: 50}))
+		Expect(body["keys"]).To(BeEquivalentTo(13))
+		Expect(body["bytesSupported"]).To(BeTrue())
+		Expect(body["nodes"]).To(HaveLen(2))
+	})
+
+	It("rejects a non-numeric max", func() {
+		resp, _ := get("/api/v1/cache/tree?max=lots")
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
+	It("serves key detail with the key taken from the query", func() {
+		resp, body := get("/api/v1/cache/key?key=tx%3Aabc%2Fdef")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(browser.lastKey).To(Equal("tx:abc/def"))
+		Expect(body["value"]).To(Equal("hello"))
+	})
+
+	It("maps ErrKeyNotFound to 404", func() {
+		browser.keyErr = cache.ErrKeyNotFound
+		resp, _ := get("/api/v1/cache/key?key=missing")
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+	})
+
+	It("requires key on the key endpoint", func() {
+		resp, _ := get("/api/v1/cache/key")
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
+	It("serves search results", func() {
+		resp, body := get("/api/v1/cache/search?q=tx&limit=10")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(browser.lastSearch).To(Equal(cache.SearchRequest{Query: "tx", Limit: 10}))
+		Expect(body["keys"]).To(HaveLen(1))
+	})
+
+	It("requires q on the search endpoint", func() {
+		resp, _ := get("/api/v1/cache/search")
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
+	It("serves stats", func() {
+		resp, body := get("/api/v1/cache/stats")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(body["keys"]).To(BeEquivalentTo(13))
+		Expect(body["version"]).To(Equal("7.2.0"))
+	})
+
+	It("deletes a key", func() {
+		resp, body := del("/api/v1/cache/key?key=tx%3A1")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(browser.lastDelete).To(Equal("tx:1"))
+		Expect(body["deleted"]).To(BeEquivalentTo(1))
+	})
+
+	It("deletes a prefix but refuses an empty one", func() {
+		resp, body := del("/api/v1/cache/prefix?prefix=tx%3A")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(body["deleted"]).To(BeEquivalentTo(12))
+
+		resp, _ = del("/api/v1/cache/prefix")
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+})

--- a/valkey/browser.go
+++ b/valkey/browser.go
@@ -1,0 +1,367 @@
+package valkey
+
+import (
+	"context"
+	"slices"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+
+	"github.com/flanksource/clicky/cache"
+)
+
+// BrowserConfig tunes the valkey-backed cache.Browser.
+type BrowserConfig struct {
+	// KeyPrefix is the physical namespace shared with the rest of the app
+	// (the same prefix the cache writes with). It is stripped from every key
+	// the browser returns and re-applied on lookups, so the API speaks
+	// logical keys only.
+	KeyPrefix string
+	// Separator splits keys into tree segments. Default ":".
+	Separator string
+	// MaxScan caps the number of keys a single tree/search/stats request
+	// scans. Default 100000.
+	MaxScan int
+	// MaxChildren caps the number of nodes returned per tree level. Default
+	// 1000.
+	MaxChildren int
+	// MaxValueBytes caps the string value returned by Key. Default 256KiB.
+	MaxValueBytes int
+	// MaxItems caps the collection items returned by Key. Default 1000.
+	MaxItems int
+	// OpTimeout bounds a whole browser request. Scans over large keyspaces
+	// take longer than single-key ops, so this is deliberately more generous
+	// than the timeseries opTimeout. Default 10s.
+	OpTimeout time.Duration
+}
+
+func (c BrowserConfig) withDefaults() BrowserConfig {
+	if c.Separator == "" {
+		c.Separator = ":"
+	}
+	if c.MaxScan <= 0 {
+		c.MaxScan = 100_000
+	}
+	if c.MaxChildren <= 0 {
+		c.MaxChildren = 1_000
+	}
+	if c.MaxValueBytes <= 0 {
+		c.MaxValueBytes = 256 << 10
+	}
+	if c.MaxItems <= 0 {
+		c.MaxItems = 1_000
+	}
+	if c.OpTimeout <= 0 {
+		c.OpTimeout = 10 * time.Second
+	}
+	return c
+}
+
+type browser struct {
+	client valkey.Client
+	cfg    BrowserConfig
+	// memoryUnsupported latches once the server rejects MEMORY USAGE
+	// (miniredis, older forks) so later requests skip the probe and report
+	// BytesSupported=false instead of failing.
+	memoryUnsupported atomic.Bool
+}
+
+// NewBrowser returns a cache.Browser over client. The client is owned by the
+// caller (NewBrowser does not close it), so an app can share its existing
+// connection.
+func NewBrowser(client valkey.Client, cfg BrowserConfig) cache.Browser {
+	return &browser{client: client, cfg: cfg.withDefaults()}
+}
+
+func (b *browser) opCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, b.cfg.OpTimeout)
+}
+
+// globEscape neutralises glob metacharacters in user-supplied fragments so a
+// prefix like "tx:[0]" matches literally inside a SCAN MATCH pattern.
+func globEscape(s string) string {
+	var out strings.Builder
+	for _, r := range s {
+		switch r {
+		case '*', '?', '[', ']', '\\':
+			out.WriteByte('\\')
+		}
+		out.WriteRune(r)
+	}
+	return out.String()
+}
+
+// scan iterates SCAN MATCH pattern until the cursor is exhausted or max keys
+// were collected; the second return reports whether the scan stopped early.
+func (b *browser) scan(ctx context.Context, pattern string, max int) ([]string, bool, error) {
+	var keys []string
+	var cursor uint64
+	for {
+		entry, err := b.client.Do(ctx, b.client.B().Scan().Cursor(cursor).
+			Match(pattern).Count(1000).Build()).AsScanEntry()
+		if err != nil {
+			return nil, false, err
+		}
+		keys = append(keys, entry.Elements...)
+		if len(keys) >= max {
+			return keys[:max], entry.Cursor != 0 || len(keys) > max, nil
+		}
+		if entry.Cursor == 0 {
+			return keys, false, nil
+		}
+		cursor = entry.Cursor
+	}
+}
+
+func (b *browser) Tree(ctx context.Context, req cache.TreeRequest) (cache.TreeResponse, error) {
+	ctx, cancel := b.opCtx(ctx)
+	defer cancel()
+
+	pattern := globEscape(b.cfg.KeyPrefix+req.Prefix) + "*"
+	keys, truncated, err := b.scan(ctx, pattern, b.cfg.MaxScan)
+	if err != nil {
+		return cache.TreeResponse{}, err
+	}
+
+	// Byte sizes for every scanned key, so each group node can report the
+	// aggregated MEMORY USAGE of all keys beneath it (not just its direct
+	// leaves). nil when the backend has no MEMORY USAGE support.
+	bytesByKey, err := b.memoryUsage(ctx, keys)
+	if err != nil {
+		return cache.TreeResponse{}, err
+	}
+
+	sep := b.cfg.Separator
+	type group struct {
+		keys     int
+		children map[string]struct{}
+		bytes    int64
+	}
+	groups := map[string]*group{}
+	var leaves []string
+	for _, physical := range keys {
+		logical := strings.TrimPrefix(physical, b.cfg.KeyPrefix)
+		tail := strings.TrimPrefix(logical, req.Prefix)
+		idx := strings.Index(tail, sep)
+		if idx < 0 || tail == "" {
+			leaves = append(leaves, logical)
+			continue
+		}
+		seg := tail[:idx]
+		g := groups[seg]
+		if g == nil {
+			g = &group{children: map[string]struct{}{}}
+			groups[seg] = g
+		}
+		g.keys++
+		g.bytes += bytesByKey[physical]
+		rest := tail[idx+len(sep):]
+		if next := strings.Index(rest, sep); next >= 0 {
+			g.children[rest[:next]] = struct{}{}
+		} else {
+			g.children[rest] = struct{}{}
+		}
+	}
+
+	groupNames := make([]string, 0, len(groups))
+	for name := range groups {
+		groupNames = append(groupNames, name)
+	}
+	sort.Strings(groupNames)
+	sort.Strings(leaves)
+
+	nodes := make([]cache.TreeNode, 0, len(groupNames)+len(leaves))
+	for _, name := range groupNames {
+		g := groups[name]
+		node := cache.TreeNode{
+			Name:     name,
+			Prefix:   req.Prefix + name + sep,
+			Keys:     g.keys,
+			Children: len(g.children),
+		}
+		if bytesByKey != nil {
+			node.Bytes = g.bytes
+		}
+		nodes = append(nodes, node)
+	}
+	maxChildren := req.MaxChildren
+	if maxChildren <= 0 || maxChildren > b.cfg.MaxChildren {
+		maxChildren = b.cfg.MaxChildren
+	}
+	leafBudget := maxChildren - len(nodes)
+	if len(nodes) > maxChildren {
+		nodes = nodes[:maxChildren]
+		leafBudget = 0
+		truncated = true
+	}
+	if leafBudget < len(leaves) {
+		leaves = leaves[:max(leafBudget, 0)]
+		truncated = true
+	}
+
+	leafNodes, err := b.leafNodes(ctx, req.Prefix, leaves, bytesByKey)
+	if err != nil {
+		return cache.TreeResponse{}, err
+	}
+	nodes = append(nodes, leafNodes...)
+
+	return cache.TreeResponse{
+		Prefix:         req.Prefix,
+		Nodes:          nodes,
+		Keys:           len(keys),
+		Truncated:      truncated,
+		BytesSupported: !b.memoryUnsupported.Load(),
+	}, nil
+}
+
+// memoryUsage pipelines MEMORY USAGE for every physical key and returns a
+// physical-key→bytes map. It returns a nil map (and no error) when the backend
+// does not support MEMORY USAGE, latching memoryUnsupported so callers skip the
+// probe and report BytesSupported=false. A key that vanished between the scan
+// and this call (TTL race) contributes nothing rather than failing the level.
+func (b *browser) memoryUsage(ctx context.Context, physical []string) (map[string]int64, error) {
+	if b.memoryUnsupported.Load() || len(physical) == 0 {
+		return nil, nil
+	}
+	cmds := make(valkey.Commands, 0, len(physical))
+	for _, key := range physical {
+		cmds = append(cmds, b.client.B().MemoryUsage().Key(key).Build())
+	}
+	resps := b.client.DoMulti(ctx, cmds...)
+	out := make(map[string]int64, len(physical))
+	for i, key := range physical {
+		bytes, err := resps[i].AsInt64()
+		switch {
+		case err == nil:
+			out[key] = bytes
+		case valkey.IsValkeyNil(err):
+			// Key expired between scan and probe; skip it.
+		case isUnknownCommand(err):
+			b.memoryUnsupported.Store(true)
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// leafNodes pipelines TYPE+TTL for each logical key and renders leaf TreeNodes
+// in the given order, attaching per-key MEMORY USAGE from bytesByKey (nil when
+// the backend has no support). Name is the key tail relative to stripPrefix so
+// a tree level displays segments, not full keys.
+func (b *browser) leafNodes(ctx context.Context, stripPrefix string, logical []string, bytesByKey map[string]int64) ([]cache.TreeNode, error) {
+	if len(logical) == 0 {
+		return nil, nil
+	}
+	const perKey = 2
+	cmds := make(valkey.Commands, 0, len(logical)*perKey)
+	for _, key := range logical {
+		physical := b.cfg.KeyPrefix + key
+		cmds = append(cmds,
+			b.client.B().Type().Key(physical).Build(),
+			b.client.B().Ttl().Key(physical).Build())
+	}
+	resps := b.client.DoMulti(ctx, cmds...)
+
+	nodes := make([]cache.TreeNode, 0, len(logical))
+	for i, key := range logical {
+		typ, err := resps[i*perKey].ToString()
+		if err != nil {
+			return nil, err
+		}
+		ttl, err := resps[i*perKey+1].AsInt64()
+		if err != nil {
+			return nil, err
+		}
+		name := strings.TrimPrefix(key, stripPrefix)
+		if name == "" {
+			name = key
+		}
+		node := cache.TreeNode{Name: name, Key: key, Keys: 1, Type: typ, TTLSeconds: ttl}
+		if bytesByKey != nil {
+			node.Bytes = bytesByKey[b.cfg.KeyPrefix+key]
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// isUnknownCommand matches the server error for a command the backend does
+// not implement (e.g. MEMORY on miniredis).
+func isUnknownCommand(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "unknown command")
+}
+
+func (b *browser) Search(ctx context.Context, req cache.SearchRequest) (cache.SearchResponse, error) {
+	ctx, cancel := b.opCtx(ctx)
+	defer cancel()
+
+	limit := req.Limit
+	if limit <= 0 || limit > b.cfg.MaxChildren {
+		limit = 100
+	}
+	pattern := globEscape(b.cfg.KeyPrefix) + "*" + globEscape(req.Query) + "*"
+	// Scan one past the limit so truncation is reported without a full pass.
+	keys, scanTruncated, err := b.scan(ctx, pattern, limit+1)
+	if err != nil {
+		return cache.SearchResponse{}, err
+	}
+	truncated := scanTruncated || len(keys) > limit
+	if len(keys) > limit {
+		keys = keys[:limit]
+	}
+	bytesByKey, err := b.memoryUsage(ctx, keys)
+	if err != nil {
+		return cache.SearchResponse{}, err
+	}
+	logical := make([]string, 0, len(keys))
+	for _, k := range keys {
+		logical = append(logical, strings.TrimPrefix(k, b.cfg.KeyPrefix))
+	}
+	sort.Strings(logical)
+	nodes, err := b.leafNodes(ctx, "", logical, bytesByKey)
+	if err != nil {
+		return cache.SearchResponse{}, err
+	}
+	return cache.SearchResponse{Keys: nodes, Truncated: truncated}, nil
+}
+
+func (b *browser) DeleteKey(ctx context.Context, key string) (cache.DeleteResponse, error) {
+	ctx, cancel := b.opCtx(ctx)
+	defer cancel()
+	deleted, err := b.client.Do(ctx, b.client.B().Del().Key(b.cfg.KeyPrefix+key).Build()).AsInt64()
+	if err != nil {
+		return cache.DeleteResponse{}, err
+	}
+	return cache.DeleteResponse{Deleted: deleted}, nil
+}
+
+func (b *browser) DeletePrefix(ctx context.Context, prefix string) (cache.DeleteResponse, error) {
+	ctx, cancel := b.opCtx(ctx)
+	defer cancel()
+	keys, _, err := b.scan(ctx, globEscape(b.cfg.KeyPrefix+prefix)+"*", b.cfg.MaxScan)
+	if err != nil {
+		return cache.DeleteResponse{}, err
+	}
+	// One DEL per key, pipelined: valkey-go rejects multi-key DELs whose keys
+	// hash to different slots, and a browser prefix routinely spans slots.
+	var deleted int64
+	for batch := range slices.Chunk(keys, 512) {
+		cmds := make(valkey.Commands, 0, len(batch))
+		for _, key := range batch {
+			cmds = append(cmds, b.client.B().Del().Key(key).Build())
+		}
+		for _, resp := range b.client.DoMulti(ctx, cmds...) {
+			n, err := resp.AsInt64()
+			if err != nil {
+				return cache.DeleteResponse{}, err
+			}
+			deleted += n
+		}
+	}
+	return cache.DeleteResponse{Deleted: deleted}, nil
+}

--- a/valkey/browser.go
+++ b/valkey/browser.go
@@ -2,6 +2,7 @@ package valkey
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sort"
 	"strings"
@@ -301,8 +302,11 @@ func (b *browser) Search(ctx context.Context, req cache.SearchRequest) (cache.Se
 	defer cancel()
 
 	limit := req.Limit
-	if limit <= 0 || limit > b.cfg.MaxChildren {
-		limit = 100
+	if limit <= 0 {
+		limit = min(100, b.cfg.MaxChildren)
+	}
+	if limit > b.cfg.MaxChildren {
+		limit = b.cfg.MaxChildren
 	}
 	pattern := globEscape(b.cfg.KeyPrefix) + "*" + globEscape(req.Query) + "*"
 	// Scan one past the limit so truncation is reported without a full pass.
@@ -343,9 +347,13 @@ func (b *browser) DeleteKey(ctx context.Context, key string) (cache.DeleteRespon
 func (b *browser) DeletePrefix(ctx context.Context, prefix string) (cache.DeleteResponse, error) {
 	ctx, cancel := b.opCtx(ctx)
 	defer cancel()
-	keys, _, err := b.scan(ctx, globEscape(b.cfg.KeyPrefix+prefix)+"*", b.cfg.MaxScan)
+	pattern := globEscape(b.cfg.KeyPrefix+prefix) + "*"
+	keys, truncated, err := b.scan(ctx, pattern, b.cfg.MaxScan)
 	if err != nil {
 		return cache.DeleteResponse{}, err
+	}
+	if truncated {
+		return cache.DeleteResponse{}, fmt.Errorf("prefix delete %q truncated at maxScan=%d; refine prefix or raise cap", pattern, b.cfg.MaxScan)
 	}
 	// One DEL per key, pipelined: valkey-go rejects multi-key DELs whose keys
 	// hash to different slots, and a browser prefix routinely spans slots.

--- a/valkey/browser_key.go
+++ b/valkey/browser_key.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/valkey-io/valkey-go"
+
 	"github.com/flanksource/clicky/cache"
 )
 
@@ -31,6 +33,8 @@ func (b *browser) Key(ctx context.Context, key string) (cache.KeyDetail, error) 
 		switch {
 		case err == nil:
 			detail.Bytes = bytes
+		case valkey.IsValkeyNil(err):
+			// Key expired between TYPE and MEMORY USAGE; treat as non-fatal.
 		case isUnknownCommand(err):
 			b.memoryUnsupported.Store(true)
 		default:

--- a/valkey/browser_key.go
+++ b/valkey/browser_key.go
@@ -1,0 +1,200 @@
+package valkey
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/flanksource/clicky/cache"
+)
+
+func (b *browser) Key(ctx context.Context, key string) (cache.KeyDetail, error) {
+	ctx, cancel := b.opCtx(ctx)
+	defer cancel()
+
+	physical := b.cfg.KeyPrefix + key
+	typ, err := b.client.Do(ctx, b.client.B().Type().Key(physical).Build()).ToString()
+	if err != nil {
+		return cache.KeyDetail{}, err
+	}
+	if typ == "none" {
+		return cache.KeyDetail{}, cache.ErrKeyNotFound
+	}
+
+	detail := cache.KeyDetail{Key: key, Type: typ}
+	if detail.TTLSeconds, err = b.client.Do(ctx, b.client.B().Ttl().Key(physical).Build()).AsInt64(); err != nil {
+		return cache.KeyDetail{}, err
+	}
+	if !b.memoryUnsupported.Load() {
+		bytes, err := b.client.Do(ctx, b.client.B().MemoryUsage().Key(physical).Build()).AsInt64()
+		switch {
+		case err == nil:
+			detail.Bytes = bytes
+		case isUnknownCommand(err):
+			b.memoryUnsupported.Store(true)
+		default:
+			return cache.KeyDetail{}, err
+		}
+	}
+	if err := b.loadValue(ctx, physical, &detail); err != nil {
+		return cache.KeyDetail{}, err
+	}
+	return detail, nil
+}
+
+// loadValue fills Length plus the type-appropriate value field, capping
+// strings at MaxValueBytes and collections at MaxItems.
+func (b *browser) loadValue(ctx context.Context, physical string, d *cache.KeyDetail) error {
+	c := b.client
+	maxItems := int64(b.cfg.MaxItems)
+	var err error
+	switch d.Type {
+	case "string":
+		if d.Length, err = c.Do(ctx, c.B().Strlen().Key(physical).Build()).AsInt64(); err != nil {
+			return err
+		}
+		d.Value, err = c.Do(ctx, c.B().Getrange().Key(physical).
+			Start(0).End(int64(b.cfg.MaxValueBytes)-1).Build()).ToString()
+		if err != nil {
+			return err
+		}
+		d.Truncated = d.Length > int64(b.cfg.MaxValueBytes)
+	case "hash":
+		if d.Length, err = c.Do(ctx, c.B().Hlen().Key(physical).Build()).AsInt64(); err != nil {
+			return err
+		}
+		fields, err := c.Do(ctx, c.B().Hgetall().Key(physical).Build()).AsStrMap()
+		if err != nil {
+			return err
+		}
+		d.Fields = capFields(fields, b.cfg.MaxItems)
+		d.Truncated = d.Length > maxItems
+	case "list":
+		if d.Length, err = c.Do(ctx, c.B().Llen().Key(physical).Build()).AsInt64(); err != nil {
+			return err
+		}
+		if d.Items, err = c.Do(ctx, c.B().Lrange().Key(physical).
+			Start(0).Stop(maxItems-1).Build()).AsStrSlice(); err != nil {
+			return err
+		}
+		d.Truncated = d.Length > maxItems
+	case "set":
+		if d.Length, err = c.Do(ctx, c.B().Scard().Key(physical).Build()).AsInt64(); err != nil {
+			return err
+		}
+		items, err := c.Do(ctx, c.B().Smembers().Key(physical).Build()).AsStrSlice()
+		if err != nil {
+			return err
+		}
+		sort.Strings(items)
+		if int64(len(items)) > maxItems {
+			items = items[:maxItems]
+		}
+		d.Items = items
+		d.Truncated = d.Length > maxItems
+	case "zset":
+		if d.Length, err = c.Do(ctx, c.B().Zcard().Key(physical).Build()).AsInt64(); err != nil {
+			return err
+		}
+		scores, err := c.Do(ctx, c.B().Zrange().Key(physical).
+			Min("0").Max(strconv.FormatInt(maxItems-1, 10)).Withscores().Build()).AsZScores()
+		if err != nil {
+			return err
+		}
+		d.Members = make([]cache.ScoredMember, 0, len(scores))
+		for _, s := range scores {
+			d.Members = append(d.Members, cache.ScoredMember{Member: s.Member, Score: s.Score})
+		}
+		d.Truncated = d.Length > maxItems
+	case "stream":
+		if d.Length, err = c.Do(ctx, c.B().Xlen().Key(physical).Build()).AsInt64(); err != nil {
+			return err
+		}
+		// Stream entries are not rendered; Length and metadata are enough
+		// for the browser to show what the key is.
+	}
+	return nil
+}
+
+// capFields bounds a hash to max entries deterministically (sorted by field
+// name) so truncation is stable across requests.
+func capFields(fields map[string]string, max int) map[string]string {
+	if len(fields) <= max {
+		return fields
+	}
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	capped := make(map[string]string, max)
+	for _, name := range names[:max] {
+		capped[name] = fields[name]
+	}
+	return capped
+}
+
+func (b *browser) Stats(ctx context.Context) (cache.Stats, error) {
+	ctx, cancel := b.opCtx(ctx)
+	defer cancel()
+
+	var stats cache.Stats
+	if b.cfg.KeyPrefix == "" {
+		keys, err := b.client.Do(ctx, b.client.B().Dbsize().Build()).AsInt64()
+		if err != nil {
+			return cache.Stats{}, err
+		}
+		stats.Keys = keys
+	} else {
+		// DBSIZE counts the whole DB; a namespaced browser only owns
+		// KeyPrefix, so count by scan and report the cap honestly.
+		keys, truncated, err := b.scan(ctx, globEscape(b.cfg.KeyPrefix)+"*", b.cfg.MaxScan)
+		if err != nil {
+			return cache.Stats{}, err
+		}
+		stats.Keys = int64(len(keys))
+		stats.KeysTruncated = truncated
+	}
+
+	info, err := b.client.Do(ctx, b.client.B().Info().Build()).ToString()
+	if err != nil {
+		// INFO is unsupported on some embedded backends (miniredis); the
+		// keyspace numbers above are still valid, so surface the gap in the
+		// payload instead of failing the whole overview.
+		stats.InfoError = err.Error()
+		return stats, nil
+	}
+	applyInfo(&stats, info)
+	return stats, nil
+}
+
+// applyInfo copies the fields the overview renders out of an INFO dump.
+func applyInfo(stats *cache.Stats, info string) {
+	fields := map[string]string{}
+	for _, line := range strings.Split(info, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if name, value, ok := strings.Cut(line, ":"); ok {
+			fields[name] = value
+		}
+	}
+	asInt := func(name string) int64 {
+		v, _ := strconv.ParseInt(fields[name], 10, 64)
+		return v
+	}
+	stats.UsedMemoryBytes = asInt("used_memory")
+	stats.MaxMemoryBytes = asInt("maxmemory")
+	stats.Hits = asInt("keyspace_hits")
+	stats.Misses = asInt("keyspace_misses")
+	stats.EvictedKeys = asInt("evicted_keys")
+	stats.ExpiredKeys = asInt("expired_keys")
+	stats.ConnectedClients = asInt("connected_clients")
+	stats.UptimeSeconds = asInt("uptime_in_seconds")
+	stats.Version = fields["redis_version"]
+	if stats.Version == "" {
+		stats.Version = fields["valkey_version"]
+	}
+}

--- a/valkey/browser_test.go
+++ b/valkey/browser_test.go
@@ -188,6 +188,14 @@ var _ = Describe("Valkey cache Browser", func() {
 		Expect(resp.Truncated).To(BeTrue())
 	})
 
+	It("clamps an unset search limit to MaxChildren", func() {
+		seed(valkey.BrowserConfig{MaxChildren: 1})
+		resp, err := browser.Search(ctx, cache.SearchRequest{Query: "tx"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Keys).To(HaveLen(1))
+		Expect(resp.Truncated).To(BeTrue())
+	})
+
 	It("deletes a single key", func() {
 		resp, err := browser.DeleteKey(ctx, "marker")
 		Expect(err).NotTo(HaveOccurred())
@@ -203,6 +211,14 @@ var _ = Describe("Valkey cache Browser", func() {
 		Expect(mr.Exists("app:tx:2:meta")).To(BeFalse())
 		Expect(mr.Exists("app:plan:p1")).To(BeTrue())
 		Expect(mr.Exists("other:noise")).To(BeTrue())
+	})
+
+	It("fails fast instead of partially deleting when the scan is truncated", func() {
+		seed(valkey.BrowserConfig{MaxScan: 1})
+		_, err := browser.DeletePrefix(ctx, "tx:")
+		Expect(err).To(MatchError(ContainSubstring("truncated at maxScan=1")))
+		Expect(mr.Exists("app:tx:1")).To(BeTrue())
+		Expect(mr.Exists("app:tx:2:meta")).To(BeTrue())
 	})
 
 	It("counts only namespaced keys in stats", func() {

--- a/valkey/browser_test.go
+++ b/valkey/browser_test.go
@@ -1,0 +1,231 @@
+package valkey_test
+
+import (
+	"context"
+
+	"github.com/alicebob/miniredis/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	valkeygo "github.com/valkey-io/valkey-go"
+
+	"github.com/flanksource/clicky/cache"
+	"github.com/flanksource/clicky/valkey"
+)
+
+var _ = Describe("Valkey cache Browser", func() {
+	var (
+		browser cache.Browser
+		seed    func(cfg valkey.BrowserConfig)
+		ctx     = context.Background()
+		mr      *miniredis.Miniredis
+	)
+
+	// seed loads a small namespaced keyspace:
+	//
+	//	app:tx:1       string
+	//	app:tx:2:meta  string
+	//	app:plan:p1    hash
+	//	app:queue      list
+	//	app:tags       set
+	//	app:scores     zset
+	//	app:marker     string (JSON)
+	//	other:noise    string outside the namespace
+	BeforeEach(func() {
+		var client valkeygo.Client
+		client, mr = newClient()
+		DeferCleanup(client.Close)
+		DeferCleanup(mr.Close)
+		mr.Set("app:tx:1", "one")
+		mr.Set("app:tx:2:meta", "meta-value")
+		mr.HSet("app:plan:p1", "name", "Plan One", "tier", "gold")
+		mr.Lpush("app:queue", "second")
+		mr.Lpush("app:queue", "first")
+		mr.SAdd("app:tags", "beta", "alpha")
+		mr.ZAdd("app:scores", 2.5, "bob")
+		mr.ZAdd("app:scores", 1.5, "alice")
+		mr.Set("app:marker", `{"hello":"world"}`)
+		mr.Set("other:noise", "x")
+		seed = func(cfg valkey.BrowserConfig) {
+			cfg.KeyPrefix = "app:"
+			browser = valkey.NewBrowser(client, cfg)
+		}
+		seed(valkey.BrowserConfig{})
+	})
+
+	It("groups the root level into prefix groups and sorted leaves", func() {
+		resp, err := browser.Tree(ctx, cache.TreeRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Keys).To(Equal(7))
+		Expect(resp.Truncated).To(BeFalse())
+		Expect(resp.BytesSupported).To(BeTrue())
+		for _, node := range resp.Nodes {
+			if node.Key != "" {
+				Expect(node.Bytes).To(BeNumerically(">", 0), "leaf %s should carry MEMORY USAGE", node.Key)
+			} else {
+				Expect(node.Bytes).To(BeNumerically(">", 0), "group %s should aggregate subkey MEMORY USAGE", node.Name)
+			}
+		}
+		// Bytes values are miniredis-internal overhead constants; compare
+		// everything else exactly.
+		Expect(clearBytes(resp.Nodes)).To(Equal([]cache.TreeNode{
+			{Name: "plan", Prefix: "plan:", Keys: 1, Children: 1},
+			{Name: "tx", Prefix: "tx:", Keys: 2, Children: 2},
+			{Name: "marker", Key: "marker", Keys: 1, Type: "string", TTLSeconds: -1},
+			{Name: "queue", Key: "queue", Keys: 1, Type: "list", TTLSeconds: -1},
+			{Name: "scores", Key: "scores", Keys: 1, Type: "zset", TTLSeconds: -1},
+			{Name: "tags", Key: "tags", Keys: 1, Type: "set", TTLSeconds: -1},
+		}))
+	})
+
+	It("aggregates every subkey's MEMORY USAGE into the group node", func() {
+		root, err := browser.Tree(ctx, cache.TreeRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		var txGroup int64
+		for _, node := range root.Nodes {
+			if node.Name == "tx" && node.Key == "" {
+				txGroup = node.Bytes
+			}
+		}
+
+		// tx: holds tx:1 (leaf) and tx:2:meta (under the tx:2 subgroup); the
+		// group total must equal the sum of both, not just its direct leaf.
+		tx1, err := browser.Key(ctx, "tx:1")
+		Expect(err).NotTo(HaveOccurred())
+		tx2meta, err := browser.Key(ctx, "tx:2:meta")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(txGroup).To(Equal(tx1.Bytes + tx2meta.Bytes))
+	})
+
+	It("expands a group prefix into its own level", func() {
+		resp, err := browser.Tree(ctx, cache.TreeRequest{Prefix: "tx:"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Keys).To(Equal(2))
+		Expect(clearBytes(resp.Nodes)).To(Equal([]cache.TreeNode{
+			{Name: "2", Prefix: "tx:2:", Keys: 1, Children: 1},
+			{Name: "1", Key: "tx:1", Keys: 1, Type: "string", TTLSeconds: -1},
+		}))
+	})
+
+	It("caps a level at MaxChildren and flags truncation", func() {
+		resp, err := browser.Tree(ctx, cache.TreeRequest{MaxChildren: 3})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Nodes).To(HaveLen(3))
+		Expect(resp.Truncated).To(BeTrue())
+		Expect(resp.Keys).To(Equal(7))
+	})
+
+	It("returns string key detail", func() {
+		detail, err := browser.Key(ctx, "marker")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detail.Bytes).To(BeNumerically(">", 0))
+		detail.Bytes = 0
+		Expect(detail).To(Equal(cache.KeyDetail{
+			Key:        "marker",
+			Type:       "string",
+			TTLSeconds: -1,
+			Length:     17,
+			Value:      `{"hello":"world"}`,
+		}))
+	})
+
+	It("caps long string values and reports the full length", func() {
+		seed(valkey.BrowserConfig{MaxValueBytes: 4})
+		detail, err := browser.Key(ctx, "tx:2:meta")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detail.Value).To(Equal("meta"))
+		Expect(detail.Length).To(BeEquivalentTo(len("meta-value")))
+		Expect(detail.Truncated).To(BeTrue())
+	})
+
+	It("returns hash fields", func() {
+		detail, err := browser.Key(ctx, "plan:p1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detail.Type).To(Equal("hash"))
+		Expect(detail.Length).To(BeEquivalentTo(2))
+		Expect(detail.Fields).To(Equal(map[string]string{"name": "Plan One", "tier": "gold"}))
+	})
+
+	It("returns list items in list order", func() {
+		detail, err := browser.Key(ctx, "queue")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detail.Type).To(Equal("list"))
+		Expect(detail.Items).To(Equal([]string{"first", "second"}))
+	})
+
+	It("returns sorted set members", func() {
+		detail, err := browser.Key(ctx, "tags")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detail.Type).To(Equal("set"))
+		Expect(detail.Items).To(Equal([]string{"alpha", "beta"}))
+	})
+
+	It("returns zset members with scores in rank order", func() {
+		detail, err := browser.Key(ctx, "scores")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detail.Type).To(Equal("zset"))
+		Expect(detail.Members).To(Equal([]cache.ScoredMember{
+			{Member: "alice", Score: 1.5},
+			{Member: "bob", Score: 2.5},
+		}))
+	})
+
+	It("returns ErrKeyNotFound for a missing key", func() {
+		_, err := browser.Key(ctx, "missing")
+		Expect(err).To(MatchError(cache.ErrKeyNotFound))
+	})
+
+	It("searches by substring within the namespace only", func() {
+		resp, err := browser.Search(ctx, cache.SearchRequest{Query: "tx"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Truncated).To(BeFalse())
+		Expect(keysOf(resp.Keys)).To(Equal([]string{"tx:1", "tx:2:meta"}))
+	})
+
+	It("flags truncated search results", func() {
+		resp, err := browser.Search(ctx, cache.SearchRequest{Query: "tx", Limit: 1})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Keys).To(HaveLen(1))
+		Expect(resp.Truncated).To(BeTrue())
+	})
+
+	It("deletes a single key", func() {
+		resp, err := browser.DeleteKey(ctx, "marker")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Deleted).To(BeEquivalentTo(1))
+		Expect(mr.Exists("app:marker")).To(BeFalse())
+	})
+
+	It("deletes a whole prefix without touching siblings", func() {
+		resp, err := browser.DeletePrefix(ctx, "tx:")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Deleted).To(BeEquivalentTo(2))
+		Expect(mr.Exists("app:tx:1")).To(BeFalse())
+		Expect(mr.Exists("app:tx:2:meta")).To(BeFalse())
+		Expect(mr.Exists("app:plan:p1")).To(BeTrue())
+		Expect(mr.Exists("other:noise")).To(BeTrue())
+	})
+
+	It("counts only namespaced keys in stats", func() {
+		stats, err := browser.Stats(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stats.Keys).To(BeEquivalentTo(7))
+		Expect(stats.KeysTruncated).To(BeFalse())
+	})
+})
+
+func clearBytes(nodes []cache.TreeNode) []cache.TreeNode {
+	out := make([]cache.TreeNode, len(nodes))
+	for i, n := range nodes {
+		n.Bytes = 0
+		out[i] = n
+	}
+	return out
+}
+
+func keysOf(nodes []cache.TreeNode) []string {
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, n.Key)
+	}
+	return out
+}


### PR DESCRIPTION
## What
- New `cache` package with Browser interface and HTTP routes (tree/key/search/stats/delete)
- `valkey` module implements Browser via SCAN aggregation with pipelined TYPE/TTL/MEMORY USAGE
- Per-key detail with explicit truncation flags for strings and collections

## Why
- Mirrors existing metrics interface-in-core, impl-in-submodule pattern
- Enables cache introspection and management via HTTP API

## Notes
- MEMORY USAGE support detection (BytesSupported flag) for backends without it
- Multi-key DEL slot-checked by valkey-go client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache browser HTTP API with endpoints for tree navigation, key search, key details, statistics, and key deletion.
  * Support for inspecting multiple data types (strings, hashes, lists, sets, sorted sets) with truncation handling for large values.
  * Keyspace statistics including memory usage, hit/miss rates, and eviction metrics.

* **Tests**
  * Added test suites for cache browser HTTP handler and implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->