### PR TITLE
feat(aichat): add runtime model registry

### DIFF
--- a/aichat/models.go
+++ b/aichat/models.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // Provider is a Genkit provider name (the prefix of a "provider/model" id).
@@ -53,9 +54,9 @@ type ModelInfo struct {
 // (Anthropic claude-sonnet-4 is captain's NewAnthropic default).
 const DefaultModelID = "anthropic/claude-sonnet-4-5"
 
-// catalog is the v1 model menu. Mirrors captain pkg/ai provider defaults so the
-// chat agrees with the rest of the stack.
-var catalog = []Model{
+// defaultCatalog is the v1 model menu. Mirrors captain pkg/ai provider defaults
+// so the chat agrees with the rest of the stack.
+var defaultCatalog = []Model{
 	{ID: "anthropic/claude-sonnet-4-6", Provider: ProviderAnthropic, Label: "Claude Sonnet 4.6", Reasoning: true, ContextWindow: 200000},
 	{ID: "anthropic/claude-opus-4-8", Provider: ProviderAnthropic, Label: "Claude Opus 4.8", Reasoning: true, ContextWindow: 200000},
 	{ID: "anthropic/claude-haiku-4-5", Provider: ProviderAnthropic, Label: "Claude Haiku 4.5", Reasoning: true, ContextWindow: 200000},
@@ -69,19 +70,118 @@ var catalog = []Model{
 	{ID: "googleai/gemini-2.5-flash", Provider: ProviderGoogle, Label: "Gemini 2.5 Flash", Reasoning: true, ContextWindow: 1048576},
 }
 
-// Catalog returns the configured model menu.
+var (
+	modelRegistryMu sync.RWMutex
+	catalog         = append([]Model(nil), defaultCatalog...)
+)
+
+// Catalog returns the registered model menu.
 func Catalog() []Model {
+	modelRegistryMu.RLock()
+	defer modelRegistryMu.RUnlock()
+
 	out := make([]Model, len(catalog))
 	copy(out, catalog)
 	return out
+}
+
+// RegisterModel adds a model to the global chat model registry, or replaces the
+// existing entry with the same ID while preserving its position in the menu.
+func RegisterModel(model Model) error {
+	return RegisterModels(model)
+}
+
+// RegisterModels adds models to the global chat model registry. Existing IDs
+// are updated in place; new IDs are appended to the menu.
+func RegisterModels(models ...Model) error {
+	normalized, err := normalizeModels(models, false)
+	if err != nil {
+		return err
+	}
+
+	modelRegistryMu.Lock()
+	defer modelRegistryMu.Unlock()
+
+	for _, model := range normalized {
+		updated := false
+		for i := range catalog {
+			if catalog[i].ID == model.ID {
+				catalog[i] = model
+				updated = true
+				break
+			}
+		}
+		if !updated {
+			catalog = append(catalog, model)
+		}
+	}
+	return nil
+}
+
+// SetModelCatalog replaces the global chat model registry. Use RegisterModel or
+// RegisterModels when you only need to extend the built-in catalog.
+func SetModelCatalog(models []Model) error {
+	normalized, err := normalizeModels(models, true)
+	if err != nil {
+		return err
+	}
+
+	modelRegistryMu.Lock()
+	defer modelRegistryMu.Unlock()
+	catalog = append([]Model(nil), normalized...)
+	return nil
+}
+
+// ResetModelCatalog restores the built-in model registry. It is primarily useful
+// for tests that temporarily install custom models.
+func ResetModelCatalog() {
+	modelRegistryMu.Lock()
+	defer modelRegistryMu.Unlock()
+	catalog = append([]Model(nil), defaultCatalog...)
+}
+
+func normalizeModels(models []Model, rejectDuplicateIDs bool) ([]Model, error) {
+	out := make([]Model, 0, len(models))
+	seen := make(map[string]bool, len(models))
+	for _, model := range models {
+		normalized, err := normalizeModel(model)
+		if err != nil {
+			return nil, err
+		}
+		if rejectDuplicateIDs && seen[normalized.ID] {
+			return nil, fmt.Errorf("duplicate model ID %q", normalized.ID)
+		}
+		seen[normalized.ID] = true
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func normalizeModel(model Model) (Model, error) {
+	model.ID = strings.TrimSpace(model.ID)
+	model.Label = strings.TrimSpace(model.Label)
+	if model.ID == "" {
+		return Model{}, fmt.Errorf("model ID is required")
+	}
+	if model.Provider == "" {
+		model.Provider = ProviderOf(model.ID)
+	}
+	if model.Provider == "" {
+		return Model{}, fmt.Errorf("model %q must include a provider, e.g. openai/%s", model.ID, model.ID)
+	}
+	if model.Label == "" {
+		model.Label = model.ID
+	}
+	return model, nil
 }
 
 // CatalogInfo returns the model menu annotated with whether each model's
 // provider is among the registered providers (i.e. selectable). The order
 // mirrors the catalog so the client can render a stable, grouped menu.
 func CatalogInfo(registered []Provider) []ModelInfo {
-	out := make([]ModelInfo, len(catalog))
-	for i, m := range catalog {
+	models := Catalog()
+	out := make([]ModelInfo, len(models))
+	for i, m := range models {
 		out[i] = ModelInfo{
 			ID:            m.ID,
 			Provider:      string(m.Provider),
@@ -100,12 +200,13 @@ func LookupModel(id string) (Model, error) {
 	if id == "" {
 		id = DefaultModelID
 	}
-	for _, m := range catalog {
+	models := Catalog()
+	for _, m := range models {
 		if m.ID == id {
 			return m, nil
 		}
 	}
-	return Model{}, fmt.Errorf("unknown model %q; available: %s", id, strings.Join(modelIDs(), ", "))
+	return Model{}, fmt.Errorf("unknown model %q; available: %s", id, strings.Join(modelIDsFrom(models), ", "))
 }
 
 // defaultModel picks the model used when a request omits one: the catalog
@@ -113,10 +214,13 @@ func LookupModel(id string) (Model, error) {
 // whose provider is configured. Returns false when no configured provider has a
 // catalog model (caller fails loud).
 func defaultModel(registered []Provider) (Model, bool) {
-	if def, err := LookupModel(DefaultModelID); err == nil && providerRegistered(registered, def.Provider) {
-		return def, true
+	models := Catalog()
+	for _, m := range models {
+		if m.ID == DefaultModelID && providerRegistered(registered, m.Provider) {
+			return m, true
+		}
 	}
-	for _, m := range catalog {
+	for _, m := range models {
 		if providerRegistered(registered, m.Provider) {
 			return m, true
 		}
@@ -144,8 +248,12 @@ func ProviderOf(id string) Provider {
 }
 
 func modelIDs() []string {
-	ids := make([]string, len(catalog))
-	for i, m := range catalog {
+	return modelIDsFrom(Catalog())
+}
+
+func modelIDsFrom(models []Model) []string {
+	ids := make([]string, len(models))
+	for i, m := range models {
 		ids[i] = m.ID
 	}
 	sort.Strings(ids)

--- a/aichat/models_test.go
+++ b/aichat/models_test.go
@@ -18,6 +18,69 @@ func TestLookupModelUnknownFailsLoud(t *testing.T) {
 	}
 }
 
+func TestRegisterModelAddsAndUpdatesCatalog(t *testing.T) {
+	t.Cleanup(ResetModelCatalog)
+
+	id := "openai/test-custom-model"
+	if err := RegisterModel(Model{ID: id, Label: "Custom", Reasoning: true, ContextWindow: 123}); err != nil {
+		t.Fatalf("RegisterModel: %v", err)
+	}
+
+	m, err := LookupModel(id)
+	if err != nil {
+		t.Fatalf("LookupModel(%q): %v", id, err)
+	}
+	if m.Provider != ProviderOpenAI {
+		t.Errorf("Provider = %q, want %q", m.Provider, ProviderOpenAI)
+	}
+	if m.Label != "Custom" || !m.Reasoning || m.ContextWindow != 123 {
+		t.Errorf("model = %+v, want registered values", m)
+	}
+
+	if err := RegisterModel(Model{ID: id, Provider: ProviderOpenAI, Label: "Updated", ContextWindow: 456}); err != nil {
+		t.Fatalf("RegisterModel update: %v", err)
+	}
+	m, err = LookupModel(id)
+	if err != nil {
+		t.Fatalf("LookupModel(%q) after update: %v", id, err)
+	}
+	if m.Label != "Updated" || m.ContextWindow != 456 || m.Reasoning {
+		t.Errorf("updated model = %+v", m)
+	}
+}
+
+func TestSetModelCatalogAndReset(t *testing.T) {
+	t.Cleanup(ResetModelCatalog)
+
+	if err := SetModelCatalog([]Model{{ID: "openai/only-model", Label: "Only"}}); err != nil {
+		t.Fatalf("SetModelCatalog: %v", err)
+	}
+	if _, err := LookupModel("openai/gpt-4o"); err == nil {
+		t.Error("expected built-in model to be absent after SetModelCatalog")
+	}
+	m, err := LookupModel("openai/only-model")
+	if err != nil {
+		t.Fatalf("LookupModel custom catalog: %v", err)
+	}
+	if m.Provider != ProviderOpenAI || m.Label != "Only" {
+		t.Errorf("model = %+v", m)
+	}
+
+	ResetModelCatalog()
+	if _, err := LookupModel("openai/gpt-4o"); err != nil {
+		t.Fatalf("built-in model should be restored: %v", err)
+	}
+}
+
+func TestRegisterModelValidation(t *testing.T) {
+	if err := RegisterModel(Model{}); err == nil {
+		t.Error("expected missing ID to fail")
+	}
+	if err := SetModelCatalog([]Model{{ID: "openai/dup"}, {ID: "openai/dup"}}); err == nil {
+		t.Error("expected duplicate IDs to fail in SetModelCatalog")
+	}
+}
+
 func TestAnthropicCatalogIncludesRequestedModels(t *testing.T) {
 	for _, id := range []string{
 		"anthropic/claude-haiku-4-5",


### PR DESCRIPTION
## What

Makes the chat model catalog mutable so callers can extend or replace the built-in model menu at runtime.

- The package-level `catalog` is now guarded by a `sync.RWMutex` and seeded from a new immutable `defaultCatalog`.
- New API:
  - `RegisterModel` / `RegisterModels` — append new model IDs or update existing entries in place (preserving menu position).
  - `SetModelCatalog` — replace the catalog wholesale (rejects duplicate IDs).
  - `ResetModelCatalog` — restore the built-in catalog (primarily for tests).
- Registered models are normalized and validated via `normalizeModel`: ID/label are trimmed, the provider is inferred from the `provider/model` ID prefix when omitted, the label defaults to the ID, and an empty ID or unresolvable provider is rejected.
- Catalog readers (`Catalog`, `CatalogInfo`, `LookupModel`, `defaultModel`, `modelIDs`) now snapshot the registry under the lock instead of reading the package var directly.

## Why

The built-in catalog mirrored captain's provider defaults but was a fixed slice. Consumers embedding the chat backend need to register their own models without forking the catalog.

## Tests

`go test ./...` in the `aichat` module passes. Added coverage for register/update, set+reset, and validation (missing ID, duplicate IDs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime APIs to register new AI models or update existing ones
  * Support for registering single or multiple models simultaneously
  * Ability to replace the entire model catalog or reset to built-in defaults
  * Improved thread-safety for concurrent model catalog access

* **Tests**
  * Expanded test coverage for model registration, validation, and catalog reset functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->