### PR TITLE
fix(batch): detect item timeout by elapsed time, not context state

### DIFF
--- a/task/batch.go
+++ b/task/batch.go
@@ -267,9 +267,19 @@ func (b *Batch[T]) Run() chan BatchResult[T] {
 				value, err := item(t)
 				duration := time.Since(start)
 
-				// Check if item timed out during execution
-				if b.ItemTimeout > 0 && itemCtx.Err() == context.DeadlineExceeded {
-					t.Warnf("Item %d in batch '%s' exceeded timeout of %v", itemNum, b.Name, b.ItemTimeout)
+				// Check if item timed out during execution. We base the verdict on
+				// elapsed wall-clock time rather than itemCtx.Err(), because the
+				// item callable does not receive the context and therefore cannot
+				// be interrupted. When the parent batch context is cancelled by the
+				// batch timeout, itemCtx.Err() becomes context.Canceled instead of
+				// context.DeadlineExceeded, which previously caused overrun items
+				// to be reported as successful (a racy outcome that depended on
+				// which timer fired first). Comparing duration against ItemTimeout
+				// is deterministic and only flags items that exceeded their own
+				// per-item budget, leaving batch-level cancellation to the
+				// monitoring goroutine.
+				if b.ItemTimeout > 0 && duration > b.ItemTimeout {
+					t.Warnf("Item %d in batch '%s' exceeded timeout of %v (took %v)", itemNum, b.Name, b.ItemTimeout, duration)
 					results <- BatchResult[T]{
 						Error:    fmt.Errorf("%w: item %d exceeded timeout of %v", ErrItemTimeout, itemNum, b.ItemTimeout),
 						Duration: duration,

--- a/task/batch_test.go
+++ b/task/batch_test.go
@@ -373,69 +373,70 @@ func TestBatch_ZeroTimeoutBackwardCompatibility(t *testing.T) {
 	}
 }
 
-// func TestBatch_ErrorIdentification(t *testing.T) {
-// 	// Test that errors can be identified with errors.Is()
-// 	t.Run("BatchTimeout", func(t *testing.T) {
-// 		batch := &Batch[int]{
-// 			Name:       "test-error-id-batch",
-// 			Timeout:    100 * time.Millisecond,
-// 			MaxWorkers: 1,
-// 		}
+func TestBatch_ErrorIdentification(t *testing.T) {
+	withTestGlobal(t)
+	// Test that errors can be identified with errors.Is()
+	t.Run("BatchTimeout", func(t *testing.T) {
+		batch := &Batch[int]{
+			Name:       "test-error-id-batch",
+			Timeout:    100 * time.Millisecond,
+			MaxWorkers: 1,
+		}
 
-// 		// Add items that take longer than timeout
-// 		for i := 0; i < 10; i++ {
-// 			i := i
-// 			batch.Items = append(batch.Items, func(log logger.Logger) (int, error) {
-// 				time.Sleep(200 * time.Millisecond)
-// 				return i, nil
-// 			})
-// 		}
+		// Add items that take longer than timeout
+		for i := 0; i < 10; i++ {
+			i := i
+			batch.Items = append(batch.Items, func(log logger.Logger) (int, error) {
+				time.Sleep(200 * time.Millisecond)
+				return i, nil
+			})
+		}
 
-// 		var foundErr error
-// 		for result := range batch.Run() {
-// 			if result.Error != nil {
-// 				foundErr = result.Error
-// 				break
-// 			}
-// 		}
+		var foundErr error
+		for result := range batch.Run() {
+			if result.Error != nil {
+				foundErr = result.Error
+				break
+			}
+		}
 
-// 		if foundErr == nil {
-// 			t.Fatal("Expected to find an error")
-// 		}
+		if foundErr == nil {
+			t.Fatal("Expected to find an error")
+		}
 
-// 		if !errors.Is(foundErr, ErrBatchTimeout) {
-// 			t.Errorf("Expected ErrBatchTimeout, got: %v", foundErr)
-// 		}
-// 	})
+		if !errors.Is(foundErr, ErrBatchTimeout) {
+			t.Errorf("Expected ErrBatchTimeout, got: %v", foundErr)
+		}
+	})
 
-// 	t.Run("ItemTimeout", func(t *testing.T) {
-// 		batch := &Batch[int]{
-// 			Name:        "test-error-id-item",
-// 			ItemTimeout: 50 * time.Millisecond,
-// 			MaxWorkers:  1,
-// 		}
+	t.Run("ItemTimeout", func(t *testing.T) {
+		batch := &Batch[int]{
+			Name:        "test-error-id-item",
+			ItemTimeout: 50 * time.Millisecond,
+			MaxWorkers:  1,
+		}
 
-// 		batch.Items = append(batch.Items, func(log logger.Logger) (int, error) {
-// 			time.Sleep(100 * time.Millisecond)
-// 			return 42, nil
-// 		})
+		batch.Items = append(batch.Items, func(log logger.Logger) (int, error) {
+			time.Sleep(100 * time.Millisecond)
+			return 42, nil
+		})
 
-// 		var foundErr error
-// 		for result := range batch.Run() {
-// 			if result.Error != nil {
-// 				foundErr = result.Error
-// 			}
-// 		}
+		var foundErr error
+		for result := range batch.Run() {
+			if result.Error != nil {
+				foundErr = result.Error
+			}
+		}
 
-// 		if foundErr == nil {
-// 			t.Fatal("Expected to find an error")
-// 		}
+		if foundErr == nil {
+			t.Fatal("Expected to find an error")
+		}
 
-// 		if !errors.Is(foundErr, ErrItemTimeout) {
-// 			t.Errorf("Expected ErrItemTimeout, got: %v", foundErr)
-// 		}
-// 	})
-// }
+		if !errors.Is(foundErr, ErrItemTimeout) {
+			t.Errorf("Expected ErrItemTimeout, got: %v", foundErr)
+		}
+	})
+}
 
 func TestBatch_MethodChaining(t *testing.T) {
 	withTestGlobal(t)


### PR DESCRIPTION
Closes #61.

The post-execution item-timeout verdict in `Batch.Run` checked `itemCtx.Err() == context.DeadlineExceeded`. Because item callables do not receive the context, an over-budget item always runs to completion and the timeout was only inferred afterwards from context state. When the parent `batchCtx` was cancelled by the batch timeout before the item's own deadline expired, `itemCtx.Err()` returned `context.Canceled` instead of `context.DeadlineExceeded`, so an overrun item was wrongly reported as a successful result.

With `Timeout` left at zero, `Run` defaults it to `len(items)*ItemTimeout`, which for a single 50ms item equals the item timeout — so two 50ms timers raced and the outcome flipped per run.

Base the verdict on deterministic wall-clock time: `duration > ItemTimeout`. This only flags items that exceeded their own per-item budget regardless of which timer fired, and leaves batch-level cancellation to the monitoring goroutine.

Split into two commits: the first re-enables `TestBatch_ErrorIdentification` (was commented out), the second applies the production fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-item timeout detection reliability by using measured elapsed time instead of context error status, ensuring more consistent timeout handling.

* **Tests**
  * Added error identification tests to verify correct handling of batch and item timeout errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->