### PR TITLE
fix(aichat): pin clicky require to v1.21.29 so go get works

### DIFF
--- a/aichat/go.mod
+++ b/aichat/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/firebase/genkit/go v1.8.0
 	github.com/flanksource/captain v0.0.7
-	github.com/flanksource/clicky v1.21.8
+	github.com/flanksource/clicky v1.21.29
 	github.com/spf13/cobra v1.10.2
 )
 


### PR DESCRIPTION
## Problem

`go get github.com/flanksource/clicky/aichat` fails to compile for external consumers:

```
approval.go:64: op.Group undefined (type *rpc.RPCOperation has no field or method Group)
tools_clicky.go:79: cannot call cmd.Hidden (variable of type bool): bool is not a function
```

The `aichat` submodule's `go.mod` requires `github.com/flanksource/clicky v1.21.8`, but its code uses API only present in clicky **>= v1.21.29** (`rpc.RPCOperation.Group`, `entity.ExecutableCommand.Hidden()`/`Runnable()`). The `replace => ../` directive masks this during local dev but is **ignored by downstream consumers**, so `go get` resolves the stale `v1.21.8` pin and the build breaks.

## Fix

Bump the pin to `v1.21.29`, which contains all required API.

## Verification

- Current `aichat` source builds against released `clicky v1.21.29` (replace dropped) → exit 0.
- Simulated consumer importing `aichat` pulls `clicky v1.21.29` via the pin and builds → exit 0.

## Release note

On merge, the `release-submodules` job re-pins `aichat` to the new release version and pushes an `aichat/vX.Y.Z` tag (none exists today), which is what finally makes `go get github.com/flanksource/clicky/aichat` installable from the proxy.

`valkey/go.mod` still pins the non-existent `clicky v0.0.0`; the same workflow re-pins it on release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled dependency to a newer version, which may improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->