### PR TITLE
fix: handle map[string]any input in ToPrettyData

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,67 @@
+package clicky
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatMap pins down the public Format() entry point's behavior for
+// map[string]any input across the three formats that already work.
+//
+// Format() routes through FormatWithOptions, which tries
+// ToPrettyDataWithOptions (which handles maps) before falling back to
+// the broken ToPrettyData path. This test guards against a future
+// refactor that breaks that working path.
+func TestFormatMap(t *testing.T) {
+	data := map[string]any{
+		"name":  "clicky",
+		"count": 42,
+		"nested": map[string]any{
+			"key": "value",
+		},
+	}
+
+	cases := []struct {
+		name      string
+		format    string
+		contains  []string
+	}{
+		{
+			name:     "markdown",
+			format:   "markdown",
+			contains: []string{"name", "count", "nested", "key", "value", "clicky"},
+		},
+		{
+			name:     "json",
+			format:   "json",
+			contains: []string{`"name"`, `"clicky"`},
+		},
+		{
+			name:     "yaml",
+			format:   "yaml",
+			contains: []string{"name:", "clicky"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := Format(data, FormatOptions{Format: c.format})
+			if err != nil {
+				t.Fatalf("Format returned error: %v", err)
+			}
+			if out == "" {
+				t.Fatalf("Format returned empty string for map[%s]any; want non-empty %s", "string", c.name)
+			}
+			// Markdown prettifies keys ("name" -> "Name:") so we
+			// compare case-insensitively. JSON/YAML pin their casing
+			// and pass through unchanged, but lower-casing them too
+			// doesn't hurt and keeps the test simple.
+			haystack := strings.ToLower(out)
+			for _, want := range c.contains {
+				if !strings.Contains(haystack, strings.ToLower(want)) {
+					t.Errorf("%s output missing %q\nfull output: %q", c.name, want, out)
+				}
+			}
+		})
+	}
+}

--- a/formatters/map_input_test.go
+++ b/formatters/map_input_test.go
@@ -1,0 +1,114 @@
+package formatters
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMapStringAnyToMarkdown asserts that a top-level
+// map[string]any (or any non-struct map kind) can flow through the
+// MarkdownFormatter path that uses the ToPrettyData conversion.
+//
+// The map-handling logic was added to ToPrettyDataWithOptions but never
+// mirrored into ToPrettyData, so any formatter that calls the older
+// ToPrettyData returns an empty string and an "expected struct, got map"
+// error for map input. This test exercises each of those entry points.
+func TestMapStringAnyToMarkdown(t *testing.T) {
+	data := map[string]any{
+		"name":  "clicky",
+		"count": 42,
+		"nested": map[string]any{
+			"key": "value",
+		},
+	}
+
+	// We only need to see the keys/values make it through. Using
+	// lower-case contains so we don't pin prettified casing.
+	expected := []string{"name", "count", "nested", "key", "value", "clicky", "42"}
+
+	formatters := []struct {
+		name string
+		run  func(t *testing.T) string
+	}{
+		{
+			name: "MarkdownFormatter.Format",
+			run: func(t *testing.T) string {
+				out, err := NewMarkdownFormatter().Format(data)
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+				return out
+			},
+		},
+		{
+			name: "FormatManager.Markdown",
+			run: func(t *testing.T) string {
+				out, err := NewFormatManager().Markdown(data)
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+				return out
+			},
+		},
+		{
+			name: "ToPrettyData",
+			run: func(t *testing.T) string {
+				pd, err := ToPrettyData(data)
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+				if pd == nil {
+					t.Fatalf("returned nil PrettyData")
+				}
+				// Render the PrettyData as markdown so we can assert
+				// on the same output shape as the other subtests.
+				out, err := NewMarkdownFormatter().FormatPrettyData(pd, FormatOptions{})
+				if err != nil {
+					t.Fatalf("FormatPrettyData returned error: %v", err)
+				}
+				return out
+			},
+		},
+	}
+
+	for _, f := range formatters {
+		t.Run(f.name, func(t *testing.T) {
+			out := f.run(t)
+			if out == "" {
+				t.Fatalf("got empty string, want non-empty output containing %v", expected)
+			}
+			lower := strings.ToLower(out)
+			for _, want := range expected {
+				if !strings.Contains(lower, want) {
+					t.Errorf("output missing %q\nfull output: %q", want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestMapStringAnyWithNestedTable guards the richer case of a top-level
+// map whose value is a slice of maps. The map-handling code in
+// ToPrettyDataWithOptions already nests the slice as a sub-table, so a
+// proper fix to ToPrettyData should produce the same nested output.
+func TestMapStringAnyWithNestedTable(t *testing.T) {
+	data := map[string]any{
+		"label": "servers",
+		"servers": []any{
+			map[string]any{"name": "web-01", "status": "up"},
+			map[string]any{"name": "db-01", "status": "up"},
+		},
+	}
+
+	out, err := NewMarkdownFormatter().Format(data)
+	if err != nil {
+		t.Fatalf("MarkdownFormatter.Format returned error: %v", err)
+	}
+
+	lower := strings.ToLower(out)
+	for _, want := range []string{"label", "servers", "web-01", "db-01"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("output missing %q\nfull output: %q", want, out)
+		}
+	}
+}

--- a/formatters/parser.go
+++ b/formatters/parser.go
@@ -629,6 +629,14 @@ func ToPrettyData(data interface{}, opts ...TypeOptions) (*api.PrettyData, error
 		return nil, fmt.Errorf("cannot format slice input when both SkipTable and SkipTree are set")
 	}
 
+	// For maps, delegate to the shared parser path which has explicit
+	// map handling (it builds a schema from map keys, infers field
+	// types, and recurses for nested map/struct/table fields). The
+	// remaining code below assumes struct input.
+	if val.Kind() == reflect.Map {
+		return parseStructDataWithOptions(val, FormatOptions{})
+	}
+
 	// Create the schema from struct tags
 	schema, err := ParseStructSchema(val)
 	if err != nil {


### PR DESCRIPTION
\`MarkdownFormatter.Format(map[string]any{...})\` (and any formatter that routes through \`ToPrettyData\`) returned an empty string and the error \`failed to parse struct schema: expected struct, got map\`.

Root cause: \`ToPrettyData\` in \`formatters/parser.go\` called \`ParseStructSchema\` unconditionally, which rejects any non-struct reflect kind. The sibling \`ToPrettyDataWithOptions\` already had explicit map handling, but it was never mirrored back into the older \`ToPrettyData\`. The public \`Format(data, FormatOptions{Format: \"markdown\"})\` entry happened to work because \`formatWithOptions\` tries \`ToPrettyDataWithOptions\` first and only falls back to the broken path on error; the bug only surfaced for callers that go through the manager/formatter methods directly.

Delegate to the shared parser path for map input so both functions agree. The struct code path is untouched.

Fixes #38.