### PR TITLE
feat(sse): add RunsSSEHandler for streaming run listings

### DIFF
--- a/task/sse.go
+++ b/task/sse.go
@@ -83,3 +83,102 @@ func SSEHandler(taskIDs ...string) http.Handler {
 		}
 	})
 }
+
+// RunsSSEHandler streams the run listing (RunMeta) as SSE. Unlike SSEHandler it
+// never sends a terminal event: a manager view stays subscribed to observe new
+// and changing runs. supplement (may be nil) merges extra runs — e.g. archived
+// or persisted runs the in-memory registry no longer holds; live runs win on id.
+// It emits a single "event: runs" frame carrying the full listing, and only
+// re-emits when the listing changes.
+func RunsSSEHandler(supplement func(RunFilter) []RunMeta) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filter := runFilterFromQuery(r)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		flusher.Flush()
+
+		// Listing updates are cheaper and less urgent than per-task progress, so
+		// poll on a slower tick than SSEHandler.
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+
+		var lastSent string
+		emit := func() {
+			GCRuns()
+			runs := mergeRuns(RunsRaw(filter), supplement, filter)
+			data, err := json.Marshal(runs)
+			if err != nil {
+				return
+			}
+			if string(data) == lastSent {
+				return
+			}
+			lastSent = string(data)
+			_, _ = fmt.Fprintf(w, "event: runs\ndata: %s\n\n", data)
+			flusher.Flush()
+		}
+
+		emit()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				emit()
+			}
+		}
+	})
+}
+
+// mergeRuns unions live runs with supplement(filter), deduped by id. Live runs
+// win on collision (a supplement source may hold a stale terminal snapshot of a
+// run that is still live in memory).
+func mergeRuns(live []RunMeta, supplement func(RunFilter) []RunMeta, filter RunFilter) []RunMeta {
+	if supplement == nil {
+		if live == nil {
+			return []RunMeta{}
+		}
+		return live
+	}
+	seen := make(map[string]bool, len(live))
+	for _, m := range live {
+		seen[m.ID] = true
+	}
+	out := append([]RunMeta{}, live...)
+	for _, m := range supplement(filter) {
+		if !seen[m.ID] {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// runFilterFromQuery builds a RunFilter from the standard task listing query
+// params: kind, status, and repeated label=k=v pairs.
+func runFilterFromQuery(r *http.Request) RunFilter {
+	q := r.URL.Query()
+	filter := RunFilter{
+		Kind:   q.Get("kind"),
+		Status: q.Get("status"),
+	}
+	for _, v := range q["label"] {
+		k, val, ok := strings.Cut(v, "=")
+		if !ok {
+			continue
+		}
+		if filter.Labels == nil {
+			filter.Labels = map[string]string{}
+		}
+		filter.Labels[k] = val
+	}
+	return filter
+}

--- a/task/sse_test.go
+++ b/task/sse_test.go
@@ -1,0 +1,162 @@
+package task
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runsFrameReader reads SSE "event: runs" frames off a stream, decoding each
+// data payload into []RunMeta. readFrame returns the next listing or fails the
+// test if none arrives within the timeout.
+type runsFrameReader struct {
+	t   *testing.T
+	br  *bufio.Reader
+	out chan []RunMeta
+}
+
+func newRunsFrameReader(t *testing.T, body *bufio.Reader) *runsFrameReader {
+	t.Helper()
+	r := &runsFrameReader{t: t, br: body, out: make(chan []RunMeta, 8)}
+	go r.pump()
+	return r
+}
+
+// pump scans the stream line-by-line, emitting the JSON that follows each
+// "event: runs" line.
+func (r *runsFrameReader) pump() {
+	var pendingRuns bool
+	for {
+		line, err := r.br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\n")
+		switch {
+		case line == "event: runs":
+			pendingRuns = true
+		case strings.HasPrefix(line, "data: ") && pendingRuns:
+			pendingRuns = false
+			var runs []RunMeta
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &runs); err == nil {
+				r.out <- runs
+			}
+		}
+	}
+}
+
+func (r *runsFrameReader) readFrame(timeout time.Duration) []RunMeta {
+	r.t.Helper()
+	select {
+	case runs := <-r.out:
+		return runs
+	case <-time.After(timeout):
+		r.t.Fatalf("timed out waiting for an event: runs frame")
+		return nil
+	}
+}
+
+// expectNoFrame asserts no further listing arrives within the window — proves
+// the handler dedups identical listings instead of re-emitting every tick.
+func (r *runsFrameReader) expectNoFrame(window time.Duration) {
+	r.t.Helper()
+	select {
+	case runs := <-r.out:
+		r.t.Fatalf("expected no frame for an unchanged listing, got %+v", runs)
+	case <-time.After(window):
+	}
+}
+
+func startRunsStream(t *testing.T, h http.Handler) (*runsFrameReader, func()) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	reader := newRunsFrameReader(t, bufio.NewReader(resp.Body))
+	stop := func() {
+		cancel()
+		_ = resp.Body.Close()
+		srv.Close()
+	}
+	return reader, stop
+}
+
+func runNames(runs []RunMeta) map[string]bool {
+	set := make(map[string]bool, len(runs))
+	for _, r := range runs {
+		set[r.Name] = true
+	}
+	return set
+}
+
+func TestRunsSSEHandlerEmitsListingAndReEmitsOnChange(t *testing.T) {
+	withTestGlobal(t)
+
+	g1 := StartGroup[any]("first-run", WithConcurrency(1))
+	runGroupToCompletion(t, g1, "step")
+
+	reader, stop := startRunsStream(t, RunsSSEHandler(nil))
+	defer stop()
+
+	// Initial frame carries the one live run.
+	first := reader.readFrame(2 * time.Second)
+	if names := runNames(first); !names["first-run"] || len(first) != 1 {
+		t.Fatalf("initial frame expected [first-run], got %+v", first)
+	}
+
+	// An unchanged listing must NOT be re-emitted every tick.
+	reader.expectNoFrame(1200 * time.Millisecond)
+
+	// A new run changes the listing → the handler re-emits.
+	g2 := StartGroup[any]("second-run", WithConcurrency(1))
+	runGroupToCompletion(t, g2, "step")
+
+	second := reader.readFrame(2 * time.Second)
+	if names := runNames(second); !names["first-run"] || !names["second-run"] || len(second) != 2 {
+		t.Fatalf("change frame expected [first-run, second-run], got %+v", second)
+	}
+}
+
+func TestRunsSSEHandlerMergesSupplementDedupedByID(t *testing.T) {
+	withTestGlobal(t)
+
+	live := StartGroup[any]("live-run", WithKind("test"), WithConcurrency(1))
+	runGroupToCompletion(t, live, "step")
+	liveID := live.ID()
+
+	// Supplement returns an archived run plus a stale duplicate of the live id;
+	// the live run must win on id and the archived run must be appended.
+	supplement := func(RunFilter) []RunMeta {
+		return []RunMeta{
+			{ID: liveID, Name: "STALE-DUP", Status: "success"},
+			{ID: "archived-1", Name: "archived-run", Status: "success"},
+		}
+	}
+
+	reader, stop := startRunsStream(t, RunsSSEHandler(supplement))
+	defer stop()
+
+	frame := reader.readFrame(2 * time.Second)
+	if len(frame) != 2 {
+		t.Fatalf("expected live + archived (deduped), got %d: %+v", len(frame), frame)
+	}
+	names := runNames(frame)
+	if !names["live-run"] || !names["archived-run"] {
+		t.Fatalf("expected [live-run, archived-run], got %+v", frame)
+	}
+	if names["STALE-DUP"] {
+		t.Fatalf("stale supplement duplicate of live id should be dropped, got %+v", frame)
+	}
+}


### PR DESCRIPTION
**What**
- Introduce `RunsSSEHandler` to stream run listings as SSE events
- Implement run merging with deduplication by ID
- Add `runFilterFromQuery` helper to parse query parameters
- Add `mergeRuns` utility for combining live and supplemental run metadata

**Why**
- Enable manager views to observe new and changing runs without terminal events
- Allow supplement sources (e.g., archived runs) to augment live in-memory runs
- Live runs take precedence on collision

**Testing**
- Comprehensive test coverage verifying listing emission, change detection, and deduplication behavior