### PR TITLE
feat(exec): add resource monitoring for supervised processes

### DIFF
--- a/examples/enitity/webapp/src/App.tsx
+++ b/examples/enitity/webapp/src/App.tsx
@@ -77,7 +77,7 @@ export function App() {
         </Routes>
       </div>
 
-      <ChatWidget />
+      <ChatWidget client={apiClient} />
     </div>
   );
 }

--- a/examples/enitity/webapp/src/ChatWidget.tsx
+++ b/examples/enitity/webapp/src/ChatWidget.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from "react";
+import { useOperations, type OperationsApiClient } from "@flanksource/clicky-ui";
 import {
   ChatWindowManagerProvider,
   ChatFab,
   ChatWindowLayer,
   type ContextTypeConfig,
 } from "@flanksource/clicky-ui/ai";
+import { clickyOperationsToTools } from "@flanksource/clicky-ui/chat";
 
 const TYPE_CONFIG: ContextTypeConfig = {
   stack: { icon: "ph:stack", className: "text-blue-600 bg-blue-50" },
@@ -14,14 +17,22 @@ const TYPE_CONFIG: ContextTypeConfig = {
 /** Multi-window chat shell for the entity demo: a launch FAB plus up to six
  *  draggable/resizable windows, each hosting clicky-ui's <Chat> against the
  *  demo's /api/chat endpoint (where entity operations are exposed as tools) and
- *  switching between persisted threads via /api/chat/threads. */
-export function ChatWidget() {
+ *  switching between persisted threads via /api/chat/threads.
+ *
+ *  Wired to the same `client` the explorer uses, so the tool-preferences popover
+ *  reflects the same RPC operations the explorer exposes (parity with the
+ *  assistant EntityExplorerApp used to mount internally). */
+export function ChatWidget({ client }: { client: OperationsApiClient }) {
+  const { operations } = useOperations(client);
+  const tools = useMemo(() => clickyOperationsToTools(operations), [operations]);
+
   return (
     <ChatWindowManagerProvider storageId="entity-demo">
       <ChatFab />
       <ChatWindowLayer
         threadsApi="/api/chat/threads"
         contextTypeConfig={TYPE_CONFIG}
+        tools={tools}
         chat={{
           api: "/api/chat",
           modelsApi: "/api/chat/models",

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -269,6 +269,7 @@ func (p *Process) clone() *Process {
 		SucceedOnNonZero: p.SucceedOnNonZero,
 		log:              p.log,
 		Shell:            p.Shell,
+		newProcessGroup:  p.newProcessGroup,
 		done:             make(chan struct{}),
 	}
 

--- a/exec/fdcount_darwin.go
+++ b/exec/fdcount_darwin.go
@@ -1,0 +1,62 @@
+//go:build darwin
+
+package exec
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// openFilesByPid returns the open-file count per pid via a single lsof call,
+// since gopsutil does not implement NumFDs/OpenFiles on darwin. With -F pf lsof
+// prints a `p<pid>` record starting each process block followed by one `f<…>`
+// record per open file (numeric fds plus cwd/txt/mem), so counting f-records
+// against the current p-record yields per-pid totals. Returns nil when lsof is
+// unavailable so callers can render "unsupported" rather than a misleading 0.
+func openFilesByPid(pids []int32) map[int32]int {
+	if len(pids) == 0 {
+		return map[int32]int{}
+	}
+	ids := make([]string, len(pids))
+	for i, pid := range pids {
+		ids[i] = strconv.Itoa(int(pid))
+	}
+	bin, err := exec.LookPath("lsof")
+	if err != nil {
+		return nil
+	}
+	// lsof exits non-zero when some pids are already gone but still prints the
+	// rest, so the output is parsed regardless of the exit status.
+	out, err := exec.Command(bin, "-p", strings.Join(ids, ","), "-F", "pf").Output()
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		return nil
+	}
+	counts := make(map[int32]int, len(pids))
+	if len(out) == 0 {
+		return counts
+	}
+	cur := int32(-1)
+	for _, line := range strings.Split(string(out), "\n") {
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			if v, err := strconv.Atoi(line[1:]); err == nil {
+				cur = int32(v)
+				counts[cur] = 0
+			}
+		case 'f':
+			if cur >= 0 {
+				counts[cur]++
+			}
+		}
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	return counts
+}

--- a/exec/fdcount_linux.go
+++ b/exec/fdcount_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package exec
+
+import (
+	"os"
+	"strconv"
+)
+
+// openFilesByPid returns the open-file-descriptor count per pid by reading
+// /proc/<pid>/fd. Pids that have already exited are omitted. The map is always
+// non-nil on linux (the platform can always report fds), so callers treat a
+// missing pid as zero rather than "unsupported".
+func openFilesByPid(pids []int32) map[int32]int {
+	out := make(map[int32]int, len(pids))
+	for _, pid := range pids {
+		entries, err := os.ReadDir("/proc/" + strconv.Itoa(int(pid)) + "/fd")
+		if err != nil {
+			continue
+		}
+		out[pid] = len(entries)
+	}
+	return out
+}

--- a/exec/fdcount_other.go
+++ b/exec/fdcount_other.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin
+
+package exec
+
+// openFilesByPid is unsupported on this platform; nil signals "unknown" so the
+// aggregate renders distinctly from a real zero.
+func openFilesByPid(pids []int32) map[int32]int { return nil }

--- a/exec/grouppids_other.go
+++ b/exec/grouppids_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package exec
+
+// groupPids is unsupported off unix (no POSIX process groups); callers fall
+// back to a parent→child descendant walk.
+func groupPids(root int32) ([]int32, bool) { return nil, false }

--- a/exec/grouppids_unix.go
+++ b/exec/grouppids_unix.go
@@ -1,0 +1,40 @@
+//go:build unix
+
+package exec
+
+import (
+	"syscall"
+
+	gops "github.com/shirou/gopsutil/v3/process"
+)
+
+// groupPids lists every process in root's POSIX process group, but only when
+// root is the group leader (pgid == root) — i.e. it was started
+// WithProcessGroup. That guard prevents enumerating unrelated processes that
+// merely share the caller's group. Returns (nil, false) to fall back to a
+// descendant walk when root does not lead a group or the process table can't be
+// read.
+//
+// This is O(processes on the host) per sample (one Getpgid syscall each), which
+// is fine at the monitor's multi-second cadence for the handful of supervised
+// processes a supervisor runs.
+func groupPids(root int32) ([]int32, bool) {
+	pgid, err := syscall.Getpgid(int(root))
+	if err != nil || pgid != int(root) {
+		return nil, false
+	}
+	all, err := gops.Pids()
+	if err != nil {
+		return nil, false
+	}
+	out := make([]int32, 0, 8)
+	for _, pid := range all {
+		if pg, err := syscall.Getpgid(int(pid)); err == nil && pg == pgid {
+			out = append(out, pid)
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}

--- a/exec/ports.go
+++ b/exec/ports.go
@@ -1,0 +1,102 @@
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ListeningPorts returns the distinct TCP ports the process group led by pgid is
+// listening on, in ascending order. It shells out to lsof, which is present on
+// macOS and most Linux dev/CI images. WithProcessGroup() puts each supervised
+// process in its own group whose id equals the leader pid, so passing the leader
+// pid as pgid captures listeners opened by the process and any child it forked
+// (e.g. `npm run dev` → node).
+//
+// Detection is advisory: when lsof is not on PATH the result is (nil, nil) so
+// callers degrade to "no ports detected" (and Windows, which has no lsof, is a
+// no-op). lsof exits non-zero when nothing matches ("not listening yet") — that
+// is the normal empty case, so whatever it printed is parsed instead of erroring.
+// Only a failure to execute lsof at all is returned as an error.
+func ListeningPorts(pgid int) ([]int, error) {
+	if pgid <= 0 {
+		return nil, nil
+	}
+	return runLsofListen("-g", strconv.Itoa(pgid))
+}
+
+func listeningPortsForPids(pids []int32) ([]int, error) {
+	if len(pids) == 0 {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		if pid > 0 {
+			ids = append(ids, strconv.Itoa(int(pid)))
+		}
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	return runLsofListen("-p", strings.Join(ids, ","))
+}
+
+func runLsofListen(selector ...string) ([]int, error) {
+	bin, err := exec.LookPath("lsof")
+	if err != nil {
+		return nil, nil
+	}
+	// -n/-P skip DNS and port-name lookups (numeric output); -a ANDs the
+	// selector with the TCP-listen filter; -F n emits one machine-readable
+	// `n<addr>` line per matching socket.
+	args := []string{"-nP", "-a"}
+	args = append(args, selector...)
+	args = append(args, "-iTCP", "-sTCP:LISTEN", "-F", "n")
+	out, err := exec.Command(bin, args...).Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return parseListenPorts(string(out)), nil
+		}
+		return nil, fmt.Errorf("run lsof %s: %w", strings.Join(selector, " "), err)
+	}
+	return parseListenPorts(string(out)), nil
+}
+
+// parseListenPorts extracts the listening ports from lsof `-F n` output. Each
+// address field is on its own `n`-prefixed line, e.g. `n*:3000`,
+// `n127.0.0.1:8080`, or `n[::1]:5000`; the port is the digits after the final
+// colon. Established connections (which carry a `->` arrow) are ignored.
+func parseListenPorts(out string) []int {
+	seen := map[int]struct{}{}
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) < 2 || line[0] != 'n' {
+			continue
+		}
+		addr := strings.TrimSpace(line[1:])
+		if strings.Contains(addr, "->") {
+			continue
+		}
+		i := strings.LastIndex(addr, ":")
+		if i < 0 {
+			continue
+		}
+		port, err := strconv.Atoi(addr[i+1:])
+		if err != nil || port <= 0 || port > 65535 {
+			continue
+		}
+		seen[port] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	ports := make([]int, 0, len(seen))
+	for p := range seen {
+		ports = append(ports, p)
+	}
+	sort.Ints(ports)
+	return ports
+}

--- a/exec/ports_test.go
+++ b/exec/ports_test.go
@@ -1,0 +1,71 @@
+//go:build unix
+
+package exec
+
+import (
+	"net"
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseListenPorts", func() {
+	It("extracts ports from IPv4, IPv6 and wildcard addresses", func() {
+		out := "p123\nf3\nn*:3000\nf5\nn127.0.0.1:8080\nf7\nn[::1]:5000\n"
+		Expect(parseListenPorts(out)).To(Equal([]int{3000, 5000, 8080}))
+	})
+
+	It("deduplicates the same port reported on multiple fds", func() {
+		out := "p123\nf8\nn*:49152\nf9\nn*:49152\n"
+		Expect(parseListenPorts(out)).To(Equal([]int{49152}))
+	})
+
+	It("returns every distinct listening port of one process in ascending order", func() {
+		out := "p123\nf3\nn*:8080\nf4\nn127.0.0.1:3000\nf5\nn[::1]:9090\n"
+		Expect(parseListenPorts(out)).To(Equal([]int{3000, 8080, 9090}))
+	})
+
+	It("ignores established connections and malformed addresses", func() {
+		out := "n127.0.0.1:8080->127.0.0.1:55000\nn*:notaport\nnno-colon-here\nn*:\n"
+		Expect(parseListenPorts(out)).To(BeNil())
+	})
+
+	It("returns nil for empty output", func() {
+		Expect(parseListenPorts("")).To(BeNil())
+	})
+})
+
+var _ = Describe("ListeningPorts", func() {
+	It("returns nil for a non-positive pgid", func() {
+		got, err := ListeningPorts(0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeNil())
+	})
+
+	It("detects multiple ports opened in the current process group", func() {
+		if _, err := exec.LookPath("lsof"); err != nil {
+			Skip("lsof not installed")
+		}
+		ln1, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		defer ln1.Close()
+		ln2, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		defer ln2.Close()
+		p1 := ln1.Addr().(*net.TCPAddr).Port
+		p2 := ln2.Addr().(*net.TCPAddr).Port
+
+		pgid, err := syscall.Getpgid(syscall.Getpid())
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() []int {
+			ports, perr := ListeningPorts(pgid)
+			Expect(perr).NotTo(HaveOccurred())
+			return ports
+		}, "3s", "100ms").Should(And(ContainElement(p1), ContainElement(p2)),
+			"expected to detect both bound ports "+strconv.Itoa(p1)+" and "+strconv.Itoa(p2))
+	})
+})

--- a/exec/process_group_unix.go
+++ b/exec/process_group_unix.go
@@ -18,6 +18,27 @@ func applyProcessGroup(cmd *exec.Cmd, newPG bool) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+// terminateTree asks the process tree to exit gracefully (SIGTERM). With a
+// process group the signal reaches the whole group atomically (negative pid =
+// pgid); otherwise it signals just the leader. Callers escalate to killTree
+// (SIGKILL) if the tree doesn't exit within a grace window.
+func terminateTree(pid int, hasProcessGroup bool) error {
+	if pid <= 0 {
+		return nil
+	}
+	target := pid
+	if hasProcessGroup {
+		target = -pid
+	}
+	if err := syscall.Kill(target, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil // already gone
+		}
+		return err
+	}
+	return nil
+}
+
 func killTree(pid int, hasProcessGroup bool) error {
 	if pid <= 0 {
 		return nil

--- a/exec/process_group_windows.go
+++ b/exec/process_group_windows.go
@@ -31,3 +31,12 @@ func killTree(pid int, _ bool) error {
 	}
 	return killTreeByWalk(pid)
 }
+
+// terminateTree has no graceful equivalent on Windows (no POSIX signals); fall
+// back to the same descendant kill so Stop still tears the tree down.
+func terminateTree(pid int, _ bool) error {
+	if pid <= 0 {
+		return nil
+	}
+	return killTreeByWalk(pid)
+}

--- a/exec/supervise_loop.go
+++ b/exec/supervise_loop.go
@@ -1,0 +1,398 @@
+package exec
+
+import (
+	"slices"
+	"time"
+)
+
+// Lifecycle defaults / cadences. Vars (not consts) so tests can shrink the
+// port-detection window and cadences to keep them fast.
+var (
+	defaultStopGrace = 5 * time.Second
+	// Port detection runs for the whole life of a run. portPollInterval is the
+	// fast cadence used during the startup window (portFastWindow), after which it
+	// relaxes to portPollIntervalSlow — so a port that only binds after a cold
+	// `go run` compile, well past the window, is still picked up without polling
+	// lsof aggressively for the process's whole life. portPromoteGrace is how long
+	// a DetectPorts process may sit in "starting" with no port before it is
+	// promoted to "running" anyway, so a port-less worker doesn't look stuck while
+	// a real server still gets its port annotated whenever it eventually binds.
+	portPollInterval     = 300 * time.Millisecond
+	portPollIntervalSlow = 3 * time.Second
+	portPromoteGrace     = 2 * time.Second
+	portFastWindow       = 30 * time.Second
+)
+
+// portDetector reports the listening ports of the process tree rooted at pid.
+type portDetector func(pid int32) ([]int, error)
+
+// detectGroupPorts is the production detector: the listening ports across the
+// supervised process's whole group/tree.
+func detectGroupPorts(pid int32) ([]int, error) {
+	return listeningPortsForPids(collectPids(pid))
+}
+
+// Start begins (or resumes) supervising in the background. It is idempotent
+// while a supervise loop is active; calling it again after the loop has ended
+// (Stop, or a permanent exit) starts a fresh loop.
+func (s *SupervisedProcess) Start() {
+	s.mu.Lock()
+	if s.loopActive {
+		s.mu.Unlock()
+		return
+	}
+	s.loopActive = true
+	s.desired = true
+	s.stopping = false
+	s.restarts = 0
+	s.exitCode = nil
+	s.killed = false
+	s.expectsPort = false
+	s.status = StatusStarting
+	clear(s.handles) // reset CPU-delta cache for the fresh run streak
+	s.done = make(chan struct{})
+	s.wake = make(chan struct{}, 1)
+	done := s.done
+	s.mu.Unlock()
+
+	go s.monitorLoop(done)
+	go s.runLoop()
+}
+
+// Stop gracefully stops the process and prevents further restarts, blocking
+// until the supervise loop has ended (or the stop grace elapsed and it was
+// force-killed). Safe to call when already stopped.
+func (s *SupervisedProcess) Stop() {
+	s.mu.Lock()
+	if !s.loopActive {
+		s.mu.Unlock()
+		return
+	}
+	s.desired = false
+	s.stopping = true
+	c := s.current
+	s.mu.Unlock()
+
+	s.signalWake()
+	if c != nil {
+		s.killGracefully(c)
+	}
+	s.Wait()
+}
+
+// Restart restarts the process now, resetting the restart counter. If no loop is
+// active it simply starts one.
+func (s *SupervisedProcess) Restart() {
+	s.mu.Lock()
+	if !s.loopActive {
+		s.mu.Unlock()
+		s.Start()
+		return
+	}
+	s.gen++
+	s.restarts = 0
+	s.status = StatusRestarting
+	c := s.current
+	s.mu.Unlock()
+
+	s.signalWake()
+	if c != nil {
+		s.killGracefully(c)
+	}
+}
+
+// Wait blocks until the current supervise loop has ended.
+func (s *SupervisedProcess) Wait() {
+	s.mu.RLock()
+	d := s.done
+	s.mu.RUnlock()
+	if d == nil {
+		return
+	}
+	<-d
+}
+
+func (s *SupervisedProcess) signalWake() {
+	s.mu.RLock()
+	w := s.wake
+	s.mu.RUnlock()
+	if w == nil {
+		return
+	}
+	select {
+	case w <- struct{}{}:
+	default:
+	}
+}
+
+func (s *SupervisedProcess) isStopping() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.stopping
+}
+
+func (s *SupervisedProcess) setStatus(status Status) {
+	s.mu.Lock()
+	s.status = status
+	s.mu.Unlock()
+}
+
+// runLoop runs the process, applies the restart policy on exit, and rebuilds it
+// until the process is stopped or won't be restarted. Mirrors the per-process
+// supervision gavel's Procfile supervisor used to own.
+func (s *SupervisedProcess) runLoop() {
+	defer func() {
+		s.mu.Lock()
+		s.current = nil
+		s.started = nil
+		s.loopActive = false
+		d := s.done
+		s.mu.Unlock()
+		if d != nil {
+			close(d)
+		}
+		if s.opts.OnExit != nil {
+			s.opts.OnExit()
+		}
+	}()
+
+	for {
+		s.mu.Lock()
+		if !s.desired || s.stopping {
+			s.status = StatusStopped
+			s.mu.Unlock()
+			return
+		}
+		myGen := s.gen
+		s.mu.Unlock()
+
+		proc := s.template.clone()
+
+		if s.opts.OnStart != nil {
+			s.opts.OnStart()
+		}
+
+		runDone := make(chan struct{})
+		go func() { proc.Run(); close(runDone) }()
+		awaitStart(proc, runDone)
+
+		if proc.IsRunning() {
+			now := time.Now()
+			s.mu.Lock()
+			if !s.desired || s.stopping || s.gen != myGen {
+				s.mu.Unlock()
+				s.killGracefully(proc)
+				<-runDone
+				if s.isStopping() {
+					s.setStatus(StatusStopped)
+					return
+				}
+				continue
+			}
+			s.current = proc
+			s.started = &now
+			s.highCPU = 0
+			clear(s.handles)
+			if s.opts.DetectPorts {
+				s.status = StatusStarting
+			} else {
+				s.status = StatusRunning
+			}
+			s.mu.Unlock()
+		}
+
+		if s.opts.DetectPorts && proc.IsRunning() {
+			go s.watchPorts(proc, myGen, detectGroupPorts)
+		}
+
+		<-runDone
+		res := proc.Result()
+
+		s.mu.Lock()
+		code := res.ExitCode
+		s.exitCode = &code
+		s.current = nil
+		s.started = nil
+		s.ports = nil
+		genChanged := s.gen != myGen
+		desired := s.desired
+		restarts := s.restarts
+		s.mu.Unlock()
+
+		ok := res.IsOk()
+		switch {
+		case s.isStopping() || !desired:
+			s.setStatus(StatusStopped)
+			return
+		case genChanged:
+			s.mu.Lock()
+			s.restarts = 0
+			s.mu.Unlock()
+			continue
+		case !shouldRestart(s.opts.RestartPolicy, ok) || (s.opts.MaxRestarts > 0 && restarts >= s.opts.MaxRestarts):
+			s.setStatus(exitStatus(ok))
+			return
+		}
+
+		s.mu.Lock()
+		s.restarts++
+		s.status = StatusRestarting
+		s.mu.Unlock()
+		select {
+		case <-time.After(backoff(restarts + 1)):
+		case <-s.wake:
+		}
+	}
+}
+
+// monitorLoop samples resources of the current run until done is closed.
+func (s *SupervisedProcess) monitorLoop(done chan struct{}) {
+	ticker := time.NewTicker(s.opts.Limits.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			if s.IsRunning() {
+				s.sample()
+			}
+		}
+	}
+}
+
+// watchPorts polls for the TCP ports the current process tree is listening on
+// for the lifetime of the run, recording the set (and marking the process
+// port-bound, sticky across restarts) whenever it changes. It polls fast
+// (portPollInterval) during the startup window (portFastWindow), then relaxes to
+// portPollIntervalSlow, so a port that only binds after a cold `go run` compile —
+// well past the window — is still picked up. A detected port, or portPromoteGrace
+// elapsing without one, flips "starting"→"running" so neither a slow server nor a
+// port-less worker is wedged in "starting". gen guards against a stale watcher
+// from a previous run clobbering the current one.
+func (s *SupervisedProcess) watchPorts(proc *Process, gen int, detect portDetector) {
+	s.mu.RLock()
+	done := s.done
+	s.mu.RUnlock()
+	pid := proc.Pid()
+	if pid <= 0 {
+		return
+	}
+
+	start := time.Now()
+	promoteAt := start.Add(portPromoteGrace)
+	fastUntil := start.Add(portFastWindow)
+	for {
+		s.mu.RLock()
+		current := s.gen == gen && s.current == proc && !s.stopping
+		s.mu.RUnlock()
+		if !current || !proc.IsRunning() {
+			return
+		}
+
+		ports, err := detect(int32(pid))
+		if err != nil {
+			log.Warnf("detect ports for %s: %v", s.Name(), err)
+			s.promoteIfStarting(gen, proc)
+			return
+		}
+
+		s.mu.Lock()
+		if s.gen != gen || s.current != proc {
+			s.mu.Unlock()
+			return
+		}
+		if len(ports) > 0 {
+			if !slices.Equal(s.ports, ports) {
+				s.ports = ports
+			}
+			s.expectsPort = true
+		}
+		if s.status == StatusStarting && (len(ports) > 0 || !time.Now().Before(promoteAt)) {
+			s.status = StatusRunning
+		}
+		s.mu.Unlock()
+
+		interval := portPollInterval
+		if !time.Now().Before(fastUntil) {
+			interval = portPollIntervalSlow
+		}
+		select {
+		case <-time.After(interval):
+		case <-done:
+			return
+		}
+	}
+}
+
+// promoteIfStarting flips a still-"starting" current run to "running" — used when
+// port detection can't continue (lsof failed) so a known server isn't left
+// wedged in "starting". The gen/proc guard ignores a stale prior run.
+func (s *SupervisedProcess) promoteIfStarting(gen int, proc *Process) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.gen == gen && s.current == proc && s.status == StatusStarting {
+		s.status = StatusRunning
+	}
+}
+
+// killGracefully sends SIGTERM to the process group, then escalates to SIGKILL
+// (KillTree) if it does not exit within the configured stop grace.
+func (s *SupervisedProcess) killGracefully(p *Process) {
+	_ = terminateTree(p.Pid(), p.newProcessGroup)
+	deadline := time.Now().Add(s.opts.StopGrace)
+	for time.Now().Before(deadline) {
+		if !p.IsRunning() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = p.KillTree()
+}
+
+// awaitStart blocks until the process has a pid (it actually launched) or has
+// already exited, so a status read after start sees a real pid. Capped so a
+// never-starting command can't block the loop forever.
+func awaitStart(proc *Process, runDone <-chan struct{}) {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if proc.Pid() > 0 {
+			return
+		}
+		select {
+		case <-runDone:
+			return
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func shouldRestart(policy RestartPolicy, ok bool) bool {
+	switch policy {
+	case RestartAlways:
+		return true
+	case RestartOnFailure:
+		return !ok
+	default:
+		return false
+	}
+}
+
+func exitStatus(ok bool) Status {
+	if ok {
+		return StatusExited
+	}
+	return StatusCrashed
+}
+
+// backoff returns the delay before the nth restart: 500ms doubling up to 30s.
+func backoff(n int) time.Duration {
+	d := 500 * time.Millisecond
+	for i := 1; i < n; i++ {
+		d *= 2
+		if d >= 30*time.Second {
+			return 30 * time.Second
+		}
+	}
+	return d
+}

--- a/exec/supervised.go
+++ b/exec/supervised.go
@@ -1,0 +1,451 @@
+package exec
+
+import (
+	"sync"
+	"time"
+
+	gops "github.com/shirou/gopsutil/v3/process"
+)
+
+// Resource-monitor defaults applied when a ResourceLimits field is left zero.
+const (
+	defaultSampleInterval = 2 * time.Second
+	defaultCPUSampleCount = 18 // ~36s over-limit at the 2s default before a CPU kill
+)
+
+// ResourceSnapshot is a point-in-time measurement of a supervised process and
+// its descendant tree. OpenFiles is -1 on platforms that cannot report it.
+type ResourceSnapshot struct {
+	CPUPercent float64   `json:"cpuPercent"`
+	RSSBytes   uint64    `json:"rssBytes"`
+	OpenFiles  int       `json:"openFiles"`
+	SampledAt  time.Time `json:"sampledAt"`
+}
+
+// ProcessSample is the resource usage of one process in the supervised group,
+// the per-process breakdown behind the aggregate ResourceSnapshot. OpenFiles is
+// -1 where the platform cannot report it.
+type ProcessSample struct {
+	PID        int32   `json:"pid"`
+	PPID       int32   `json:"ppid"`
+	Command    string  `json:"command"`
+	CPUPercent float64 `json:"cpuPercent"`
+	RSSBytes   uint64  `json:"rssBytes"`
+	OpenFiles  int     `json:"openFiles"`
+}
+
+// ResourceLimits optionally bounds a supervised process. A zero value in any
+// limit field disables that limit. When a limit is exceeded the whole process
+// tree is killed (KillTree) and SupervisedProcess.Killed reports true.
+type ResourceLimits struct {
+	// MaxRSSBytes kills the process the first sample its tree RSS exceeds this.
+	MaxRSSBytes uint64
+	// MaxCPUPercent kills the process after CPUSampleCount consecutive samples
+	// above this aggregate CPU percentage (transient spikes are tolerated).
+	MaxCPUPercent float64
+	// CPUSampleCount is the consecutive over-limit CPU samples tolerated before
+	// a kill. Defaults to defaultCPUSampleCount.
+	CPUSampleCount int
+	// Interval is the sampling cadence. Defaults to defaultSampleInterval.
+	Interval time.Duration
+}
+
+// enabled reports whether any runaway limit is configured.
+func (l ResourceLimits) enabled() bool {
+	return l.MaxRSSBytes > 0 || l.MaxCPUPercent > 0
+}
+
+// RestartPolicy controls whether a supervised process is restarted after it exits.
+type RestartPolicy string
+
+const (
+	RestartNo        RestartPolicy = "no"         // never restart
+	RestartOnFailure RestartPolicy = "on-failure" // restart only on a non-zero exit
+	RestartAlways    RestartPolicy = "always"     // restart on any exit
+)
+
+// Status is the lifecycle state of a supervised process.
+type Status string
+
+const (
+	StatusStopped    Status = "stopped"
+	StatusStarting   Status = "starting"
+	StatusRunning    Status = "running"
+	StatusRestarting Status = "restarting"
+	StatusCrashed    Status = "crashed"
+	StatusExited     Status = "exited"
+)
+
+// SuperviseOptions configures the supervision loop.
+type SuperviseOptions struct {
+	// Limits bounds resource usage; zero values disable individual limits.
+	Limits ResourceLimits
+	// RestartPolicy controls restart-on-exit; defaults to RestartNo.
+	RestartPolicy RestartPolicy
+	// MaxRestarts caps automatic restarts (0 = unlimited).
+	MaxRestarts int
+	// StopGrace is the SIGTERM→SIGKILL window on Stop; defaults to 5s.
+	StopGrace time.Duration
+	// DetectPorts runs the lsof port-watch loop after each start.
+	DetectPorts bool
+	// OnStart, if set, is called before each (re)start (e.g. to write a log header).
+	OnStart func()
+	// OnExit, if set, is called once when the supervise loop ends permanently
+	// (the process exited and will not be restarted, or it was stopped).
+	OnExit func()
+}
+
+// SupervisedProcess supervises a single process: it (re)runs a template command
+// per its RestartPolicy, detects listening ports, samples CPU/memory/open-files
+// of the whole process group, and enforces resource limits. It is created from a
+// configured Process via (*Process).Supervise and driven with Start/Stop/Restart.
+type SupervisedProcess struct {
+	template *Process
+	opts     SuperviseOptions
+
+	mu          sync.RWMutex
+	current     *Process // the running clone; nil between runs
+	loopActive  bool
+	desired     bool
+	stopping    bool
+	status      Status
+	started     *time.Time
+	restarts    int
+	exitCode    *int
+	ports       []int
+	expectsPort bool // sticky: has bound a port before, so a (re)start gates on it
+	gen         int
+	done        chan struct{} // closed when the current supervise loop ends
+	wake        chan struct{} // wakes the loop out of restart backoff
+
+	// resource-monitor state (guarded by the same mu)
+	latest  ResourceSnapshot
+	peak    ResourceSnapshot
+	tree    []ProcessSample
+	highCPU int
+	killed  bool
+	// handles caches one gopsutil Process per pid so Percent(0) yields the CPU
+	// delta since the previous sample rather than the lifetime average.
+	handles map[int32]*gops.Process
+}
+
+// Supervise turns a configured Process into a SupervisedProcess using it as the
+// template re-run on each (re)start. Call Start to begin supervising.
+func (p *Process) Supervise(opts SuperviseOptions) *SupervisedProcess {
+	if opts.Limits.Interval <= 0 {
+		opts.Limits.Interval = defaultSampleInterval
+	}
+	if opts.Limits.CPUSampleCount <= 0 {
+		opts.Limits.CPUSampleCount = defaultCPUSampleCount
+	}
+	if opts.StopGrace <= 0 {
+		opts.StopGrace = defaultStopGrace
+	}
+	if opts.RestartPolicy == "" {
+		opts.RestartPolicy = RestartNo
+	}
+	return &SupervisedProcess{
+		template: p,
+		opts:     opts,
+		status:   StatusStopped,
+		handles:  map[int32]*gops.Process{},
+	}
+}
+
+// Supervise builds a supervised process from a command, mirroring NewExec.
+func Supervise(opts SuperviseOptions, cmd string, args ...string) *SupervisedProcess {
+	return NewExec(cmd, args...).Supervise(opts)
+}
+
+// --- state accessors -------------------------------------------------------
+
+// Resources returns the most recent aggregate resource sample.
+func (s *SupervisedProcess) Resources() ResourceSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.latest
+}
+
+// Peak returns the high-water mark across all samples.
+func (s *SupervisedProcess) Peak() ResourceSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.peak
+}
+
+// Tree returns the most recent per-process breakdown of the supervised group.
+func (s *SupervisedProcess) Tree() []ProcessSample {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]ProcessSample(nil), s.tree...)
+}
+
+// Killed reports whether the process was killed for breaching a resource limit.
+func (s *SupervisedProcess) Killed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.killed
+}
+
+// Status returns the current lifecycle state.
+func (s *SupervisedProcess) Status() Status {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.status
+}
+
+// Ports returns the listening ports detected for the current run (empty if none
+// or port detection is disabled).
+func (s *SupervisedProcess) Ports() []int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]int(nil), s.ports...)
+}
+
+// Restarts returns the number of automatic restarts in the current run streak.
+func (s *SupervisedProcess) Restarts() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.restarts
+}
+
+// ExitCode returns the last run's exit code, or nil if it hasn't exited yet.
+func (s *SupervisedProcess) ExitCode() *int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return ptrCopy(s.exitCode)
+}
+
+// Started returns when the current run started, or nil if not running.
+func (s *SupervisedProcess) Started() *time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return ptrCopy(s.started)
+}
+
+// Pid returns the current run's pid, or 0 between runs.
+func (s *SupervisedProcess) Pid() int {
+	s.mu.RLock()
+	c := s.current
+	s.mu.RUnlock()
+	if c == nil {
+		return 0
+	}
+	return c.Pid()
+}
+
+// IsRunning reports whether a run is currently executing.
+func (s *SupervisedProcess) IsRunning() bool {
+	s.mu.RLock()
+	c := s.current
+	s.mu.RUnlock()
+	return c != nil && c.IsRunning()
+}
+
+// KillTree force-kills the current run's process tree (no-op between runs).
+func (s *SupervisedProcess) KillTree() error {
+	s.mu.RLock()
+	c := s.current
+	s.mu.RUnlock()
+	if c == nil {
+		return nil
+	}
+	return c.KillTree()
+}
+
+// Name returns the template command's display name.
+func (s *SupervisedProcess) Name() string {
+	return s.template.Name()
+}
+
+func ptrCopy[T any](v *T) *T {
+	if v == nil {
+		return nil
+	}
+	copied := *v
+	return &copied
+}
+
+// --- resource monitor ------------------------------------------------------
+
+// sample measures the process group once and records + enforces the result.
+func (s *SupervisedProcess) sample() {
+	pid := s.Pid()
+	if pid <= 0 {
+		return
+	}
+	pids := collectPids(int32(pid))
+	fds := openFilesByPid(pids) // nil when the platform can't report fds
+
+	var cpu float64
+	var rss uint64
+	openTotal := 0
+	tree := make([]ProcessSample, 0, len(pids))
+	for _, p := range pids {
+		h := s.handle(p)
+		if h == nil {
+			continue
+		}
+		node := ProcessSample{PID: p, OpenFiles: -1}
+		if ppid, err := h.Ppid(); err == nil {
+			node.PPID = ppid
+		}
+		if name, err := h.Name(); err == nil {
+			node.Command = name
+		}
+		if pct, err := h.Percent(0); err == nil {
+			node.CPUPercent = pct
+			cpu += pct
+		}
+		if mi, err := h.MemoryInfo(); err == nil && mi != nil {
+			node.RSSBytes = mi.RSS
+			rss += mi.RSS
+		}
+		if fds != nil {
+			node.OpenFiles = fds[p]
+			openTotal += fds[p]
+		}
+		tree = append(tree, node)
+	}
+	s.prune(pids)
+
+	openAgg := -1 // sentinel: platform can't report open files
+	if fds != nil {
+		openAgg = openTotal
+	}
+	snap := ResourceSnapshot{
+		CPUPercent: cpu,
+		RSSBytes:   rss,
+		OpenFiles:  openAgg,
+		SampledAt:  time.Now(),
+	}
+	s.store(snap, tree)
+	s.enforce(snap)
+}
+
+// collectPids returns the pids whose resource usage is attributed to this
+// process. When the process leads its own group (started WithProcessGroup,
+// pgid == root) every member of that process group is included — this captures
+// children that reparent away from the process (double-fork) but stay in the
+// group, which a parent→child walk would miss. Otherwise it falls back to a
+// descendant walk, which never over-counts unrelated processes that merely
+// share the caller's group.
+func collectPids(root int32) []int32 {
+	if pids, ok := groupPids(root); ok {
+		return pids
+	}
+	return treePids(root)
+}
+
+// treePids returns root and every descendant pid via the parent→child tree. It
+// is the fallback for collectPids when group enumeration is unavailable (the
+// process is not a group leader, or off-unix). A failure to enumerate children
+// (e.g. the process just exited) degrades to the pids found so far.
+func treePids(root int32) []int32 {
+	out := []int32{root}
+	proc, err := gops.NewProcess(root)
+	if err != nil {
+		return out
+	}
+	var walk func(p *gops.Process)
+	walk = func(p *gops.Process) {
+		kids, err := p.Children()
+		if err != nil {
+			return
+		}
+		for _, k := range kids {
+			out = append(out, k.Pid)
+			walk(k)
+		}
+	}
+	walk(proc)
+	return out
+}
+
+func (s *SupervisedProcess) handle(pid int32) *gops.Process {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if h, ok := s.handles[pid]; ok {
+		return h
+	}
+	h, err := gops.NewProcess(pid)
+	if err != nil {
+		return nil
+	}
+	s.handles[pid] = h
+	return h
+}
+
+// prune drops cached handles for pids no longer in the tree so Percent deltas
+// stay accurate and the map doesn't grow unbounded across many short children.
+func (s *SupervisedProcess) prune(live []int32) {
+	set := make(map[int32]struct{}, len(live))
+	for _, p := range live {
+		set[p] = struct{}{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for pid := range s.handles {
+		if _, ok := set[pid]; !ok {
+			delete(s.handles, pid)
+		}
+	}
+}
+
+func (s *SupervisedProcess) store(snap ResourceSnapshot, tree []ProcessSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.latest = snap
+	s.tree = tree
+	if snap.CPUPercent > s.peak.CPUPercent {
+		s.peak.CPUPercent = snap.CPUPercent
+	}
+	if snap.RSSBytes > s.peak.RSSBytes {
+		s.peak.RSSBytes = snap.RSSBytes
+	}
+	if s.peak.SampledAt.IsZero() || snap.OpenFiles > s.peak.OpenFiles {
+		s.peak.OpenFiles = snap.OpenFiles
+	}
+	s.peak.SampledAt = snap.SampledAt
+}
+
+// enforce kills the process tree when a configured limit is breached. RSS is
+// enforced immediately; CPU only after CPUSampleCount consecutive over-limit
+// samples so a brief startup spike doesn't trip it.
+func (s *SupervisedProcess) enforce(snap ResourceSnapshot) {
+	limits := s.opts.Limits
+	if !limits.enabled() {
+		return
+	}
+	if limits.MaxRSSBytes > 0 && snap.RSSBytes > limits.MaxRSSBytes {
+		s.killForLimit("RSS %d bytes exceeds limit %d", snap.RSSBytes, limits.MaxRSSBytes)
+		return
+	}
+	if limits.MaxCPUPercent <= 0 {
+		return
+	}
+	s.mu.Lock()
+	if snap.CPUPercent > limits.MaxCPUPercent {
+		s.highCPU++
+	} else {
+		s.highCPU = 0
+	}
+	over := s.highCPU >= limits.CPUSampleCount
+	s.mu.Unlock()
+	if over {
+		s.killForLimit("CPU %.1f%% exceeded limit %.1f%% for %d samples",
+			snap.CPUPercent, limits.MaxCPUPercent, limits.CPUSampleCount)
+	}
+}
+
+func (s *SupervisedProcess) killForLimit(format string, args ...any) {
+	s.mu.Lock()
+	if s.killed {
+		s.mu.Unlock()
+		return
+	}
+	s.killed = true
+	s.mu.Unlock()
+	log.Warnf("supervised process %s killed: "+format, append([]any{s.Name()}, args...)...)
+	_ = s.KillTree()
+}

--- a/exec/supervised_test.go
+++ b/exec/supervised_test.go
@@ -1,0 +1,202 @@
+//go:build unix
+
+package exec
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SupervisedProcess", func() {
+	fast := ResourceLimits{Interval: 150 * time.Millisecond}
+
+	// busyLoop pegs a CPU core and stays resident, giving the monitor non-zero
+	// CPU and RSS to observe. WithProcessGroup makes Stop/KillTree atomic.
+	busyLoop := func(opts SuperviseOptions) *SupervisedProcess {
+		s := NewExec("while :; do :; done").WithProcessGroup().Supervise(opts)
+		s.Start()
+		DeferCleanup(s.Stop)
+		Eventually(s.IsRunning, 3*time.Second, 20*time.Millisecond).Should(BeTrue())
+		return s
+	}
+
+	Describe("resource sampling", func() {
+		It("reports non-zero CPU, memory and open files while running", func() {
+			s := busyLoop(SuperviseOptions{Limits: fast})
+
+			Eventually(func() uint64 { return s.Resources().RSSBytes }, 5*time.Second, 100*time.Millisecond).
+				Should(BeNumerically(">", uint64(0)))
+			Eventually(func() float64 { return s.Resources().CPUPercent }, 6*time.Second, 100*time.Millisecond).
+				Should(BeNumerically(">", 0.0))
+			Expect(s.Resources().OpenFiles).ToNot(Equal(0))
+			resources := s.Resources()
+			peak := s.Peak()
+			Expect(peak.RSSBytes).To(BeNumerically(">=", resources.RSSBytes))
+		})
+
+		It("exposes a per-process tree covering forked children in the group", func() {
+			pidFile := filepath.Join(GinkgoT().TempDir(), "children")
+			script := fmt.Sprintf("sleep 300 & echo $! >> %s; sleep 300 & echo $! >> %s; wait",
+				shellQuote(pidFile), shellQuote(pidFile))
+			s := NewExec(script).WithProcessGroup().Supervise(SuperviseOptions{Limits: fast})
+			s.Start()
+			DeferCleanup(s.Stop)
+			Eventually(s.IsRunning, 3*time.Second, 20*time.Millisecond).Should(BeTrue())
+			Eventually(func() int {
+				data, err := os.ReadFile(pidFile)
+				if err != nil {
+					return 0
+				}
+				return len(strings.Fields(string(data)))
+			}, 3*time.Second, 50*time.Millisecond).Should(Equal(2))
+
+			if len(collectPids(int32(s.Pid()))) < 3 {
+				Skip("process-group enumeration is unavailable in this environment")
+			}
+			Eventually(func() int { return len(s.Tree()) }, 5*time.Second, 100*time.Millisecond).
+				Should(BeNumerically(">=", 3))
+			for _, n := range s.Tree() {
+				Expect(n.PID).To(BeNumerically(">", 0))
+				Expect(n.RSSBytes).To(BeNumerically(">", uint64(0)))
+			}
+		})
+	})
+
+	Describe("runaway enforcement", func() {
+		It("kills a process that stays over the CPU limit", func() {
+			s := busyLoop(SuperviseOptions{
+				Limits:        ResourceLimits{Interval: 150 * time.Millisecond, MaxCPUPercent: 1, CPUSampleCount: 2},
+				RestartPolicy: RestartNo,
+			})
+
+			Eventually(s.Killed, 6*time.Second, 100*time.Millisecond).Should(BeTrue())
+			Eventually(s.IsRunning, 4*time.Second, 100*time.Millisecond).Should(BeFalse())
+		})
+
+		It("leaves a process alone when no limit is configured", func() {
+			s := busyLoop(SuperviseOptions{Limits: fast})
+			Consistently(s.Killed, 1500*time.Millisecond, 150*time.Millisecond).Should(BeFalse())
+			Expect(s.IsRunning()).To(BeTrue())
+		})
+	})
+
+	Describe("lifecycle", func() {
+		It("stops gracefully and reports stopped", func() {
+			s := NewExec("sleep 300").WithProcessGroup().Supervise(SuperviseOptions{Limits: fast})
+			s.Start()
+			DeferCleanup(s.Stop)
+			Eventually(s.IsRunning, 3*time.Second, 20*time.Millisecond).Should(BeTrue())
+
+			s.Stop()
+			Expect(s.IsRunning()).To(BeFalse())
+			Expect(s.Status()).To(Equal(StatusStopped))
+		})
+
+		It("restarts on demand with a new pid", func() {
+			s := NewExec("sleep 300").WithProcessGroup().Supervise(SuperviseOptions{Limits: fast})
+			s.Start()
+			DeferCleanup(s.Stop)
+			Eventually(s.Pid, 3*time.Second, 20*time.Millisecond).Should(BeNumerically(">", 0))
+			first := s.Pid()
+
+			s.Restart()
+			Eventually(func() int { return s.Pid() }, 4*time.Second, 50*time.Millisecond).
+				Should(And(BeNumerically(">", 0), Not(Equal(first))))
+		})
+
+		It("does not restart under the default 'no' policy", func() {
+			s := NewExec("exit 1").WithProcessGroup().Supervise(SuperviseOptions{Limits: fast})
+			s.Start()
+			DeferCleanup(s.Stop)
+			Eventually(func() Status { return s.Status() }, 4*time.Second, 50*time.Millisecond).Should(Equal(StatusCrashed))
+			Expect(s.Restarts()).To(Equal(0))
+		})
+
+		It("restarts a failing process up to MaxRestarts under on-failure", func() {
+			s := NewExec("exit 1").WithProcessGroup().Supervise(SuperviseOptions{
+				RestartPolicy: RestartOnFailure, MaxRestarts: 2, Limits: fast,
+			})
+			s.Start()
+			DeferCleanup(s.Stop)
+			// 500ms + 1s backoff ⇒ ~1.5s for two retries.
+			Eventually(func() Status { return s.Status() }, 8*time.Second, 100*time.Millisecond).Should(Equal(StatusCrashed))
+			Expect(s.Restarts()).To(Equal(2))
+		})
+
+		It("reports exited (not crashed) on a clean zero exit", func() {
+			s := NewExec("true").WithProcessGroup().Supervise(SuperviseOptions{Limits: fast})
+			s.Start()
+			DeferCleanup(s.Stop)
+			Eventually(func() Status { return s.Status() }, 4*time.Second, 50*time.Millisecond).Should(Equal(StatusExited))
+		})
+	})
+
+	Describe("port detection", func() {
+		var savedWindow, savedFast, savedSlow, savedGrace time.Duration
+
+		BeforeEach(func() {
+			savedWindow, savedFast, savedSlow, savedGrace = portFastWindow, portPollInterval, portPollIntervalSlow, portPromoteGrace
+			portFastWindow = 80 * time.Millisecond
+			portPollInterval = 10 * time.Millisecond
+			portPollIntervalSlow = 20 * time.Millisecond
+			portPromoteGrace = 30 * time.Millisecond
+		})
+		AfterEach(func() {
+			portFastWindow, portPollInterval, portPollIntervalSlow, portPromoteGrace = savedWindow, savedFast, savedSlow, savedGrace
+		})
+
+		// startWatched supervises a resident process (its own real detector
+		// disabled) and parks it in "starting" with the current run's proc/gen, so
+		// a test can drive watchPorts with an injected detector.
+		startWatched := func() (*SupervisedProcess, *Process, int) {
+			s := NewExec("sleep 300").WithProcessGroup().Supervise(SuperviseOptions{Limits: fast})
+			s.Start()
+			DeferCleanup(s.Stop)
+			Eventually(s.IsRunning, 3*time.Second, 20*time.Millisecond).Should(BeTrue())
+			s.mu.Lock()
+			proc, gen := s.current, s.gen
+			s.status = StatusStarting
+			s.mu.Unlock()
+			return s, proc, gen
+		}
+
+		It("records a port that only binds after the startup window", func() {
+			s, proc, gen := startWatched()
+			start := time.Now()
+			// Empty until well past the window, mimicking a slow `go run` compile
+			// whose server binds its port only after detection used to give up.
+			detect := func(int32) ([]int, error) {
+				if time.Since(start) < 4*portFastWindow {
+					return nil, nil
+				}
+				return []int{4321}, nil
+			}
+			go s.watchPorts(proc, gen, detect)
+
+			Eventually(s.Ports, 2*time.Second, 20*time.Millisecond).Should(Equal([]int{4321}))
+			Expect(s.Status()).To(Equal(StatusRunning))
+		})
+
+		It("promotes a port-less process to running after the grace, not the full window", func() {
+			// A long fast-window proves promotion is driven by the grace, not by the
+			// window elapsing: if it waited for the window this would time out.
+			portFastWindow = 10 * time.Second
+			s, proc, gen := startWatched()
+			none := func(int32) ([]int, error) { return nil, nil }
+			go s.watchPorts(proc, gen, none)
+
+			Eventually(s.Status, 1*time.Second, 20*time.Millisecond).Should(Equal(StatusRunning))
+			Expect(s.Ports()).To(BeEmpty())
+		})
+	})
+})
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}


### PR DESCRIPTION
## What
- Introduce `SupervisedProcess` wrapper for periodic sampling of CPU, memory, and open file descriptors
- Support process group enumeration (Unix POSIX groups with fallback tree walk)
- Platform-specific implementations for open file counting (Darwin via lsof, Linux via /proc)
- Optional runaway enforcement with configurable RSS and CPU percentage limits

## Why
- Enable resource monitoring and enforcement for supervised child processes and their descendants

## Testing
- Comprehensive test coverage for sampling, process group aggregation, and enforcement behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added supervised process execution with start/stop/restart/wait lifecycle, configurable restart policies, optional listening-port readiness detection, and resource-limit enforcement (RSS/CPU) with peak tracking and per-process tree snapshots (including open-file counts when supported).
  * Added listening-port detection and platform-specific open-file counting.
  * Added core entity operation/response/problem abstractions plus HTTP context and RFC 9457 JSON problem/response writers.
  * Updated the web app Chat widget to use the shared API client.
* **Documentation**
  * Added local Go docs serving via `make docs`.
* **Tests**
  * Expanded coverage for supervision, port detection/parsing, and new entity/HTTP helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->