### PR TITLE
feat(api): support timing counters

### DIFF
--- a/examples/enitity/go.mod
+++ b/examples/enitity/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/flanksource/captain v0.0.20
-	github.com/flanksource/clicky v1.21.51
+	github.com/flanksource/clicky v1.21.52
 	github.com/flanksource/clicky/aichat v1.21.49
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/rpc/http/middleware.go
+++ b/rpc/http/middleware.go
@@ -36,7 +36,7 @@ func (rec *timingRecorder) stamp() {
 		return
 	}
 	rec.stamped = true
-	value := formatMetric("total", time.Since(rec.start))
+	value := formatMetric("total", time.Since(rec.start), "")
 	if phases := rec.timings.Header(); phases != "" {
 		value += ", " + phases
 	}

--- a/rpc/http/middleware_test.go
+++ b/rpc/http/middleware_test.go
@@ -12,7 +12,7 @@ var serverTimingRe = regexp.MustCompile(`^total;dur=[0-9]+\.[0-9], find;dur=[0-9
 
 func TestMiddlewareStampsServerTiming(t *testing.T) {
 	handler := TimingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		AddTiming(r.Context(), "find", 2*time.Millisecond)
+		AddTiming(r.Context(), TimingMetric{Name: "find", Duration: 2 * time.Millisecond})
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -41,7 +41,7 @@ func TestMiddlewareTotalOnlyWhenNoPhases(t *testing.T) {
 
 func TestMiddlewareStampsWhenHandlerDoesNotWrite(t *testing.T) {
 	handler := TimingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		AddTiming(r.Context(), "find", 2*time.Millisecond)
+		AddTiming(r.Context(), TimingMetric{Name: "find", Duration: 2 * time.Millisecond})
 		// Return without calling WriteHeader/Write/Flush.
 	}))
 

--- a/rpc/http/timing.go
+++ b/rpc/http/timing.go
@@ -10,6 +10,7 @@ package rpchttp
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,19 +19,36 @@ import (
 // timingsKey keys the request-scoped *Timings accumulator into a context.
 type timingsKey struct{}
 
-// Timings is a request-scoped, insertion-ordered accumulator of named phase
-// durations. Durations for the same name sum, so AddTiming may be called once
-// per file in a loop and still report a single total for that phase.
+// TimingCounter is a named integer aggregated into a metric's description.
+type TimingCounter struct {
+	Name  string
+	Value int64
+}
+
+// TimingMetric is one contribution to a request-scoped server timing metric.
+type TimingMetric struct {
+	Name     string
+	Duration time.Duration
+	Counters []TimingCounter
+}
+
+type timingTotal struct {
+	duration     time.Duration
+	counterOrder []string
+	counters     map[string]int64
+}
+
+// Timings is a request-scoped, insertion-ordered accumulator of named metrics.
 type Timings struct {
-	mu     sync.Mutex
-	order  []string
-	totals map[string]time.Duration
+	mu      sync.Mutex
+	order   []string
+	metrics map[string]*timingTotal
 }
 
 // WithTimings returns a context carrying a fresh accumulator and the accumulator
 // itself, so a middleware can read it back after the handler returns.
 func WithTimings(ctx context.Context) (context.Context, *Timings) {
-	t := &Timings{totals: make(map[string]time.Duration)}
+	t := &Timings{metrics: make(map[string]*timingTotal)}
 	return context.WithValue(ctx, timingsKey{}, t), t
 }
 
@@ -40,12 +58,11 @@ func TimingsFromContext(ctx context.Context) (*Timings, bool) {
 	return t, ok
 }
 
-// AddTiming adds d to the named phase of the current request's accumulator. It
-// is a no-op when no accumulator is present (the CLI path has no HTTP response
-// to attach a header to).
-func AddTiming(ctx context.Context, name string, d time.Duration) {
+// AddTiming aggregates a metric into the current request. It is a no-op when no
+// accumulator is present, such as on the CLI path.
+func AddTiming(ctx context.Context, metric TimingMetric) {
 	if t, ok := TimingsFromContext(ctx); ok {
-		t.add(name, d)
+		t.add(metric)
 	}
 }
 
@@ -55,17 +72,26 @@ func AddTiming(ctx context.Context, name string, d time.Duration) {
 func Track(ctx context.Context, name string) func() {
 	start := time.Now()
 	return func() {
-		AddTiming(ctx, name, time.Since(start))
+		AddTiming(ctx, TimingMetric{Name: name, Duration: time.Since(start)})
 	}
 }
 
-func (t *Timings) add(name string, d time.Duration) {
+func (t *Timings) add(metric TimingMetric) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if _, seen := t.totals[name]; !seen {
-		t.order = append(t.order, name)
+	total, seen := t.metrics[metric.Name]
+	if !seen {
+		total = &timingTotal{counters: make(map[string]int64)}
+		t.metrics[metric.Name] = total
+		t.order = append(t.order, metric.Name)
 	}
-	t.totals[name] += d
+	total.duration += metric.Duration
+	for _, counter := range metric.Counters {
+		if _, seen := total.counters[counter.Name]; !seen {
+			total.counterOrder = append(total.counterOrder, counter.Name)
+		}
+		total.counters[counter.Name] += counter.Value
+	}
 }
 
 // Header renders the accumulated phases as a Server-Timing value fragment
@@ -76,11 +102,28 @@ func (t *Timings) Header() string {
 	defer t.mu.Unlock()
 	parts := make([]string, 0, len(t.order))
 	for _, name := range t.order {
-		parts = append(parts, formatMetric(name, t.totals[name]))
+		total := t.metrics[name]
+		parts = append(parts, formatMetric(name, total.duration, total.counterDescription()))
 	}
 	return strings.Join(parts, ", ")
 }
 
-func formatMetric(name string, d time.Duration) string {
-	return fmt.Sprintf("%s;dur=%.1f", name, float64(d)/float64(time.Millisecond))
+func (t *timingTotal) counterDescription() string {
+	if len(t.counterOrder) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(t.counterOrder))
+	for _, name := range t.counterOrder {
+		parts = append(parts, name+"="+strconv.FormatInt(t.counters[name], 10))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatMetric(name string, d time.Duration, description string) string {
+	metric := fmt.Sprintf("%s;dur=%.1f", name, float64(d)/float64(time.Millisecond))
+	if description == "" {
+		return metric
+	}
+	description = strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(description)
+	return metric + `;desc="` + description + `"`
 }

--- a/rpc/http/timing_counter_spec_test.go
+++ b/rpc/http/timing_counter_spec_test.go
@@ -1,0 +1,47 @@
+package rpchttp
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HTTP server timing counters", func() {
+	It("aggregates duration and counters in first-seen order", func() {
+		ctx, timings := WithTimings(context.Background())
+
+		AddTiming(ctx, TimingMetric{
+			Name: "sql", Duration: 2 * time.Millisecond,
+			Counters: []TimingCounter{{Name: "queries", Value: 1}, {Name: "rows_returned", Value: 500}},
+		})
+		AddTiming(ctx, TimingMetric{
+			Name: "redis", Duration: time.Millisecond,
+			Counters: []TimingCounter{{Name: "ops", Value: 1}, {Name: "hits", Value: 1}},
+		})
+		AddTiming(ctx, TimingMetric{
+			Name: "sql", Duration: 3 * time.Millisecond,
+			Counters: []TimingCounter{{Name: "queries", Value: 1}, {Name: "rows_returned", Value: 1}},
+		})
+
+		Expect(timings.Header()).To(Equal(
+			`sql;dur=5.0;desc="queries=2 rows_returned=501", redis;dur=1.0;desc="ops=1 hits=1"`,
+		))
+	})
+
+	It("retains zero-valued seeded metrics", func() {
+		ctx, timings := WithTimings(context.Background())
+
+		AddTiming(ctx, TimingMetric{
+			Name: "redis",
+			Counters: []TimingCounter{
+				{Name: "ops"}, {Name: "hits"}, {Name: "misses"}, {Name: "errors"},
+			},
+		})
+
+		Expect(timings.Header()).To(Equal(
+			`redis;dur=0.0;desc="ops=0 hits=0 misses=0 errors=0"`,
+		))
+	})
+})

--- a/rpc/http/timing_suite_test.go
+++ b/rpc/http/timing_suite_test.go
@@ -1,0 +1,13 @@
+package rpchttp
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServerTiming(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTP Server Timing Suite")
+}

--- a/rpc/http/timing_test.go
+++ b/rpc/http/timing_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestAddTimingSumsByName(t *testing.T) {
 	ctx, timings := WithTimings(context.Background())
-	AddTiming(ctx, "parse", 2*time.Millisecond)
-	AddTiming(ctx, "find", 1*time.Millisecond)
-	AddTiming(ctx, "parse", 3*time.Millisecond)
+	AddTiming(ctx, TimingMetric{Name: "parse", Duration: 2 * time.Millisecond})
+	AddTiming(ctx, TimingMetric{Name: "find", Duration: time.Millisecond})
+	AddTiming(ctx, TimingMetric{Name: "parse", Duration: 3 * time.Millisecond})
 
 	if got := timings.Header(); got != "parse;dur=5.0, find;dur=1.0" {
 		t.Fatalf("Header() = %q", got)
@@ -30,17 +30,17 @@ func TestTrackRecordsElapsed(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	stop()
 
-	total, ok := timings.totals["enrich"]
+	total, ok := timings.metrics["enrich"]
 	if !ok {
 		t.Fatal("enrich not recorded")
 	}
-	if total < 5*time.Millisecond {
-		t.Fatalf("elapsed = %v, want >= 5ms", total)
+	if total.duration < 5*time.Millisecond {
+		t.Fatalf("elapsed = %v, want >= 5ms", total.duration)
 	}
 }
 
 func TestAddTimingNoAccumulatorIsNoop(t *testing.T) {
 	// Must not panic on the CLI path where no accumulator was installed.
-	AddTiming(context.Background(), "parse", time.Millisecond)
+	AddTiming(context.Background(), TimingMetric{Name: "parse", Duration: time.Millisecond})
 	Track(context.Background(), "parse")()
 }


### PR DESCRIPTION
### What
- Add counters to HTTP server timing metrics while preserving duration aggregation and metric order.

### Notes
- Breaking API change: `AddTiming` now accepts `TimingMetric` instead of separate name and duration arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced HTTP Server-Timing metrics to include named counters alongside durations.
  * Aggregated timing metrics now preserve insertion order and combine matching durations and counters.
  * Counter details are safely escaped and included in timing descriptions.

* **Bug Fixes**
  * Improved formatting for total timing metrics when no unit is provided.

* **Tests**
  * Added coverage for timing and counter aggregation, ordering, seeded counters, and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->