### PR TITLE
fix(aichat): set Anthropic max_tokens for aichat requests

### DIFF
--- a/aichat/genkit.go
+++ b/aichat/genkit.go
@@ -49,26 +49,36 @@ func initGenkit(ctx context.Context) (*genkit.Genkit, []Provider, error) {
 	return g, registered, nil
 }
 
+const defaultMaxOutputTokens = 4096
+
 // effortConfig builds the provider-specific generation config that translates
-// an Effort value into the provider's native reasoning control. Returns nil
-// when there is nothing to set (no effort, or a non-reasoning model).
+// an Effort value into the provider's native reasoning control. Anthropic also
+// requires max_tokens on every request, so return a config for Anthropic even
+// when no reasoning effort is selected.
 func effortConfig(m Model, e Effort) map[string]any {
-	if !m.Reasoning || e == EffortNone {
-		return nil
-	}
 	switch m.Provider {
 	case ProviderOpenAI:
+		if !m.Reasoning || e == EffortNone {
+			return nil
+		}
 		// OpenAI o-series: reasoning_effort low|medium|high.
 		return map[string]any{"reasoning_effort": string(e)}
 	case ProviderGoogle:
+		if !m.Reasoning || e == EffortNone {
+			return nil
+		}
 		// Gemini 2.5+: thinkingConfig.thinkingBudget (token budget).
 		return map[string]any{"thinkingConfig": map[string]any{"thinkingBudget": geminiThinkingBudget(e)}}
 	case ProviderAnthropic:
-		// Anthropic: extended-thinking budget tokens.
-		return map[string]any{"thinking": map[string]any{
-			"type":          "enabled",
-			"budget_tokens": anthropicThinkingBudget(e),
-		}}
+		cfg := map[string]any{"max_tokens": anthropicMaxTokens(e)}
+		if m.Reasoning && e != EffortNone {
+			// Anthropic: extended-thinking budget tokens.
+			cfg["thinking"] = map[string]any{
+				"type":          "enabled",
+				"budget_tokens": anthropicThinkingBudget(e),
+			}
+		}
+		return cfg
 	default:
 		return nil
 	}
@@ -85,6 +95,16 @@ func anthropicThinkingBudget(e Effort) int {
 	default:
 		return 0
 	}
+}
+
+func anthropicMaxTokens(e Effort) int {
+	budget := anthropicThinkingBudget(e)
+	if budget == 0 {
+		return defaultMaxOutputTokens
+	}
+	// Anthropic's thinking budget is counted inside max_tokens. Leave room for
+	// the visible answer in addition to the hidden thinking budget.
+	return budget + defaultMaxOutputTokens
 }
 
 func geminiThinkingBudget(e Effort) int {

--- a/aichat/models.go
+++ b/aichat/models.go
@@ -56,6 +56,9 @@ const DefaultModelID = "anthropic/claude-sonnet-4-5"
 // catalog is the v1 model menu. Mirrors captain pkg/ai provider defaults so the
 // chat agrees with the rest of the stack.
 var catalog = []Model{
+	{ID: "anthropic/claude-sonnet-4-6", Provider: ProviderAnthropic, Label: "Claude Sonnet 4.6", Reasoning: true, ContextWindow: 200000},
+	{ID: "anthropic/claude-opus-4-8", Provider: ProviderAnthropic, Label: "Claude Opus 4.8", Reasoning: true, ContextWindow: 200000},
+	{ID: "anthropic/claude-haiku-4-5", Provider: ProviderAnthropic, Label: "Claude Haiku 4.5", Reasoning: true, ContextWindow: 200000},
 	{ID: "anthropic/claude-sonnet-4-5", Provider: ProviderAnthropic, Label: "Claude Sonnet 4.5", Reasoning: true, ContextWindow: 200000},
 	{ID: "anthropic/claude-opus-4-1", Provider: ProviderAnthropic, Label: "Claude Opus 4.1", Reasoning: true, ContextWindow: 200000},
 	{ID: "anthropic/claude-3-5-haiku-latest", Provider: ProviderAnthropic, Label: "Claude 3.5 Haiku", Reasoning: false, ContextWindow: 200000},

--- a/aichat/models_test.go
+++ b/aichat/models_test.go
@@ -18,6 +18,22 @@ func TestLookupModelUnknownFailsLoud(t *testing.T) {
 	}
 }
 
+func TestAnthropicCatalogIncludesRequestedModels(t *testing.T) {
+	for _, id := range []string{
+		"anthropic/claude-haiku-4-5",
+		"anthropic/claude-sonnet-4-6",
+		"anthropic/claude-opus-4-8",
+	} {
+		m, err := LookupModel(id)
+		if err != nil {
+			t.Fatalf("LookupModel(%q): %v", id, err)
+		}
+		if m.Provider != ProviderAnthropic {
+			t.Errorf("LookupModel(%q).Provider = %q, want %q", id, m.Provider, ProviderAnthropic)
+		}
+	}
+}
+
 func TestEffortConfigPerProvider(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/aichat/models_test.go
+++ b/aichat/models_test.go
@@ -29,8 +29,8 @@ func TestEffortConfigPerProvider(t *testing.T) {
 		{"openai-high", Model{Provider: ProviderOpenAI, Reasoning: true}, EffortHigh, "reasoning_effort", false},
 		{"gemini-medium", Model{Provider: ProviderGoogle, Reasoning: true}, EffortMedium, "thinkingConfig", false},
 		{"anthropic-low", Model{Provider: ProviderAnthropic, Reasoning: true}, EffortLow, "thinking", false},
+		{"anthropic-no-effort-still-sets-max-tokens", Model{Provider: ProviderAnthropic, Reasoning: true}, EffortNone, "max_tokens", false},
 		{"non-reasoning", Model{Provider: ProviderOpenAI, Reasoning: false}, EffortHigh, "", true},
-		{"no-effort", Model{Provider: ProviderAnthropic, Reasoning: true}, EffortNone, "", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -45,6 +45,13 @@ func TestEffortConfigPerProvider(t *testing.T) {
 				t.Errorf("cfg %v missing key %q", cfg, c.wantKey)
 			}
 		})
+	}
+}
+
+func TestAnthropicEffortConfigSetsMaxTokens(t *testing.T) {
+	cfg := effortConfig(Model{Provider: ProviderAnthropic, Reasoning: true}, EffortHigh)
+	if got := cfg["max_tokens"]; got != anthropicThinkingBudget(EffortHigh)+defaultMaxOutputTokens {
+		t.Errorf("max_tokens = %v, want thinking budget plus visible output budget", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- set Anthropic max_tokens for aichat requests
- add Claude Haiku 4.5, Sonnet 4.6, and Opus 4.8 to the aichat model catalog

## Tests
- cd aichat && go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new Anthropic Claude models to the available provider lineup: Sonnet 4.6, Opus 4.8, and Haiku 4.5. Each model includes 200,000 token context windows and integrated reasoning capabilities.

* **Improvements**
  * Enhanced token limit configuration and management for the Anthropic provider to ensure optimal resource allocation and consistent behavior across all processing levels and reasoning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->