### PR TITLE
fix(aichat): preserve dynamic tool names across chat turns

### DIFF
--- a/aichat/messages.go
+++ b/aichat/messages.go
@@ -68,8 +68,8 @@ func (p UIPart) toolName() string {
 	if p.ToolName != "" {
 		return p.ToolName
 	}
-	if strings.HasPrefix(p.Type, "tool-") {
-		return strings.TrimPrefix(p.Type, "tool-")
+	if after, ok := strings.CutPrefix(p.Type, "tool-"); ok {
+		return after
 	}
 	return ""
 }
@@ -238,11 +238,11 @@ func addResumeDirective(p UIPart, dirs *resumeDirectives) {
 }
 
 func textOf(m UIMessage) string {
-	var s string
+	var s strings.Builder
 	for _, p := range m.Parts {
 		if p.Type == "text" {
-			s += p.Text
+			s.WriteString(p.Text)
 		}
 	}
-	return s
+	return s.String()
 }

--- a/aichat/messages.go
+++ b/aichat/messages.go
@@ -68,7 +68,10 @@ func (p UIPart) toolName() string {
 	if p.ToolName != "" {
 		return p.ToolName
 	}
-	return strings.TrimPrefix(p.Type, "tool-")
+	if strings.HasPrefix(p.Type, "tool-") {
+		return strings.TrimPrefix(p.Type, "tool-")
+	}
+	return ""
 }
 
 // pendingApproval reports whether this tool part carries a user approval
@@ -186,13 +189,21 @@ func assistantParts(m UIMessage, resuming bool, dirs *resumeDirectives) (model, 
 		case p.Type == "text" && p.Text != "":
 			model = append(model, ai.NewTextPart(p.Text))
 		case p.isTool():
-			req := &ai.ToolRequest{Name: p.toolName(), Ref: p.ToolCallID, Input: decodeJSON(p.Input)}
+			name := p.toolName()
+			if name == "" || p.ToolCallID == "" {
+				// Older/partial UI message streams can contain malformed tool parts
+				// (for example a `tool-` part without a name). Provider APIs reject
+				// empty tool names, so drop the bad part rather than poisoning the next
+				// chat turn.
+				continue
+			}
+			req := &ai.ToolRequest{Name: name, Ref: p.ToolCallID, Input: decodeJSON(p.Input)}
 			model = append(model, ai.NewToolRequestPart(req))
 			if resuming {
 				addResumeDirective(p, dirs)
 			} else if p.State == "output-available" && len(p.Output) > 0 {
 				toolResp = append(toolResp, ai.NewToolResponsePart(&ai.ToolResponse{
-					Name: p.toolName(), Ref: p.ToolCallID, Output: decodeJSON(p.Output),
+					Name: name, Ref: p.ToolCallID, Output: decodeJSON(p.Output),
 				}))
 			}
 		}

--- a/aichat/messages_test.go
+++ b/aichat/messages_test.go
@@ -152,3 +152,34 @@ func TestTypedToolPartNameFallsBackToTypeSuffix(t *testing.T) {
 		t.Error("isTool = false for tool- prefixed part")
 	}
 }
+
+func TestDynamicToolWithoutNameHasNoFallbackName(t *testing.T) {
+	p := UIPart{Type: "dynamic-tool", ToolCallID: "c1"}
+	if p.toolName() != "" {
+		t.Errorf("toolName = %q, want empty", p.toolName())
+	}
+}
+
+func TestToGenkitMessagesSkipsMalformedToolPart(t *testing.T) {
+	msgs := []UIMessage{
+		{Role: "user", Parts: []UIPart{{Type: "text", Text: "next"}}},
+		{Role: "assistant", Parts: []UIPart{
+			{Type: "tool-", ToolCallID: "bad", State: "output-available", Output: raw(map[string]any{"ok": true})},
+			{Type: "tool-feed_refresh", ToolCallID: "good", State: "output-available", Output: raw(map[string]any{"ok": true})},
+		}},
+	}
+	out, _, err := toGenkitMessages(msgs)
+	if err != nil {
+		t.Fatalf("toGenkitMessages: %v", err)
+	}
+	for _, msg := range out {
+		for _, part := range msg.Content {
+			if part.IsToolRequest() && part.ToolRequest.Name == "" {
+				t.Fatalf("empty tool request emitted: %+v", part.ToolRequest)
+			}
+			if part.IsToolResponse() && part.ToolResponse.Name == "" {
+				t.Fatalf("empty tool response emitted: %+v", part.ToolResponse)
+			}
+		}
+	}
+}

--- a/aichat/messages_test.go
+++ b/aichat/messages_test.go
@@ -13,8 +13,6 @@ func raw(v any) json.RawMessage {
 	return b
 }
 
