### PR TITLE
ci(release): rename goreleaser folder field to directory

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,7 +92,7 @@ brews:
       name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    folder: Formula
+    directory: Formula
     homepage: https://github.com/{{ .Env.GITHUB_OWNER | default "flanksource" }}/clicky
     description: "A command-line tool for parsing and formatting structured data with schemas"
     license: "MIT"
@@ -112,7 +112,7 @@ scoops:
       name: scoop-bucket
       branch: main
       token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
-    folder: bucket
+    directory: bucket
     homepage: https://github.com/{{ .Env.GITHUB_OWNER | default "flanksource" }}/clicky
     description: "A command-line tool for parsing and formatting structured data with schemas"
     license: "MIT"


### PR DESCRIPTION
## Problem

Every release run fails at the **GoReleaser** step:

```
release failed after 0s
  │ yaml: unmarshal errors:
  │   line 95: field folder not found in type config.Homebrew
  │   line 115: field folder not found in type config.Scoop
```

GoReleaser v2 renamed the Homebrew/Scoop `folder` key to `directory`. Since the `release-submodules` job `needs: [semantic-release, goreleaser]`, the GoReleaser failure **skips submodule tagging** — so no `aichat/vX.Y.Z` tag is ever pushed and `go get github.com/flanksource/clicky/aichat` cannot resolve from the proxy.

## Fix

Rename both `folder:` → `directory:`. This unblocks GoReleaser, letting `release-submodules` push the `aichat/` (and `valkey/`) tags as designed.

## Effect on merge

A new patch release is cut (catch-all `{type: '*', release: 'patch'}` in `.releaserc.json`), GoReleaser succeeds, and `release-submodules` tags `aichat/v<version>` — which is what finally makes `go get clicky/aichat` work for external users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release packaging settings to use the current directory naming for Homebrew and Scoop distributions, helping ensure builds publish correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->