### PR TITLE
feat(formatters): add Objects/ExecutionRoots payload fields to ClickyNode

### DIFF
--- a/formatters/html_react_formatter.go
+++ b/formatters/html_react_formatter.go
@@ -140,6 +140,11 @@ type ClickyNode struct {
 	BadgeText  string `json:"badgeText,omitempty"`
 	BadgeShape string `json:"badgeShape,omitempty"`
 	BadgeIcon  string `json:"badgeIcon,omitempty"`
+	// Object/execution tree payloads — set for Kind "object-graph" / "execution-tree".
+	// Passed through verbatim to clicky-ui's <ObjectGraph>/<ExecutionTree> roots,
+	// so producers can supply their own node shape without mirroring it here.
+	Objects        any `json:"objects,omitempty"`
+	ExecutionRoots any `json:"executionRoots,omitempty"`
 }
 
 func (f *HTMLReactFormatter) Format(data any, opts FormatOptions) (string, error) {


### PR DESCRIPTION
## What

Adds two purely-additive pass-through `any` fields to `ClickyNode`:

- `Objects` (`json:"objects"`) — set for `Kind: "object-graph"`
- `ExecutionRoots` (`json:"executionRoots"`) — set for `Kind: "execution-tree"`

Both are forwarded verbatim to clicky-ui's `<ObjectGraph>` / `<ExecutionTree>` roots, so producers can supply their own node shape without mirroring it in clicky.

## Why

`oipa-cli`'s arthas trace feature (`cmd/arthas_parse.go` `ClickyDocument()`) needs these fields to render captured watch/trace records as object-graphs / execution-trees on the web. They currently exist only as uncommitted local edits; the published `v1.21.25` lacks them, which breaks oipa-cli's Docker build (`go build`) in CI.

## Impact

Purely additive (+5 lines, two `any` fields). No existing fields changed or removed; builds clean with `GOWORK=off`. Merging triggers `release.yml` to publish `v1.21.26`, after which oipa-cli bumps `go.mod` to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom node payloads in object graph and execution tree visualizations through optional configuration fields, enabling more flexible data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->