### PR TITLE
ci(release): check out branch tip for GoReleaser and decouple submodule tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # semantic-release pushed the release commit/tag after this workflow
+          # started, so check out the live branch tip (not the trigger SHA),
+          # otherwise GoReleaser sees the previous tag at HEAD and fails with
+          # "git tag vX was not made against commit <sha>".
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - name: Fetch tags
@@ -163,7 +168,11 @@ jobs:
   # uninstallable) and commit that pin before tagging.
   release-submodules:
     name: Release Sub-modules
-    needs: [semantic-release, goreleaser]
+    # Only needs the semantic-release tag (clicky@vX.Y.Z) to pin against — the
+    # sub-module tags must publish even if GoReleaser's binary/Homebrew/Docker
+    # release fails, otherwise `go get .../aichat` stays broken on an unrelated
+    # packaging error.
+    needs: semantic-release
     if: needs.semantic-release.outputs.new_release_published == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

After fixing the goreleaser `folder` field, the GoReleaser job still fails:

```
release failed: git tag v1.21.30 was not made against commit 29bb8d65...
```

semantic-release pushes the `chore(release)` commit **and the version tag after the workflow starts**. The GoReleaser job checked out the *trigger SHA*, so the freshly-created tag sits on a child commit and GoReleaser refuses to release (current tag must point at HEAD). The `release-submodules` job already worked around this with `ref: ${{ github.ref_name }}` — but it `needs: goreleaser`, so the GoReleaser failure skips submodule tagging and `go get github.com/flanksource/clicky/aichat` stays broken.

## Fixes

1. **GoReleaser checks out the live branch tip** (`ref: ${{ github.ref_name }}`) so the new tag is at HEAD.
2. **`release-submodules` depends on `semantic-release` only** (not `goreleaser`). Submodule tags only need the clicky`@vX.Y.Z` tag to pin against; they must publish even if binary/Homebrew/Docker packaging fails.

## Effect on merge

A new patch release runs cleanly end-to-end: GoReleaser succeeds, and `release-submodules` pushes `aichat/v<version>` + `valkey/v<version>` — finally making `go get clicky/aichat` resolve from the proxy.