-func boolp(b bool) *bool { return &b }
-
 func TestToGenkitMessagesTextOnly(t *testing.T) {
 	msgs := []UIMessage{
 		{Role: "user", Parts: []UIPart{{Type: "text", Text: "hello"}}},
@@ -96,7 +94,7 @@ func TestToGenkitMessagesApprovalResumeApprovedRestarts(t *testing.T) {
 		{Role: "assistant", Parts: []UIPart{{
 			Type: "dynamic-tool", ToolName: "stack_restart", ToolCallID: "call-9",
 			State: "approval-responded", Input: raw(map[string]any{"id": "x"}),
-			Approval: &Approval{ID: "call-9", Approved: boolp(true)},
+			Approval: &Approval{ID: "call-9", Approved: new(true)},
 		}}},
 	}
 	if !isApprovalResume(msgs) {
@@ -128,7 +126,7 @@ func TestToGenkitMessagesApprovalResumeDeniedResponds(t *testing.T) {
 		{Role: "assistant", Parts: []UIPart{{
 			Type: "dynamic-tool", ToolName: "stack_delete", ToolCallID: "call-7",
 			State: "approval-responded", Input: raw(map[string]any{"id": "x"}),
-			Approval: &Approval{ID: "call-7", Approved: boolp(false), Reason: "too risky"},
+			Approval: &Approval{ID: "call-7", Approved: new(false), Reason: "too risky"},
 		}}},
 	}
 	_, resume, err := toGenkitMessages(msgs)

--- a/aichat/models.go
+++ b/aichat/models.go
@@ -2,6 +2,7 @@ package aichat
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -230,12 +231,7 @@ func defaultModel(registered []Provider) (Model, bool) {
 
 // providerRegistered reports whether p is among the configured providers.
 func providerRegistered(registered []Provider, p Provider) bool {
-	for _, r := range registered {
-		if r == p {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(registered, p)
 }
 
 // ProviderOf extracts the provider from a "provider/model" id without requiring

--- a/aichat/sse.go
+++ b/aichat/sse.go
@@ -93,6 +93,10 @@ func (s *sseWriter) toolInputAvailable(callID, name string, input any) error {
 		"toolCallId": callID,
 		"toolName":   name,
 		"input":      input,
+		// clicky tools are discovered dynamically from the Cobra/OpenAPI surface.
+		// Mark them dynamic so the AI SDK stores the toolName explicitly on the
+		// UIMessage part instead of encoding it only in a static `tool-<name>` type.
+		"dynamic": true,
 	})
 }
 

--- a/aichat/sse_test.go
+++ b/aichat/sse_test.go
@@ -97,6 +97,7 @@ func TestSSEToolRoundTrip(t *testing.T) {
 		`"type":"tool-input-available"`,
 		`"toolCallId":"call_1"`,
 		`"toolName":"listThings"`,
+		`"dynamic":true`,
 		`"type":"tool-output-available"`,
 		`"type":"text-delta"`,
 		`"delta":"Found 2"`,

--- a/aichat/sse_test.go
+++ b/aichat/sse_test.go
@@ -131,7 +131,7 @@ func assertDataLines(t *testing.T, got, want string) {
 
 func dataLines(s string) []string {
 	var out []string
-	for _, line := range strings.Split(s, "\n") {
+	for line := range strings.SplitSeq(s, "\n") {
 		if strings.HasPrefix(line, "data: ") {
 			out = append(out, line)
 		}


### PR DESCRIPTION
## What

Fixes tool-name loss when UI message history is converted back into Genkit messages for the next chat turn.

- `sse.go`: `tool-input-available` events are now emitted with `"dynamic": true`. Because clicky tools are discovered dynamically from the Cobra/OpenAPI surface, this tells the AI SDK to store the `toolName` explicitly on the `UIMessage` part instead of encoding it only in a static `tool-<name>` type.
- `messages.go`:
  - `toolName()` no longer fabricates a name by trimming a `tool-` prefix that isn't there (e.g. a `dynamic-tool` part) — it returns empty in that case.
  - `assistantParts` drops tool parts that have an empty name or empty call ID rather than emitting tool requests/responses with a blank name, which provider APIs reject and which would poison the next turn.

## Why

Older/partial UI message streams could carry malformed tool parts (e.g. a bare `tool-` type with no name). Marking tools dynamic keeps the tool name intact across round-trips, and the defensive drop prevents a single bad part from failing the whole conversation.

## Tests

`go test ./...` in the `aichat` module passes. Added:
- `TestDynamicToolWithoutNameHasNoFallbackName`
- `TestToGenkitMessagesSkipsMalformedToolPart`
- updated SSE round-trip assertion for `"dynamic":true`.