### PR TITLE
feat: expand filters, rendering, tasks

### DIFF
--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,6 +49,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/aichat/adapter_ginkgo_test.go
+++ b/aichat/adapter_ginkgo_test.go
@@ -2,6 +2,7 @@ package aichat_test
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -90,5 +91,42 @@ var _ = Describe("Cobra tool provider", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(set.Definitions).To(HaveLen(1))
 		Expect(set.Definitions[0].Name).To(Equal("unsafe_name"))
+	})
+
+	It("publishes an output schema for operations with a declared response type", func(ctx SpecContext) {
+		root := &cobra.Command{Use: "example"}
+		clicky.AddCommand(root, greetOptions{}, func(options greetOptions) (greetResult, error) {
+			return greetResult{Message: "hello " + options.Name}, nil
+		})
+
+		provider, err := clickyaichat.NewCobraToolProvider(clickyaichat.CobraToolProviderOptions{Root: root})
+		Expect(err).NotTo(HaveOccurred())
+		set, err := provider.ToolSet(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set.Catalog).To(HaveLen(1))
+
+		outputSchema := set.Catalog[0].OutputSchema
+		Expect(outputSchema).To(HaveKeyWithValue("type", "object"))
+		Expect(outputSchema).To(HaveKeyWithValue("properties",
+			HaveKeyWithValue("message", HaveKeyWithValue("type", "string"))),
+			"the schema describes the greetResult return type")
+	})
+
+	It("omits outputSchema for operations without a declared response type", func(ctx SpecContext) {
+		root := &cobra.Command{Use: "example"}
+		root.AddCommand(&cobra.Command{Use: "visible", Run: func(*cobra.Command, []string) {}})
+
+		provider, err := clickyaichat.NewCobraToolProvider(clickyaichat.CobraToolProviderOptions{Root: root})
+		Expect(err).NotTo(HaveOccurred())
+		set, err := provider.ToolSet(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set.Catalog).To(HaveLen(1))
+		Expect(set.Catalog[0].OutputSchema).To(BeNil())
+
+		// The frontend degrades to value heuristics on a missing key, so the
+		// absence has to survive marshalling — not just be an empty map.
+		encoded, err := json.Marshal(set.Catalog[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(encoded)).NotTo(ContainSubstring("outputSchema"))
 	})
 })

--- a/aichat/tools_clicky.go
+++ b/aichat/tools_clicky.go
@@ -95,8 +95,12 @@ func (p *CobraToolProvider) ToolSet(context.Context) (capchat.ToolSet, error) {
 			IdempotentHint: info.IdempotentHint, Annotations: info.Annotations,
 			Handler: p.handlerFor(op),
 		}
+		outputSchema, err := rpc.ResponseSchema(*op)
+		if err != nil {
+			return capchat.ToolSet{}, fmt.Errorf("operation %q response schema: %w", op.Name, err)
+		}
 		set.Definitions = append(set.Definitions, definition)
-		set.Catalog = append(set.Catalog, catalogEntry(definition))
+		set.Catalog = append(set.Catalog, catalogEntry(definition, outputSchema))
 	}
 	return set, nil
 }
@@ -152,7 +156,11 @@ func defaultToolPermission(op *rpc.RPCOperation, hints entity.MCPToolHints) (api
 	}
 }
 
-func catalogEntry(definition api.ToolDefinition) captools.ToolCatalogEntry {
+// catalogEntry builds the frontend-facing DTO. outputSchema is applied raw
+// rather than through captools.ObjectSchema: an operation returning an array
+// publishes a top-level array, which coercing to an object would corrupt. A nil
+// schema leaves the field unset so it drops out of the payload entirely.
+func catalogEntry(definition api.ToolDefinition, outputSchema map[string]any) captools.ToolCatalogEntry {
 	entry := captools.CustomCatalogEntry(captools.ToolDefinition{
 		Name: definition.Name, Description: definition.Description,
 		InputSchema: definition.InputSchema, Group: definition.Group,
@@ -162,6 +170,9 @@ func catalogEntry(definition api.ToolDefinition) captools.ToolCatalogEntry {
 		IdempotentHint: definition.IdempotentHint, Annotations: definition.Annotations,
 	}, definition.Name, definition.InputSchema)
 	entry.Source = "clicky"
+	if outputSchema != nil {
+		entry.OutputSchema = outputSchema
+	}
 	return entry
 }
 

--- a/api/ansi_text.go
+++ b/api/ansi_text.go
@@ -1,0 +1,376 @@
+package api
+
+import (
+	"fmt"
+	"html"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ANSIText is captured terminal text that retains SGR presentation without
+// replaying cursor movement, screen erasure, OSC, or other active controls.
+// HTML output converts the retained presentation to escaped span markup.
+type ANSIText struct {
+	Content string
+}
+
+func (t ANSIText) String() string {
+	return ansi.Strip(sanitizeANSIText(t.Content))
+}
+
+func (t ANSIText) ANSI() string {
+	return closeANSIStyle(sanitizeANSIText(t.Content))
+}
+
+func (t ANSIText) HTML() string {
+	return ansiTextToHTML(sanitizeANSIText(t.Content))
+}
+
+func (t ANSIText) Markdown() string {
+	return t.String()
+}
+
+// VisibleLines returns independently renderable, non-blank lines. Active SGR
+// state is replayed at the start of a continuation line and reset at its end.
+func (t ANSIText) VisibleLines() []ANSIText {
+	input := sanitizeANSIText(t.Content)
+	var lines []ANSIText
+	var line strings.Builder
+	var active []string
+
+	appendLine := func() {
+		content := line.String()
+		if len(active) > 0 {
+			content += "\x1b[0m"
+		}
+		if strings.TrimSpace(ansi.Strip(content)) != "" {
+			lines = append(lines, ANSIText{Content: content})
+		}
+		line.Reset()
+		for _, sequence := range active {
+			line.WriteString(sequence)
+		}
+	}
+
+	for i := 0; i < len(input); {
+		if input[i] == '\n' {
+			appendLine()
+			i++
+			continue
+		}
+		if input[i] == '\x1b' && i+1 < len(input) && input[i+1] == '[' {
+			sequence, consumed, keep := consumeCSI(input[i:])
+			if consumed > 0 && keep {
+				line.WriteString(sequence)
+				active = updateActiveSGR(active, sequence)
+				i += consumed
+				continue
+			}
+		}
+		line.WriteByte(input[i])
+		i++
+	}
+	appendLine()
+	return lines
+}
+
+func sanitizeANSIText(input string) string {
+	var output strings.Builder
+	output.Grow(len(input))
+
+	for i := 0; i < len(input); {
+		switch input[i] {
+		case '\x1b':
+			if i+1 >= len(input) {
+				i++
+				continue
+			}
+			switch input[i+1] {
+			case '[':
+				sequence, consumed, keep := consumeCSI(input[i:])
+				if keep {
+					output.WriteString(sequence)
+				}
+				i += consumed
+			case ']', 'P', 'X', '^', '_':
+				i += consumeANSIString(input[i:])
+			default:
+				i += min(2, len(input)-i)
+			}
+		case '\r':
+			if i+1 < len(input) && input[i+1] == '\n' {
+				i++
+			} else {
+				output.WriteByte('\n')
+				i++
+			}
+		case '\n', '\t':
+			output.WriteByte(input[i])
+			i++
+		default:
+			if input[i] < 0x20 || input[i] == 0x7f {
+				i++
+				continue
+			}
+			output.WriteByte(input[i])
+			i++
+		}
+	}
+	return output.String()
+}
+
+func consumeCSI(input string) (string, int, bool) {
+	for i := 2; i < len(input); i++ {
+		if input[i] < 0x40 || input[i] > 0x7e {
+			continue
+		}
+		sequence := input[:i+1]
+		if input[i] != 'm' || !validSGRParams(input[2:i]) {
+			return sequence, i + 1, false
+		}
+		return sequence, i + 1, true
+	}
+	return "", len(input), false
+}
+
+func validSGRParams(params string) bool {
+	for i := range len(params) {
+		if (params[i] < '0' || params[i] > '9') && params[i] != ';' && params[i] != ':' {
+			return false
+		}
+	}
+	return true
+}
+
+func consumeANSIString(input string) int {
+	for i := 2; i < len(input); i++ {
+		if input[i] == '\a' {
+			return i + 1
+		}
+		if input[i] == '\x1b' && i+1 < len(input) && input[i+1] == '\\' {
+			return i + 2
+		}
+	}
+	return len(input)
+}
+
+func closeANSIStyle(input string) string {
+	if !strings.Contains(input, "\x1b[") {
+		return input
+	}
+	return input + "\x1b[0m"
+}
+
+func updateActiveSGR(active []string, sequence string) []string {
+	params := strings.TrimSuffix(strings.TrimPrefix(sequence, "\x1b["), "m")
+	if params == "" {
+		return nil
+	}
+	codes := strings.FieldsFunc(params, func(r rune) bool { return r == ';' || r == ':' })
+	hasReset := false
+	hasStyle := false
+	for _, code := range codes {
+		if code == "" || code == "0" {
+			hasReset = true
+		} else {
+			hasStyle = true
+		}
+	}
+	if hasReset {
+		active = nil
+	}
+	if hasStyle {
+		return append(active, sequence)
+	}
+	if !hasReset {
+		return append(active, sequence)
+	}
+	return active
+}
+
+type ansiHTMLStyle struct {
+	foreground string
+	background string
+	bold       bool
+	faint      bool
+	italic     bool
+	underline  bool
+	strike     bool
+}
+
+func ansiTextToHTML(input string) string {
+	style := ansiHTMLStyle{}
+	var output strings.Builder
+	textStart := 0
+
+	writeText := func(end int) {
+		if end <= textStart {
+			return
+		}
+		content := html.EscapeString(input[textStart:end])
+		if css := style.css(); css != "" {
+			fmt.Fprintf(&output, `<span style="%s">%s</span>`, css, content)
+		} else {
+			output.WriteString(content)
+		}
+	}
+
+	for i := 0; i < len(input); {
+		if input[i] != '\x1b' || i+1 >= len(input) || input[i+1] != '[' {
+			i++
+			continue
+		}
+		sequence, consumed, keep := consumeCSI(input[i:])
+		if consumed == 0 || !keep {
+			i++
+			continue
+		}
+		writeText(i)
+		style.apply(sequence)
+		i += consumed
+		textStart = i
+	}
+	writeText(len(input))
+	return output.String()
+}
+
+func (s *ansiHTMLStyle) apply(sequence string) {
+	params := strings.TrimSuffix(strings.TrimPrefix(sequence, "\x1b["), "m")
+	params = strings.ReplaceAll(params, ":", ";")
+	if params == "" {
+		*s = ansiHTMLStyle{}
+		return
+	}
+	parts := strings.Split(params, ";")
+	for i := 0; i < len(parts); i++ {
+		code, err := strconv.Atoi(parts[i])
+		if err != nil {
+			continue
+		}
+		switch {
+		case code == 0:
+			*s = ansiHTMLStyle{}
+		case code == 1:
+			s.bold = true
+		case code == 2:
+			s.faint = true
+		case code == 3:
+			s.italic = true
+		case code == 4:
+			s.underline = true
+		case code == 9:
+			s.strike = true
+		case code == 22:
+			s.bold, s.faint = false, false
+		case code == 23:
+			s.italic = false
+		case code == 24:
+			s.underline = false
+		case code == 29:
+			s.strike = false
+		case code == 39:
+			s.foreground = ""
+		case code == 49:
+			s.background = ""
+		case code >= 30 && code <= 37:
+			s.foreground = ansiColor(code - 30)
+		case code >= 90 && code <= 97:
+			s.foreground = ansiColor(code - 90 + 8)
+		case code >= 40 && code <= 47:
+			s.background = ansiColor(code - 40)
+		case code >= 100 && code <= 107:
+			s.background = ansiColor(code - 100 + 8)
+		case code == 38 || code == 48:
+			color, consumed := extendedANSIColor(parts[i+1:])
+			if color != "" {
+				if code == 38 {
+					s.foreground = color
+				} else {
+					s.background = color
+				}
+				i += consumed
+			}
+		}
+	}
+}
+
+func (s ansiHTMLStyle) css() string {
+	var styles []string
+	if s.foreground != "" {
+		styles = append(styles, "color:"+s.foreground)
+	}
+	if s.background != "" {
+		styles = append(styles, "background-color:"+s.background)
+	}
+	if s.bold {
+		styles = append(styles, "font-weight:bold")
+	}
+	if s.faint {
+		styles = append(styles, "opacity:0.7")
+	}
+	if s.italic {
+		styles = append(styles, "font-style:italic")
+	}
+	var decorations []string
+	if s.underline {
+		decorations = append(decorations, "underline")
+	}
+	if s.strike {
+		decorations = append(decorations, "line-through")
+	}
+	if len(decorations) > 0 {
+		styles = append(styles, "text-decoration:"+strings.Join(decorations, " "))
+	}
+	return strings.Join(styles, ";")
+}
+
+func extendedANSIColor(parts []string) (string, int) {
+	if len(parts) >= 2 && parts[0] == "5" {
+		value, err := strconv.Atoi(parts[1])
+		if err == nil && value >= 0 && value <= 255 {
+			return ansiColor(value), 2
+		}
+	}
+	if len(parts) >= 4 && parts[0] == "2" {
+		r, errR := strconv.Atoi(parts[1])
+		g, errG := strconv.Atoi(parts[2])
+		b, errB := strconv.Atoi(parts[3])
+		if errR == nil && errG == nil && errB == nil && validRGB(r, g, b) {
+			return fmt.Sprintf("#%02x%02x%02x", r, g, b), 4
+		}
+	}
+	return "", 0
+}
+
+func validRGB(values ...int) bool {
+	for _, value := range values {
+		if value < 0 || value > 255 {
+			return false
+		}
+	}
+	return true
+}
+
+func ansiColor(index int) string {
+	standard := [...]string{
+		"#1e1e1e", "#cd3131", "#0dbc79", "#e5e510",
+		"#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
+		"#666666", "#f14c4c", "#23d18b", "#f5f543",
+		"#3b8eea", "#d670d6", "#29b8db", "#ffffff",
+	}
+	if index >= 0 && index < len(standard) {
+		return standard[index]
+	}
+	if index >= 16 && index <= 231 {
+		levels := [...]int{0, 95, 135, 175, 215, 255}
+		value := index - 16
+		return fmt.Sprintf("#%02x%02x%02x", levels[value/36], levels[(value/6)%6], levels[value%6])
+	}
+	if index >= 232 && index <= 255 {
+		level := 8 + (index-232)*10
+		return fmt.Sprintf("#%02x%02x%02x", level, level, level)
+	}
+	return ""
+}

--- a/api/ansi_text_ginkgo_test.go
+++ b/api/ansi_text_ginkgo_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ANSIText", func() {
+	It("preserves SGR while removing active terminal controls", func() {
+		value := ANSIText{Content: "\x1b[31mred\x1b[0m\x1b[2A\x1b[2J\x1b]8;;https://example.com\x07link\x1b]8;;\x07"}
+
+		rendered := value.ANSI()
+
+		Expect(rendered).To(ContainSubstring("\x1b[31mred\x1b[0m"))
+		Expect(rendered).To(ContainSubstring("link"))
+		Expect(rendered).NotTo(ContainSubstring("\x1b[2A"))
+		Expect(rendered).NotTo(ContainSubstring("\x1b[2J"))
+		Expect(rendered).NotTo(ContainSubstring("\x1b]8;"))
+	})
+
+	It("converts SGR to escaped HTML spans", func() {
+		value := ANSIText{Content: "\x1b[1;38;2;12;34;56m<&>\x1b[0m"}
+
+		rendered := value.HTML()
+
+		Expect(rendered).To(ContainSubstring("font-weight:bold"))
+		Expect(rendered).To(ContainSubstring("color:#0c2238"))
+		Expect(rendered).To(ContainSubstring("&lt;&amp;&gt;"))
+		Expect(rendered).NotTo(ContainSubstring("\x1b["))
+		Expect(rendered).NotTo(ContainSubstring("<&>"))
+	})
+
+	It("returns independently renderable visible lines with carried styles", func() {
+		value := ANSIText{Content: "\x1b[32mfirst\nsecond\x1b[0m\n\x1b[2J\nthird"}
+
+		lines := value.VisibleLines()
+
+		Expect(lines).To(HaveLen(3))
+		Expect(lines[0].String()).To(Equal("first"))
+		Expect(lines[1].String()).To(Equal("second"))
+		Expect(lines[2].String()).To(Equal("third"))
+		Expect(lines[0].ANSI()).To(ContainSubstring("\x1b[32m"))
+		Expect(lines[1].ANSI()).To(ContainSubstring("\x1b[32m"))
+		Expect(strings.Join([]string{lines[0].HTML(), lines[1].HTML()}, "")).To(ContainSubstring("color:#0dbc79"))
+	})
+
+	It("bounds multiline TextTree labels to terminal width", func() {
+		long := strings.Repeat("x", 2_000)
+		tree := TextTree{Node: Text{}.Append("fixture").NewLine().Add(ANSIText{Content: "\x1b[31m" + long + "\x1b[0m"})}
+
+		output := tree.ANSI()
+
+		Expect(output).To(ContainSubstring("fixture"))
+		for _, line := range strings.Split(output, "\n") {
+			Expect(lipgloss.Width(line)).To(BeNumerically("<", GetTerminalWidth()-1))
+			Expect(line).NotTo(HaveSuffix(" "))
+		}
+	})
+})

--- a/api/column.go
+++ b/api/column.go
@@ -12,6 +12,8 @@ type ColumnDef struct {
 	HeaderStyle   string
 	Type          string
 	Format        string
+	Unit          string
+	FilterKey     string
 	FormatOptions map[string]string
 	MaxWidth      int
 	Hidden        bool
@@ -70,6 +72,19 @@ func (b *ColumnBuilder) Type(typ string) *ColumnBuilder {
 // Format sets the format type (currency, date, bytes, etc.).
 func (b *ColumnBuilder) Format(format string) *ColumnBuilder {
 	b.col.Format = format
+	return b
+}
+
+// Unit sets the numeric display unit (for example percentunit, bytes, or ms).
+// Unit formatting takes precedence over Format when both are present.
+func (b *ColumnBuilder) Unit(unit string) *ColumnBuilder {
+	b.col.Unit = unit
+	return b
+}
+
+// FilterKey binds this output column to a server-side filter parameter.
+func (b *ColumnBuilder) FilterKey(key string) *ColumnBuilder {
+	b.col.FilterKey = key
 	return b
 }
 
@@ -142,6 +157,8 @@ func NewEmptyTable(columns []ColumnDef) TextTable {
 			LabelStyle:    col.HeaderStyle,
 			Type:          col.Type,
 			Format:        col.Format,
+			Unit:          col.Unit,
+			FilterKey:     col.FilterKey,
 			FormatOptions: col.FormatOptions,
 		})
 	}
@@ -179,7 +196,11 @@ func NewTableFrom[T TableProvider](items []T) TextTable {
 					style = fmt.Sprintf("%s max-w-[%dch] truncate", style, col.MaxWidth)
 				}
 				text := Text{Style: style}.Add(ColumnTextable(col, val))
-				row[col.Name] = TypedValue{Textable: text}
+				cell := TypedValue{Textable: text}
+				if col.FilterKey != "" {
+					cell.FilterValue = val
+				}
+				row[col.Name] = cell
 			} else {
 				row[col.Name] = TypedValue{Textable: Text{}}
 			}

--- a/api/column_format.go
+++ b/api/column_format.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+var columnNumberPrinter = message.NewPrinter(language.AmericanEnglish)
+
+// ColumnFormatValues returns the formats supported by schema-driven columns.
+func ColumnFormatValues() []string {
+	return []string{FormatDate, FormatFloat, FieldTypeDuration, FieldTypeBytes, FormatCurrency}
+}
+
+// ColumnUnitValues returns the Grafana-compatible units supported by columns.
+func ColumnUnitValues() []string {
+	return []string{
+		ColumnUnitNone,
+		ColumnUnitShort,
+		ColumnUnitPercent,
+		ColumnUnitPercentUnit,
+		ColumnUnitBytes,
+		ColumnUnitDecimalBytes,
+		ColumnUnitBytesPerSecond,
+		ColumnUnitBinaryBytesPerSecond,
+		ColumnUnitMilliseconds,
+		ColumnUnitSeconds,
+	}
+}
+
+func formatColumnScalar(column ColumnDef, value any) (Textable, bool) {
+	switch value.(type) {
+	case PrettyShort, Textable, Pretty:
+		return nil, false
+	}
+
+	if column.Unit != "" {
+		if formatted, ok := formatColumnUnit(value, column.Unit); ok {
+			return Text{Content: formatted, Style: "number"}, true
+		}
+	}
+	if column.Format == "" {
+		return nil, false
+	}
+	parsed, err := (PrettyField{
+		Name:          column.Name,
+		Type:          column.Type,
+		Format:        column.Format,
+		FormatOptions: column.FormatOptions,
+	}).Parse(value)
+	if err != nil || parsed.Text == nil {
+		return nil, false
+	}
+	return parsed.Text, true
+}
+
+func formatColumnUnit(value any, unit string) (string, bool) {
+	number := (FieldValue{Value: value}).Float()
+	if number == nil || math.IsNaN(*number) || math.IsInf(*number, 0) {
+		return "", false
+	}
+	switch unit {
+	case ColumnUnitNone, ColumnUnitShort:
+		return formatShortNumber(*number), true
+	case ColumnUnitPercent:
+		return formatDecimal(*number) + "%", true
+	case ColumnUnitPercentUnit:
+		return formatDecimal(*number*100) + "%", true
+	case ColumnUnitBytes:
+		return formatByteValue(*number, 1024, ""), true
+	case ColumnUnitDecimalBytes:
+		return formatByteValue(*number, 1000, ""), true
+	case ColumnUnitBytesPerSecond, ColumnUnitBinaryBytesPerSecond:
+		return formatByteValue(*number, 1024, "/s"), true
+	case ColumnUnitMilliseconds:
+		return formatDurationValue(*number), true
+	case ColumnUnitSeconds:
+		return formatDurationValue(*number * 1000), true
+	default:
+		return "", false
+	}
+}
+
+func formatDecimal(value float64) string {
+	if math.Trunc(value) == value {
+		return columnNumberPrinter.Sprintf("%.0f", value)
+	}
+	return strings.TrimSuffix(columnNumberPrinter.Sprintf("%.1f", value), ".0")
+}
+
+func formatShortNumber(value float64) string {
+	units := []string{"", "K", "M", "B", "T"}
+	sign := ""
+	if value < 0 {
+		sign = "-"
+		value = math.Abs(value)
+	}
+	if value < 1000 {
+		return sign + formatDecimal(value)
+	}
+	unit := 0
+	for value >= 1000 && unit < len(units)-1 {
+		value /= 1000
+		unit++
+	}
+	if value >= 10 {
+		return fmt.Sprintf("%s%.0f%s", sign, value, units[unit])
+	}
+	return fmt.Sprintf("%s%s%s", sign, strings.TrimSuffix(fmt.Sprintf("%.1f", value), ".0"), units[unit])
+}
+
+func formatByteValue(value, base float64, suffix string) string {
+	units := []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	if value <= 0 {
+		return "0 B" + suffix
+	}
+	unit := 0
+	for value >= base && unit < len(units)-1 {
+		value /= base
+		unit++
+	}
+	rendered := fmt.Sprintf("%.0f", value)
+	if value < 10 && unit > 0 {
+		rendered = strings.TrimSuffix(fmt.Sprintf("%.1f", value), ".0")
+	}
+	return fmt.Sprintf("%s %s%s", rendered, units[unit], suffix)
+}
+
+func formatDurationValue(milliseconds float64) string {
+	abs := math.Abs(milliseconds)
+	switch {
+	case abs < 1000:
+		return columnNumberPrinter.Sprintf("%.0f ms", milliseconds)
+	case abs < 60_000:
+		return formatDecimal(milliseconds/1000) + " s"
+	case abs < 3_600_000:
+		return formatDecimal(milliseconds/60_000) + " min"
+	default:
+		return formatDecimal(milliseconds/3_600_000) + " h"
+	}
+}

--- a/api/column_format_ginkgo_test.go
+++ b/api/column_format_ginkgo_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Column formatting", func() {
+	DescribeTable("formats canonical units",
+		func(value any, unit, expected string) {
+			column := Column("value").Type("number").Unit(unit).Build()
+			Expect(ColumnTextable(column, value).String()).To(Equal(expected))
+			Expect(ColumnString(column, value)).To(Equal(expected))
+		},
+		Entry("none", 1200, ColumnUnitNone, "1.2K"),
+		Entry("short", 1200, ColumnUnitShort, "1.2K"),
+		Entry("percent", 12.34, ColumnUnitPercent, "12.3%"),
+		Entry("fractional percent", 0.423, ColumnUnitPercentUnit, "42.3%"),
+		Entry("binary bytes", 1536, ColumnUnitBytes, "1.5 KB"),
+		Entry("decimal bytes", 1500, ColumnUnitDecimalBytes, "1.5 KB"),
+		Entry("byte rate", 1536, ColumnUnitBytesPerSecond, "1.5 KB/s"),
+		Entry("binary byte rate", 1536, ColumnUnitBinaryBytesPerSecond, "1.5 KB/s"),
+		Entry("milliseconds", 1500, ColumnUnitMilliseconds, "1.5 s"),
+		Entry("seconds", 90, ColumnUnitSeconds, "1.5 min"),
+	)
+
+	It("publishes the canonical profile format and unit values", func() {
+		Expect(ColumnFormatValues()).To(Equal([]string{"date", "float", "duration", "bytes", "currency"}))
+		Expect(ColumnUnitValues()).To(Equal([]string{
+			"none", "short", "percent", "percentunit", "bytes", "decbytes", "Bps", "binBps", "ms", "s",
+		}))
+	})
+
+	It("applies Unit after Format", func() {
+		column := Column("ratio").Type("number").Format(FormatCurrency).Unit(ColumnUnitPercentUnit).Build()
+		Expect(ColumnString(column, 0.42)).To(Equal("42%"))
+	})
+
+	It("uses the existing scalar Format metadata", func() {
+		column := Column("amount").Type("number").Format(FormatCurrency).Build()
+		Expect(ColumnString(column, 12.5)).To(Equal("$12.50"))
+	})
+
+	It("propagates Unit into the table column schema", func() {
+		column := Column("latency").Type("number").Unit(ColumnUnitMilliseconds).Build()
+		table := NewEmptyTable([]ColumnDef{column})
+		Expect(table.Columns).To(HaveLen(1))
+		Expect(table.Columns[0].Unit).To(Equal(ColumnUnitMilliseconds))
+	})
+})

--- a/api/column_test.go
+++ b/api/column_test.go
@@ -92,6 +92,11 @@ var _ = Describe("Column", func() {
 		})
 	})
 
+	It("binds a server filter key through the column builder", func() {
+		column := Column("status").FilterKey("filter.status").Build()
+		Expect(column.FilterKey).To(Equal("filter.status"))
+	})
+
 	Describe("NewTableFrom", func() {
 		It("emits header-only table (schema, no rows) from empty slice", func() {
 			table := NewTableFrom([]mockEmployee{})

--- a/api/column_value.go
+++ b/api/column_value.go
@@ -40,12 +40,15 @@ func ColumnTextable(column ColumnDef, value any) Textable {
 			}
 		}
 	}
+	if formatted, ok := formatColumnScalar(column, value); ok {
+		return formatted
+	}
 	return convertToTextable(value)
 }
 
-// ColumnString returns the deterministic scalar representation used by CSV,
-// Markdown, and spreadsheet exports. Structured JSON/YAML exporters should
-// continue to encode the original raw value.
+// ColumnString returns the deterministic presentation value used by text
+// exports such as CSV and Markdown. Structured JSON/YAML and numeric spreadsheet
+// exporters should continue to encode the original raw value.
 func ColumnString(column ColumnDef, value any) string {
 	switch column.Type {
 	case ColumnTypeKeyValue, ColumnTypeKeyValues:
@@ -63,7 +66,7 @@ func ColumnString(column ColumnDef, value any) string {
 			}
 		}
 	}
-	return convertToTextable(value).String()
+	return ColumnTextable(column, value).String()
 }
 
 func normalizeKeyValuePairs(value any) ([]KeyValuePair, bool) {

--- a/api/constants.go
+++ b/api/constants.go
@@ -32,6 +32,20 @@ const (
 	FormatPretty   = "pretty"
 )
 
+// Grafana-compatible column display units.
+const (
+	ColumnUnitNone                 = "none"
+	ColumnUnitShort                = "short"
+	ColumnUnitPercent              = "percent"
+	ColumnUnitPercentUnit          = "percentunit"
+	ColumnUnitBytes                = "bytes"
+	ColumnUnitDecimalBytes         = "decbytes"
+	ColumnUnitBytesPerSecond       = "Bps"
+	ColumnUnitBinaryBytesPerSecond = "binBps"
+	ColumnUnitMilliseconds         = "ms"
+	ColumnUnitSeconds              = "s"
+)
+
 // Common strings
 const (
 	EmptyValue     = "(empty)"

--- a/api/meta.go
+++ b/api/meta.go
@@ -24,18 +24,27 @@ import (
 // already-rendered text (ANSI or plain): a line counts as blank when its
 // ANSI-stripped, space-trimmed form is empty.
 func normalizeTreeLabel(s string) string {
-	if !strings.Contains(s, "\n") {
-		return s
-	}
+	return normalizeTreeLabelWidth(s, GetTerminalWidth())
+}
+
+func normalizeTreeLabelWidth(s string, width int) string {
 	lines := strings.Split(s, "\n")
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
 		if strings.TrimSpace(ansi.Strip(line)) == "" {
 			continue
 		}
-		out = append(out, strings.TrimRight(line, " \t"))
+		out = append(out, ansi.Truncate(strings.TrimRight(line, " \t"), width, "…"))
 	}
 	return strings.Join(out, "\n")
+}
+
+func trimTreePadding(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // Interface types for reflection-based slice checking
@@ -293,7 +302,7 @@ func (tt TextTree) Visit(visitor VisitorFunc) bool {
 }
 
 // buildLipglossTree converts a TextTree to a lipgloss tree
-func (tt TextTree) buildLipglossTree(withColors bool) *lipglosstree.Tree {
+func (tt TextTree) buildLipglossTree(withColors bool, depth int) *lipglosstree.Tree {
 	// Build the node label
 	var nodeLabel string
 	if tt.Node != nil {
@@ -302,12 +311,13 @@ func (tt TextTree) buildLipglossTree(withColors bool) *lipglosstree.Tree {
 		} else {
 			nodeLabel = tt.Node.String()
 		}
-		nodeLabel = normalizeTreeLabel(nodeLabel)
+		width := max(1, GetTerminalWidth()-depth*4-2)
+		nodeLabel = normalizeTreeLabelWidth(nodeLabel, width)
 	}
 
 	// If we have no node and only one child, return the child tree directly
 	if nodeLabel == "" && len(tt.Children) == 1 {
-		return tt.Children[0].buildLipglossTree(withColors)
+		return tt.Children[0].buildLipglossTree(withColors, depth)
 	}
 
 	// If we have no node and multiple children, we need to create a wrapper
@@ -316,7 +326,7 @@ func (tt TextTree) buildLipglossTree(withColors bool) *lipglosstree.Tree {
 
 	// Add children
 	for _, child := range tt.Children {
-		childTree := child.buildLipglossTree(withColors)
+		childTree := child.buildLipglossTree(withColors, depth+1)
 		if childTree != nil {
 			t = t.Child(childTree)
 		}
@@ -330,7 +340,7 @@ func (tt TextTree) String() string {
 		return ""
 	}
 
-	t := tt.buildLipglossTree(false)
+	t := tt.buildLipglossTree(false, 0)
 	if t == nil {
 		return ""
 	}
@@ -338,7 +348,7 @@ func (tt TextTree) String() string {
 	// Use rounded enumerator
 	t = t.Enumerator(lipglosstree.RoundedEnumerator)
 
-	return t.String()
+	return trimTreePadding(t.String())
 }
 
 func (tt TextTree) HTML() string {
@@ -357,7 +367,7 @@ func (tt TextTree) ANSI() string {
 		return ""
 	}
 
-	t := tt.buildLipglossTree(true)
+	t := tt.buildLipglossTree(true, 0)
 	if t == nil {
 		return ""
 	}
@@ -365,7 +375,7 @@ func (tt TextTree) ANSI() string {
 	// Use rounded enumerator
 	t = t.Enumerator(lipglosstree.RoundedEnumerator)
 
-	return t.String()
+	return trimTreePadding(t.String())
 }
 
 func (tt TextTree) Markdown() string {
@@ -409,15 +419,18 @@ type FieldMeta struct {
 }
 
 type TypedValue struct {
-	Textable   Textable
-	Slice      *TextList
-	Map        *TextMap
-	TypedMap   *TypedMap
-	TypedList  *TypedList
-	Table      *TextTable
-	Tree       *TextTree
-	IsCircular bool
-	FieldMeta  *FieldMeta // Metadata for rendering hints
+	Textable    Textable
+	// FilterValue preserves a filterable table cell's raw scalar independently
+	// from its formatted Textable representation.
+	FilterValue any
+	Slice       *TextList
+	Map         *TextMap
+	TypedMap    *TypedMap
+	TypedList   *TypedList
+	Table       *TextTable
+	Tree        *TextTree
+	IsCircular  bool
+	FieldMeta   *FieldMeta // Metadata for rendering hints
 }
 
 type VisitorFunc func(TypedValue) bool

--- a/api/types.go
+++ b/api/types.go
@@ -55,6 +55,8 @@ type PrettyField struct {
 	Kind          string            `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Type          string            `json:"type,omitempty" yaml:"type,omitempty"`
 	Format        string            `json:"format,omitempty" yaml:"format,omitempty"`
+	Unit          string            `json:"unit,omitempty" yaml:"unit,omitempty"`
+	FilterKey     string            `json:"filterKey,omitempty" yaml:"filterKey,omitempty"`
 	Label         string            `json:"label,omitempty" yaml:"label,omitempty"`
 	Default       string            `json:"default,omitempty" yaml:"default,omitempty"`
 	Style         string            `json:"style,omitempty" yaml:"style,omitempty"`

--- a/entity/admin_entity_test.go
+++ b/entity/admin_entity_test.go
@@ -1,0 +1,123 @@
+package entity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type adminCtxKey struct{}
+
+// adminEntityInfo returns the registered IsAdmin sub-entity with the given name.
+func adminEntityInfo(t *testing.T, name string) EntityInfo {
+	t.Helper()
+	for _, info := range GetEntities() {
+		if info.IsAdmin && info.Name == name {
+			return info
+		}
+	}
+	t.Fatalf("no admin entity registered under %q", name)
+	return EntityInfo{}
+}
+
+func operationByVerb(t *testing.T, info EntityInfo, verb string) EntityOperation {
+	t.Helper()
+	for _, op := range info.Operations {
+		if op.Verb == verb {
+			return op
+		}
+	}
+	t.Fatalf("admin entity %q has no %q operation (has %d operations)", info.Name, verb, len(info.Operations))
+	return EntityOperation{}
+}
+
+// TestAdminEntityRegistersContextOperations covers the context-aware variants on
+// an Admin sub-entity. Request-scoped callers (an HTTP server resolving a
+// per-request DB handle off the context) can only declare GetWithContext /
+// ListWithContext; when RegisterEntity ignored those the admin group registered
+// zero operations, so both the CLI subcommand and its generated HTTP route
+// silently disappeared.
+func TestAdminEntityRegistersContextOperations(t *testing.T) {
+	resetEntityRegistry(t)
+	defer resetEntityRegistry(t)
+
+	const marker = "request-scoped"
+	RegisterEntity(Entity[nestedTestEntity, nestedTestOpts, nestedTestEntity]{
+		Name: "activity",
+		List: func(_ nestedTestOpts) ([]nestedTestEntity, error) { return nil, nil },
+		Admin: &Entity[nestedTestEntity, nestedTestOpts, nestedTestEntity]{
+			ListWithContext: func(ctx context.Context, _ nestedTestOpts) ([]nestedTestEntity, error) {
+				return []nestedTestEntity{{ID: "l1", Name: ctx.Value(adminCtxKey{}).(string)}}, nil
+			},
+			GetWithContext: func(ctx context.Context, id string) (nestedTestEntity, error) {
+				return nestedTestEntity{ID: id, Name: ctx.Value(adminCtxKey{}).(string)}, nil
+			},
+		},
+	})
+
+	info := adminEntityInfo(t, "activity")
+	ctx := context.WithValue(context.Background(), adminCtxKey{}, marker)
+
+	get := operationByVerb(t, info, "get")
+	if get.ContextDataFunc == nil {
+		t.Fatal("admin get operation has no ContextDataFunc")
+	}
+	got, err := get.ContextDataFunc(ctx, map[string]string{}, []string{"a-guid"})
+	if err != nil {
+		t.Fatalf("admin get: %v", err)
+	}
+	item, ok := got.(nestedTestEntity)
+	if !ok {
+		t.Fatalf("admin get returned %T, want nestedTestEntity", got)
+	}
+	if item.ID != "a-guid" || item.Name != marker {
+		t.Errorf("admin get returned %+v, want the positional id and the context value %q", item, marker)
+	}
+
+	list := operationByVerb(t, info, "list")
+	if list.ContextDataFunc == nil {
+		t.Fatal("admin list operation has no ContextDataFunc")
+	}
+	if _, err = list.ContextDataFunc(ctx, map[string]string{}, nil); err != nil {
+		t.Fatalf("admin list: %v", err)
+	}
+
+	root := &cobra.Command{Use: "root"}
+	GenerateCLI(root)
+	for _, path := range [][]string{{"admin", "activity", "get"}, {"admin", "activity", "list"}} {
+		cmd, _, err := root.Find(path)
+		if err != nil || cmd == nil || cmd.Name() != path[len(path)-1] {
+			t.Errorf("expected %v subcommand, got %v err=%v", path, cmd, err)
+		}
+	}
+}
+
+// TestAdminEntityGetWithFlagsAndContext asserts the flags+context get variant
+// also survives registration, and that the flag map reaches the handler.
+func TestAdminEntityGetWithFlagsAndContext(t *testing.T) {
+	resetEntityRegistry(t)
+	defer resetEntityRegistry(t)
+
+	RegisterEntity(Entity[nestedTestEntity, nestedTestOpts, nestedTestEntity]{
+		Name: "activity",
+		List: func(_ nestedTestOpts) ([]nestedTestEntity, error) { return nil, nil },
+		Admin: &Entity[nestedTestEntity, nestedTestOpts, nestedTestEntity]{
+			GetWithFlagsAndContext: func(_ context.Context, id string, flags map[string]string) (nestedTestEntity, error) {
+				return nestedTestEntity{ID: id, Name: flags["trace"]}, nil
+			},
+		},
+	})
+
+	get := operationByVerb(t, adminEntityInfo(t, "activity"), "get")
+	if get.ContextDataFunc == nil {
+		t.Fatal("admin get operation has no ContextDataFunc")
+	}
+	got, err := get.ContextDataFunc(context.Background(), map[string]string{"id": "b-guid", "trace": "on"}, nil)
+	if err != nil {
+		t.Fatalf("admin get: %v", err)
+	}
+	if item := got.(nestedTestEntity); item.ID != "b-guid" || item.Name != "on" {
+		t.Errorf("admin get returned %+v, want id b-guid and trace flag on", item)
+	}
+}

--- a/entity/dynamic.go
+++ b/entity/dynamic.go
@@ -19,10 +19,18 @@ type DynamicGetFunc func(ctx context.Context, id string) (map[string]any, error)
 // RegisterDynamicEntity. Filters referenced by x-clicky-filter must be
 // registered (RegisterFilter / RegisterFilterSpec) before Register is called.
 type DynamicEntityBuilder struct {
-	name   string
-	schema []byte
-	listFn DynamicListFunc
-	getFn  DynamicGetFunc
+	name    string
+	schema  []byte
+	listFn  DynamicListFunc
+	getFn   DynamicGetFunc
+	filters []builderFilter
+}
+
+// builderFilter binds a named filter to a request key that no schema property
+// declares.
+type builderFilter struct {
+	key  string
+	name string
 }
 
 // NewDynamicEntity starts building a dynamic entity from a JSON schema.
@@ -37,6 +45,18 @@ func (b *DynamicEntityBuilder) List(fn DynamicListFunc) *DynamicEntityBuilder {
 
 func (b *DynamicEntityBuilder) Get(fn DynamicGetFunc) *DynamicEntityBuilder {
 	b.getFn = fn
+	return b
+}
+
+// Filter offers the registered filter filterName under key, for an input the
+// rows do not carry — a query parameter, say — and so has no schema property to
+// hang x-clicky-filter on. Schema-declared filters need no such call.
+//
+// The key is what the request sends and what the lookup response is keyed by.
+// A value supplied for it reaches the filter's source as sibling context even
+// though it is not a declared operation parameter.
+func (b *DynamicEntityBuilder) Filter(key, filterName string) *DynamicEntityBuilder {
+	b.filters = append(b.filters, builderFilter{key: key, name: filterName})
 	return b
 }
 
@@ -77,14 +97,15 @@ func (b *DynamicEntityBuilder) Register() {
 func (b *DynamicEntityBuilder) buildFilters(ps *parsedSchema) ([]DynamicFilter, map[string]string) {
 	var filters []DynamicFilter
 	refs := map[string]string{}
-	for _, f := range ps.Fields {
-		if f.Filter == "" {
-			continue
+	bind := func(key, filterName, label string, multi bool) {
+		if key == "" {
+			panic(fmt.Sprintf("entity.NewDynamicEntity(%q): filter %q has no key", b.name, filterName))
 		}
-		nf := MustGetFilter(f.Filter)
-		key := f.Name
+		if _, taken := refs[key]; taken {
+			panic(fmt.Sprintf("entity.NewDynamicEntity(%q): filter key %q is declared twice", b.name, key))
+		}
+		nf := MustGetFilter(filterName)
 		source := nf.Source
-		label := f.Label
 		if label == "" {
 			label = nf.label()
 		}
@@ -92,33 +113,45 @@ func (b *DynamicEntityBuilder) buildFilters(ps *parsedSchema) ([]DynamicFilter, 
 			Key:        key,
 			Label:      label,
 			Type:       nf.Type,
-			Multi:      nf.Multi || f.isArray(),
+			Multi:      nf.Multi || multi,
 			Searchable: true,
-			Options: func(ctx context.Context, flags map[string]string, query string, limit int) (map[string]api.Textable, int) {
-				options, total, err := source.Options(FilterContext{Context: ctx, Key: key, Params: flags}, query, limit)
-				if err != nil {
-					return nil, 0
-				}
-				return options, total
+			Options: func(ctx context.Context, flags map[string]string, query string, limit int) (map[string]api.Textable, int, error) {
+				return source.Options(FilterContext{Context: ctx, Key: key, Params: flags}, query, limit)
 			},
-			Selected: func(ctx context.Context, flags map[string]string) map[string]api.Textable {
-				values := splitValues(flags[key])
+			Selected: func(ctx context.Context, flags map[string]string) (map[string]api.Textable, error) {
+				values := filterValuesWithoutModes(splitValues(flags[key]))
 				if len(values) == 0 {
-					return nil
+					return nil, nil
 				}
-				selected, err := source.Resolve(FilterContext{Context: ctx, Key: key, Params: flags}, values)
-				if err != nil {
-					return nil
-				}
-				return selected
+				return source.Resolve(FilterContext{Context: ctx, Key: key, Params: flags}, values)
 			},
 		})
-		refs[key] = f.Filter
+		refs[key] = filterName
 	}
+
+	for _, f := range ps.Fields {
+		if f.Filter == "" {
+			continue
+		}
+		bind(f.FilterKey, f.Filter, f.Label, f.isArray())
+	}
+	// Explicit filters come last so a schema property always wins the key, and
+	// the clash panics rather than silently replacing the declared filter.
+	for _, f := range b.filters {
+		bind(f.key, f.name, "", false)
+	}
+
 	if len(refs) == 0 {
 		refs = nil
 	}
 	return filters, refs
+}
+
+func filterValuesWithoutModes(values []string) []string {
+	for i := range values {
+		values[i] = strings.TrimPrefix(values[i], "!")
+	}
+	return values
 }
 
 func (b *DynamicEntityBuilder) listDataFunc(ps *parsedSchema) ContextDataFunc {

--- a/entity/dynamic_spec.go
+++ b/entity/dynamic_spec.go
@@ -19,10 +19,10 @@ type DynamicFilter struct {
 	Searchable bool
 	// Options returns the head set (query == "") or search matches, plus the true
 	// total behind the head. Required.
-	Options func(ctx context.Context, flags map[string]string, query string, limit int) (map[string]api.Textable, int)
+	Options func(ctx context.Context, flags map[string]string, query string, limit int) (map[string]api.Textable, int, error)
 	// Selected labels the currently-selected value(s) of this filter's key.
 	// Optional; nil means "no selection rendering".
-	Selected func(ctx context.Context, flags map[string]string) map[string]api.Textable
+	Selected func(ctx context.Context, flags map[string]string) (map[string]api.Textable, error)
 }
 
 // DynamicEntitySpec is the type-erased description of a schema-driven entity,
@@ -30,9 +30,9 @@ type DynamicFilter struct {
 // existing pipeline: ListType drives CLI flag binding and OpenAPI parameters,
 // ItemType drives the response schema, and Filters feed the shared lookup engine.
 type DynamicEntitySpec struct {
-	Name     string
-	Parent   string
-	Aliases  []string
+	Name    string
+	Parent  string
+	Aliases []string
 	// Icon is an opaque UI icon name emitted on the surface (x-clicky.surfaces[].icon).
 	Icon string
 	// Title overrides the auto-generated surface title when non-empty.
@@ -111,17 +111,17 @@ func RegisterDynamicEntity(spec DynamicEntitySpec) {
 
 func buildDynamicContextLookup(filters []DynamicFilter) ContextLookupFunc {
 	return func(ctx context.Context, flagMap map[string]string, _ []string) (any, error) {
-		return resolveDynamicLookup(ctx, filters, flagMap), nil
+		return resolveDynamicLookup(ctx, filters, flagMap)
 	}
 }
 
 func buildDynamicLookup(filters []DynamicFilter) func(map[string]string, []string) (any, error) {
 	return func(flagMap map[string]string, _ []string) (any, error) {
-		return resolveDynamicLookup(context.Background(), filters, flagMap), nil
+		return resolveDynamicLookup(context.Background(), filters, flagMap)
 	}
 }
 
-func resolveDynamicLookup(ctx context.Context, filters []DynamicFilter, flagMap map[string]string) entityLookupResponse {
+func resolveDynamicLookup(ctx context.Context, filters []DynamicFilter, flagMap map[string]string) (entityLookupResponse, error) {
 	searchKey := flagMap[lookupFilterKeyParam]
 	searchQuery := flagMap[lookupQueryParam]
 	delete(flagMap, lookupFilterKeyParam)
@@ -132,7 +132,11 @@ func resolveDynamicLookup(ctx context.Context, filters []DynamicFilter, flagMap 
 		df := df
 		var selected map[string]api.Textable
 		if df.Selected != nil {
-			selected = df.Selected(ctx, flagMap)
+			var err error
+			selected, err = df.Selected(ctx, flagMap)
+			if err != nil {
+				return entityLookupResponse{}, err
+			}
 		}
 		bound = append(bound, boundFilter{
 			Key:        df.Key,
@@ -141,7 +145,7 @@ func resolveDynamicLookup(ctx context.Context, filters []DynamicFilter, flagMap 
 			Multi:      df.Multi,
 			Searchable: df.Searchable,
 			Selected:   selected,
-			Options: func(query string, limit int) (map[string]api.Textable, int) {
+			Options: func(query string, limit int) (map[string]api.Textable, int, error) {
 				return df.Options(ctx, flagMap, query, limit)
 			},
 		})

--- a/entity/dynamic_test.go
+++ b/entity/dynamic_test.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,7 +18,7 @@ const ticketSchema = `{
   "properties": {
     "id":     {"type": "string", "x-clicky-id": true},
     "title":  {"type": "string", "x-clicky-name": true},
-    "status": {"type": "string", "x-clicky-filter": "dyn-status", "x-clicky-label": "Status"}
+    "status": {"type": "string", "x-clicky-filter": "dyn-status", "x-clicky-filter-key": "filter.status", "x-clicky-label": "Status"}
   }
 }`
 
@@ -66,7 +67,7 @@ var _ = Describe("parseSchema", func() {
 		Expect(err).ToNot(HaveOccurred())
 		lt := ps.listType()
 		Expect(lt.NumField()).To(Equal(1))
-		Expect(lt.Field(0).Tag.Get("flag")).To(Equal("status"))
+		Expect(lt.Field(0).Tag.Get("flag")).To(Equal("filter.status"))
 	})
 })
 
@@ -99,7 +100,7 @@ var _ = Describe("Dynamic entity registration", func() {
 		listCmd, _, err := root.Find([]string{"dyn-tickets", "list"})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listCmd).ToNot(BeNil())
-		Expect(listCmd.Flags().Lookup("status")).ToNot(BeNil(), "the filter property becomes a CLI flag")
+		Expect(listCmd.Flags().Lookup("filter.status")).ToNot(BeNil(), "the bound filter key becomes a CLI flag")
 
 		// List returns rows wrapped with an injected _id.
 		dataFunc := GetContextDataFunc(listCmd)
@@ -119,7 +120,22 @@ var _ = Describe("Dynamic entity registration", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(lookupJSON)).To(ContainSubstring("Open"))
 		Expect(string(lookupJSON)).To(ContainSubstring("Closed"))
-		Expect(string(lookupJSON)).To(ContainSubstring(`"status"`))
+		Expect(string(lookupJSON)).To(ContainSubstring(`"filter.status"`))
+	})
+
+	It("propagates named-filter lookup failures", func() {
+		RegisterFilter(NamedFilter{Name: "dyn-error", Source: errorFilterSource{}})
+		schema := []byte(`{"properties":{"id":{"type":"string","x-clicky-id":true},"value":{"type":"string","x-clicky-filter":"dyn-error"}}}`)
+		NewDynamicEntity("dyn-errors", schema).
+			List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+			Register()
+
+		root := &cobra.Command{Use: "root"}
+		GenerateCLI(root)
+		listCmd, _, err := root.Find([]string{"dyn-errors", "list"})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = GetLookupFunc(listCmd)(map[string]string{}, nil)
+		Expect(err).To(MatchError("lookup unavailable"))
 	})
 
 	It("shares one named filter between a dynamic and a static entity", func() {
@@ -140,13 +156,109 @@ var _ = Describe("Dynamic entity registration", func() {
 		staticOptions := lookupOptionsJSON(root, "static-issues")
 		Expect(dynOptions).To(ContainSubstring("Open"))
 		Expect(staticOptions).To(ContainSubstring("Open"))
-		Expect(dynOptions).To(Equal(staticOptions), "both entities resolve the same shared filter options")
+		Expect(dynOptions).To(ContainSubstring(`"filter.status"`))
+		Expect(staticOptions).To(ContainSubstring(`"status"`))
+	})
+
+	// A caller may filter on an input the rows never carry — a query parameter,
+	// say — which has no schema property to hang x-clicky-filter on.
+	Describe("filters that are not schema properties", func() {
+		It("serves a filter bound to a key with no matching property", func() {
+			NewDynamicEntity("dyn-params", []byte(ticketSchema)).
+				List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+				Filter("region", "dyn-status").
+				Register()
+
+			root := &cobra.Command{Use: "root"}
+			GenerateCLI(root)
+
+			options := lookupOptionsJSON(root, "dyn-params")
+			Expect(options).To(ContainSubstring(`"region"`), "the explicit filter is offered")
+			Expect(options).To(ContainSubstring(`"filter.status"`), "the schema filter still is")
+			Expect(options).To(ContainSubstring("Open"))
+		})
+
+		It("carries the label and multi flag of the named filter it binds", func() {
+			RegisterFilter(NamedFilter{
+				Name: "dyn-regions", Label: "Regions", Type: "multi-filter", Multi: true,
+				Source: StaticOptions(map[string]api.Textable{"eu": api.Text{Content: "eu"}}),
+			})
+			NewDynamicEntity("dyn-labelled", []byte(ticketSchema)).
+				List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+				Filter("regions", "dyn-regions").
+				Register()
+
+			root := &cobra.Command{Use: "root"}
+			GenerateCLI(root)
+
+			Expect(lookupOptionsJSON(root, "dyn-labelled")).To(SatisfyAll(
+				ContainSubstring(`"Regions"`),
+				ContainSubstring(`"multi-filter"`),
+			))
+		})
+
+		It("resolves the selected values of an explicit filter", func() {
+			NewDynamicEntity("dyn-selected", []byte(ticketSchema)).
+				List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+				Filter("region", "dyn-status").
+				Register()
+
+			root := &cobra.Command{Use: "root"}
+			GenerateCLI(root)
+			listCmd, _, err := root.Find([]string{"dyn-selected", "list"})
+			Expect(err).ToNot(HaveOccurred())
+
+			// "!closed" is an exclusion, so the mode marker is stripped before the
+			// source is asked to label the value.
+			resp, err := GetLookupFunc(listCmd)(map[string]string{"region": "open,!closed"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			data, err := json.Marshal(resp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(data)).To(SatisfyAll(ContainSubstring("Open"), ContainSubstring("Closed")))
+		})
+
+		It("panics when an explicit filter shadows a schema filter key", func() {
+			Expect(func() {
+				NewDynamicEntity("dyn-clash", []byte(ticketSchema)).
+					List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+					Filter("filter.status", "dyn-status").
+					Register()
+			}).To(PanicWith(ContainSubstring("filter.status")))
+		})
+
+		It("panics when an explicit filter names no registered filter", func() {
+			Expect(func() {
+				NewDynamicEntity("dyn-unknown", []byte(ticketSchema)).
+					List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+					Filter("region", "never-registered").
+					Register()
+			}).To(Panic())
+		})
+
+		It("panics when an explicit filter has no key", func() {
+			Expect(func() {
+				NewDynamicEntity("dyn-keyless", []byte(ticketSchema)).
+					List(func(context.Context, map[string]string) ([]map[string]any, error) { return nil, nil }).
+					Filter("", "dyn-status").
+					Register()
+			}).To(Panic())
+		})
 	})
 })
 
 type staticIssue struct {
 	ID   string
 	Name string
+}
+
+type errorFilterSource struct{}
+
+func (errorFilterSource) Options(FilterContext, string, int) (map[string]api.Textable, int, error) {
+	return nil, 0, fmt.Errorf("lookup unavailable")
+}
+
+func (errorFilterSource) Resolve(FilterContext, []string) (map[string]api.Textable, error) {
+	return nil, nil
 }
 
 func (s staticIssue) GetID() string   { return s.ID }

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -615,6 +615,124 @@ func entityBodyExcludingID(flagMap map[string]string) map[string]any {
 	return body
 }
 
+// entityListOperation builds the "list" operation for an entity, or reports
+// false when it declares no list func. An Admin sub-entity is the same Entity
+// type, so it registers through here too — keeping one implementation is what
+// stops the admin surface from silently lagging behind the main one.
+func entityListOperation[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R]) (EntityOperation, bool) {
+	if e.ListPagedWithContext == nil && e.ListPaged == nil && e.ListWithContext == nil && e.List == nil {
+		return EntityOperation{}, false
+	}
+	op := EntityOperation{
+		Verb:              "list",
+		LookupFunc:        buildLookupFunc[ListOpts](e.Filters),
+		ContextLookupFunc: buildLookupFuncWithContext[ListOpts](e.Filters),
+		BindCompletions:   buildFilterCompletionBinder[ListOpts](e.Filters),
+		ResponseType:      reflect.TypeOf((*T)(nil)).Elem(),
+		ResponseArray:     true,
+		ResponseEntityID:  true,
+	}
+	switch {
+	case e.ListPagedWithContext != nil:
+		op.ResponsePaged = true
+		op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
+			opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
+			if err != nil {
+				return nil, err
+			}
+			page, err := e.ListPagedWithContext(ctx, opts)
+			if err != nil {
+				return nil, err
+			}
+			return NewPagedResult(withEntityIDs(page.Data), page.Page.Limit, page.Page.Offset, page.Page.Total), nil
+		}
+	case e.ListPaged != nil:
+		op.ResponsePaged = true
+		op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
+			opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
+			if err != nil {
+				return nil, err
+			}
+			page, err := e.ListPaged(opts)
+			if err != nil {
+				return nil, err
+			}
+			return NewPagedResult(withEntityIDs(page.Data), page.Page.Limit, page.Page.Offset, page.Page.Total), nil
+		}
+	case e.ListWithContext != nil:
+		op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
+			opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
+			if err != nil {
+				return nil, err
+			}
+			items, err := e.ListWithContext(ctx, opts)
+			if err != nil {
+				return nil, err
+			}
+			return withEntityIDs(items), nil
+		}
+	default:
+		op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
+			opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
+			if err != nil {
+				return nil, err
+			}
+			items, err := e.List(opts)
+			if err != nil {
+				return nil, err
+			}
+			return withEntityIDs(items), nil
+		}
+	}
+	return op, true
+}
+
+// entityGetOperation builds the "get" operation for an entity, or reports false
+// when it declares no get func. Shared with Admin sub-entities — see
+// entityListOperation.
+func entityGetOperation[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R]) (EntityOperation, bool) {
+	op := EntityOperation{Verb: "get", ResponseType: responseTypeOf[R]()}
+	switch {
+	case e.GetWithFlagsAndContext != nil:
+		op.FlagsType = actionFlagsType(e.GetFlags)
+		op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
+			id, err := entityIDFrom(flagMap, args)
+			if err != nil {
+				return nil, err
+			}
+			return e.GetWithFlagsAndContext(ctx, id, flagMap)
+		}
+	case e.GetWithFlags != nil:
+		op.FlagsType = actionFlagsType(e.GetFlags)
+		op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
+			id, err := entityIDFrom(flagMap, args)
+			if err != nil {
+				return nil, err
+			}
+			return e.GetWithFlags(id, flagMap)
+		}
+	case e.GetWithContext != nil:
+		op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
+			id, err := entityIDFrom(flagMap, args)
+			if err != nil {
+				return nil, err
+			}
+			return e.GetWithContext(ctx, id)
+		}
+	case e.Get != nil:
+		op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
+			id, err := entityIDFrom(flagMap, args)
+			if err != nil {
+				return nil, err
+			}
+			return e.Get(id)
+		}
+	default:
+		return EntityOperation{}, false
+	}
+	return op, true
+}
+
 // RegisterEntity registers a CRUD entity. Call during init().
 // CLI commands and HTTP routes are generated later via GenerateCLI/GenerateRoutes.
 //
@@ -644,122 +762,11 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 		info.ToolGroup = info.ToolHints.Group
 	}
 
-	if e.ListPagedWithContext != nil || e.ListPaged != nil || e.ListWithContext != nil || e.List != nil {
-		op := EntityOperation{
-			Verb:              "list",
-			LookupFunc:        buildLookupFunc[ListOpts](e.Filters),
-			ContextLookupFunc: buildLookupFuncWithContext[ListOpts](e.Filters),
-			BindCompletions:   buildFilterCompletionBinder[ListOpts](e.Filters),
-			ResponseType:      reflect.TypeOf((*T)(nil)).Elem(),
-			ResponseArray:     true,
-			ResponseEntityID:  true,
-		}
-		switch {
-		case e.ListPagedWithContext != nil:
-			op.ResponsePaged = true
-			op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
-				opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
-				if err != nil {
-					return nil, err
-				}
-				page, err := e.ListPagedWithContext(ctx, opts)
-				if err != nil {
-					return nil, err
-				}
-				return NewPagedResult(withEntityIDs(page.Data), page.Page.Limit, page.Page.Offset, page.Page.Total), nil
-			}
-		case e.ListPaged != nil:
-			op.ResponsePaged = true
-			op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
-				opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
-				if err != nil {
-					return nil, err
-				}
-				page, err := e.ListPaged(opts)
-				if err != nil {
-					return nil, err
-				}
-				return NewPagedResult(withEntityIDs(page.Data), page.Page.Limit, page.Page.Offset, page.Page.Total), nil
-			}
-		case e.ListWithContext != nil:
-			op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
-				opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
-				if err != nil {
-					return nil, err
-				}
-				items, err := e.ListWithContext(ctx, opts)
-				if err != nil {
-					return nil, err
-				}
-				return withEntityIDs(items), nil
-			}
-		default:
-			op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
-				opts, err := resolveEntityOpts[ListOpts](flagMap, e.Filters)
-				if err != nil {
-					return nil, err
-				}
-				items, err := e.List(opts)
-				if err != nil {
-					return nil, err
-				}
-				return withEntityIDs(items), nil
-			}
-		}
+	if op, ok := entityListOperation(e); ok {
 		info.Operations = append(info.Operations, op)
 	}
-
-	switch {
-	case e.GetWithFlagsAndContext != nil:
-		info.Operations = append(info.Operations, EntityOperation{
-			Verb:         "get",
-			FlagsType:    actionFlagsType(e.GetFlags),
-			ResponseType: responseTypeOf[R](),
-			ContextDataFunc: func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
-				id, err := entityIDFrom(flagMap, args)
-				if err != nil {
-					return nil, err
-				}
-				return e.GetWithFlagsAndContext(ctx, id, flagMap)
-			},
-		})
-	case e.GetWithFlags != nil:
-		info.Operations = append(info.Operations, EntityOperation{
-			Verb:         "get",
-			FlagsType:    actionFlagsType(e.GetFlags),
-			ResponseType: responseTypeOf[R](),
-			DataFunc: func(flagMap map[string]string, args []string) (any, error) {
-				id, err := entityIDFrom(flagMap, args)
-				if err != nil {
-					return nil, err
-				}
-				return e.GetWithFlags(id, flagMap)
-			},
-		})
-	case e.GetWithContext != nil:
-		info.Operations = append(info.Operations, EntityOperation{
-			Verb:         "get",
-			ResponseType: responseTypeOf[R](),
-			ContextDataFunc: func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
-				id, err := entityIDFrom(flagMap, args)
-				if err != nil {
-					return nil, err
-				}
-				return e.GetWithContext(ctx, id)
-			},
-		})
-	case e.Get != nil:
-		info.Operations = append(info.Operations, EntityOperation{
-			Verb:         "get",
-			ResponseType: responseTypeOf[R](),
-			DataFunc: func(flagMap map[string]string, args []string) (any, error) {
-				id, err := entityIDFrom(flagMap, args)
-				if err != nil {
-					return nil, err
-				}
-				return e.Get(id)
-			},
-		})
+	if op, ok := entityGetOperation(e); ok {
+		info.Operations = append(info.Operations, op)
 	}
 
 	if e.CreateWithContext != nil || e.Create != nil {
@@ -863,59 +870,11 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 			ValidArgs: adminValidArgs,
 			IsAdmin:   true,
 		}
-		if admin.List != nil {
-			adminInfo.Operations = append(adminInfo.Operations, EntityOperation{
-				Verb: "list",
-				DataFunc: func(flagMap map[string]string, args []string) (any, error) {
-					opts, err := resolveEntityOpts[ListOpts](flagMap, admin.Filters)
-					if err != nil {
-						return nil, err
-					}
-					items, err := admin.List(opts)
-					if err != nil {
-						return nil, err
-					}
-					return withEntityIDs(items), nil
-				},
-				LookupFunc:        buildLookupFunc[ListOpts](admin.Filters),
-				ContextLookupFunc: buildLookupFuncWithContext[ListOpts](admin.Filters),
-				BindCompletions:   buildFilterCompletionBinder[ListOpts](admin.Filters),
-				ResponseType:      reflect.TypeOf((*T)(nil)).Elem(),
-				ResponseArray:     true,
-				ResponseEntityID:  true,
-			})
+		if op, ok := entityListOperation(admin); ok {
+			adminInfo.Operations = append(adminInfo.Operations, op)
 		}
-		if admin.GetWithFlags != nil {
-			adminInfo.Operations = append(adminInfo.Operations, EntityOperation{
-				Verb:         "get",
-				FlagsType:    actionFlagsType(admin.GetFlags),
-				ResponseType: responseTypeOf[R](),
-				DataFunc: func(flagMap map[string]string, args []string) (any, error) {
-					id := flagMap["id"]
-					if id == "" && len(args) > 0 {
-						id = args[0]
-					}
-					if id == "" {
-						return nil, fmt.Errorf("id is required")
-					}
-					return admin.GetWithFlags(id, flagMap)
-				},
-			})
-		} else if admin.Get != nil {
-			adminInfo.Operations = append(adminInfo.Operations, EntityOperation{
-				Verb:         "get",
-				ResponseType: responseTypeOf[R](),
-				DataFunc: func(flagMap map[string]string, args []string) (any, error) {
-					id := flagMap["id"]
-					if id == "" && len(args) > 0 {
-						id = args[0]
-					}
-					if id == "" {
-						return nil, fmt.Errorf("id is required")
-					}
-					return admin.Get(id)
-				},
-			})
+		if op, ok := entityGetOperation(admin); ok {
+			adminInfo.Operations = append(adminInfo.Operations, op)
 		}
 		for _, action := range admin.Actions {
 			if action == nil {
@@ -1620,13 +1579,13 @@ type boundFilter struct {
 	Selected   map[string]api.Textable
 	// Options returns the head set (query == "") or search matches, plus the true
 	// total behind the head. A non-positive limit means "no cap".
-	Options func(query string, limit int) (map[string]api.Textable, int)
+	Options func(query string, limit int) (map[string]api.Textable, int, error)
 }
 
 // resolveLookupCore renders bound filters into the lookup response, applying the
 // searchable head/search/total logic uniformly. It is the single place the
 // lookup wire shape is built, shared by the typed and dynamic entity paths.
-func resolveLookupCore(filters []boundFilter, searchKey, searchQuery string) entityLookupResponse {
+func resolveLookupCore(filters []boundFilter, searchKey, searchQuery string) (entityLookupResponse, error) {
 	response := entityLookupResponse{
 		Filters: make(map[string]entityLookupFilter, len(filters)),
 	}
@@ -1640,22 +1599,31 @@ func resolveLookupCore(filters []boundFilter, searchKey, searchQuery string) ent
 		switch {
 		case f.Searchable && searchKey == f.Key && searchQuery != "":
 			// Targeted server-side search: return matches for this filter only.
-			options, _ := f.Options(searchQuery, lookupOptionsLimit)
+			options, _, err := f.Options(searchQuery, lookupOptionsLimit)
+			if err != nil {
+				return entityLookupResponse{}, err
+			}
 			entry.Options = toClickyNodeMap(options)
 		case f.Searchable:
 			// Head request: first N options plus the true distinct total so
 			// the UI can show "… and N more" and decide whether to search.
-			options, total := f.Options("", lookupOptionsLimit)
+			options, total, err := f.Options("", lookupOptionsLimit)
+			if err != nil {
+				return entityLookupResponse{}, err
+			}
 			entry.Options = toClickyNodeMap(options)
 			entry.Total = total
 			entry.Truncated = total > len(options)
 		default:
-			options, _ := f.Options("", 0)
+			options, _, err := f.Options("", 0)
+			if err != nil {
+				return entityLookupResponse{}, err
+			}
 			entry.Options = toClickyNodeMap(options)
 		}
 		response.Filters[f.Key] = entry
 	}
-	return response
+	return response, nil
 }
 
 func resolveLookup[T any](
@@ -1698,17 +1666,18 @@ func resolveLookup[T any](
 			Multi:      meta.Multi,
 			Searchable: searchable,
 			Selected:   selected[f.Key()],
-			Options: func(query string, limit int) (map[string]api.Textable, int) {
+			Options: func(query string, limit int) (map[string]api.Textable, int, error) {
 				if searchable {
-					return filterOptionsWithQuery(ctx, f, opts, query, limit)
+					options, total := filterOptionsWithQuery(ctx, f, opts, query, limit)
+					return options, total, nil
 				}
 				options := filterOptions(ctx, f, opts)
-				return options, len(options)
+				return options, len(options), nil
 			},
 		})
 	}
 
-	return resolveLookupCore(bound, searchKey, searchQuery), nil
+	return resolveLookupCore(bound, searchKey, searchQuery)
 }
 
 // filterIsSearchable reports whether filter exposes a head/search option set,

--- a/entity/schema.go
+++ b/entity/schema.go
@@ -30,6 +30,7 @@ type schemaProperty struct {
 	IsID        bool            `json:"x-clicky-id"`
 	IsName      bool            `json:"x-clicky-name"`
 	Filter      string          `json:"x-clicky-filter"`
+	FilterKey   string          `json:"x-clicky-filter-key"`
 	Label       string          `json:"x-clicky-label"`
 	PrettyFmt   string          `json:"x-clicky-format"`
 	Short       bool            `json:"x-clicky-short"`
@@ -46,6 +47,7 @@ type schemaField struct {
 	PrettyFmt string
 	Short     bool
 	Filter    string // referenced named filter; "" => not filterable
+	FilterKey string // bound CLI/query parameter; defaults to Name
 }
 
 func (f schemaField) isArray() bool { return f.JSONType == "array" }
@@ -99,9 +101,13 @@ func parseSchema(raw []byte) (*parsedSchema, error) {
 			PrettyFmt: p.PrettyFmt,
 			Short:     p.Short,
 			Filter:    p.Filter,
+			FilterKey: p.FilterKey,
 		}
 		if p.Items != nil {
 			field.ItemType = p.Items.Type
+		}
+		if field.Filter != "" && field.FilterKey == "" {
+			field.FilterKey = name
 		}
 		if p.IsID {
 			if ps.IDKey != "" {
@@ -142,7 +148,7 @@ func (ps *parsedSchema) listType() reflect.Type {
 		fields = append(fields, reflect.StructField{
 			Name: f.GoName,
 			Type: fieldType,
-			Tag:  reflect.StructTag(fmt.Sprintf("flag:%q json:%q", f.Name, f.Name)),
+			Tag:  reflect.StructTag(fmt.Sprintf("flag:%q json:%q", f.FilterKey, f.FilterKey)),
 		})
 	}
 	return reflect.StructOf(fields)

--- a/examples/enitity/go.mod
+++ b/examples/enitity/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/flanksource/captain v0.0.20
-	github.com/flanksource/clicky v1.21.52
+	github.com/flanksource/clicky v1.21.53
 	github.com/flanksource/clicky/aichat v1.21.49
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/format.go
+++ b/format.go
@@ -33,9 +33,9 @@ var (
 // }
 
 // logWriter is the destination for clicky.Infof / Errorf / Warnf / SQL etc.
-// task.GatedStderr drops writes while the interactive renderer owns the
-// TTY so log lines cannot land mid-frame and break ClearLines accounting.
-// Off-renderer it forwards straight to os.Stderr.
+// task.GatedStderr buffers writes while the interactive renderer owns the
+// TTY (so log lines cannot land mid-frame) and flushes them right after
+// the renderer lets go. Off-renderer it forwards straight to os.Stderr.
 var logWriter = text.LineFilter(task.GatedStderr(), text.RedactSecrets()).(io.StringWriter)
 
 func RedactSecretValues(val ...string) {

--- a/formatters/column_format_ginkgo_test.go
+++ b/formatters/column_format_ginkgo_test.go
@@ -1,0 +1,74 @@
+package formatters
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+
+	"github.com/flanksource/clicky/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/xuri/excelize/v2"
+)
+
+type percentageTableRow struct {
+	Ratio float64
+}
+
+func (r percentageTableRow) Columns() []api.ColumnDef {
+	return []api.ColumnDef{{
+		Name: "ratio", Type: "number", Format: api.FormatFloat, Unit: api.ColumnUnitPercentUnit,
+		FilterKey: "filter.ratio",
+	}}
+}
+
+func (r percentageTableRow) Row() map[string]any {
+	return map[string]any{"ratio": r.Ratio}
+}
+
+var _ = Describe("Column format serialization", func() {
+	It("includes raw filter values while keeping rendered cells formatted", func() {
+		table := api.NewTableFrom([]percentageTableRow{{Ratio: 0.42}})
+
+		output, err := (&ClickyJSONFormatter{}).Format(table, FormatOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var document ClickyDocument
+		Expect(json.Unmarshal([]byte(output), &document)).To(Succeed())
+		Expect(document.Node.Columns).To(HaveLen(1))
+		Expect(document.Node.Columns[0].Format).To(Equal(api.FormatFloat))
+		Expect(document.Node.Columns[0].Unit).To(Equal(api.ColumnUnitPercentUnit))
+		Expect(document.Node.Rows[0].Cells["ratio"].Plain).To(Equal("42%"))
+		Expect(document.Node.Rows[0].Cells["ratio"].FilterValue).To(Equal(0.42))
+	})
+
+	It("formats text exports but preserves raw JSON and Excel values", func() {
+		columns := []api.ColumnDef{{Name: "ratio", Type: "number", Unit: api.ColumnUnitPercentUnit}}
+		rows := []map[string]any{{"ratio": 0.42}}
+
+		var csvOutput bytes.Buffer
+		_, err := WriteTableStream(context.Background(), &csvOutput, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "csv"})
+		Expect(err).NotTo(HaveOccurred())
+		records, err := csv.NewReader(strings.NewReader(csvOutput.String())).ReadAll()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(records[1][0]).To(Equal("42%"))
+
+		var jsonOutput bytes.Buffer
+		_, err = WriteTableStream(context.Background(), &jsonOutput, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "json"})
+		Expect(err).NotTo(HaveOccurred())
+		var decoded []map[string]any
+		Expect(json.Unmarshal(jsonOutput.Bytes(), &decoded)).To(Succeed())
+		Expect(decoded[0]["ratio"]).To(Equal(0.42))
+
+		var excelOutput bytes.Buffer
+		_, err = WriteTableStream(context.Background(), &excelOutput, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "excel"})
+		Expect(err).NotTo(HaveOccurred())
+		book, err := excelize.OpenReader(bytes.NewReader(excelOutput.Bytes()))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(book.Close)
+		value, err := book.GetCellValue("Sheet1", "A2")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(value).To(Equal("0.42"))
+	})
+})

--- a/formatters/html_react_formatter.go
+++ b/formatters/html_react_formatter.go
@@ -67,12 +67,15 @@ type ClickyField struct {
 }
 
 type ClickyColumn struct {
-	Name   string      `json:"name"`
-	Label  string      `json:"label,omitempty"`
-	Kind   string      `json:"kind,omitempty"`
-	Type   string      `json:"type,omitempty"`
-	Header *ClickyNode `json:"header,omitempty"`
-	Align  string      `json:"align,omitempty"`
+	Name      string      `json:"name"`
+	Label     string      `json:"label,omitempty"`
+	Kind      string      `json:"kind,omitempty"`
+	Type      string      `json:"type,omitempty"`
+	Format    string      `json:"format,omitempty"`
+	Unit      string      `json:"unit,omitempty"`
+	FilterKey string      `json:"filterKey,omitempty"`
+	Header    *ClickyNode `json:"header,omitempty"`
+	Align     string      `json:"align,omitempty"`
 }
 
 type ClickyRow struct {
@@ -106,6 +109,7 @@ type ClickyStackFrame struct {
 
 type ClickyNode struct {
 	Kind            string             `json:"kind"`
+	FilterValue     any                `json:"filterValue,omitempty"`
 	Plain           string             `json:"plain,omitempty"`
 	Style           *ClickyStyle       `json:"style,omitempty"`
 	Text            string             `json:"text,omitempty"`
@@ -512,6 +516,9 @@ func convertTable(table *api.TextTable) ClickyNode {
 				column.Label = table.Columns[i].Label
 				column.Kind = table.Columns[i].Kind
 				column.Type = table.Columns[i].Type
+				column.Format = table.Columns[i].Format
+				column.Unit = table.Columns[i].Unit
+				column.FilterKey = table.Columns[i].FilterKey
 				column.Align = alignFromStyle(table.Columns[i].Style)
 			}
 			if column.Label == "" {
@@ -525,11 +532,14 @@ func convertTable(table *api.TextTable) ClickyNode {
 	} else {
 		for _, columnDef := range table.Columns {
 			column := ClickyColumn{
-				Name:  columnDef.Name,
-				Label: columnDef.Label,
-				Kind:  columnDef.Kind,
-				Type:  columnDef.Type,
-				Align: alignFromStyle(columnDef.Style),
+				Name:      columnDef.Name,
+				Label:     columnDef.Label,
+				Kind:      columnDef.Kind,
+				Type:      columnDef.Type,
+				Format:    columnDef.Format,
+				Unit:      columnDef.Unit,
+				FilterKey: columnDef.FilterKey,
+				Align:     alignFromStyle(columnDef.Style),
 			}
 			if column.Label == "" {
 				column.Label = columnDef.Name
@@ -542,11 +552,15 @@ func convertTable(table *api.TextTable) ClickyNode {
 		rowNode := ClickyRow{Cells: map[string]ClickyNode{}}
 		for _, column := range node.Columns {
 			if cell, ok := row[column.Name]; ok {
-				rowNode.Cells[column.Name] = convertTypedValue(&cell, nil)
+				cellNode := convertTypedValue(&cell, nil)
+				cellNode.FilterValue = cell.FilterValue
+				rowNode.Cells[column.Name] = cellNode
 				continue
 			}
 			if cell, ok := row[column.Label]; ok {
-				rowNode.Cells[column.Name] = convertTypedValue(&cell, nil)
+				cellNode := convertTypedValue(&cell, nil)
+				cellNode.FilterValue = cell.FilterValue
+				rowNode.Cells[column.Name] = cellNode
 				continue
 			}
 			rowNode.Cells[column.Name] = clickyTextNode("")

--- a/formatters/html_react_formatter_test.go
+++ b/formatters/html_react_formatter_test.go
@@ -184,7 +184,7 @@ func TestHTMLReactConvertTable(t *testing.T) {
 		},
 		Columns: []api.PrettyField{
 			{Name: "Name", Label: "Name"},
-			{Name: "Status", Label: "Status", Kind: "status", Type: api.ColumnTypeKeyValue},
+			{Name: "Status", Label: "Status", Kind: "status", Type: api.ColumnTypeKeyValue, FilterKey: "filter.status"},
 		},
 		Rows: []api.TableRow{
 			{
@@ -214,6 +214,9 @@ func TestHTMLReactConvertTable(t *testing.T) {
 	}
 	if node.Columns[1].Type != api.ColumnTypeKeyValue {
 		t.Fatalf("expected column type to survive clicky conversion, got %#v", node.Columns[1])
+	}
+	if node.Columns[1].FilterKey != "filter.status" {
+		t.Fatalf("expected filter key to survive clicky conversion, got %#v", node.Columns[1])
 	}
 	if len(node.Rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(node.Rows))

--- a/formatters/stream.go
+++ b/formatters/stream.go
@@ -341,7 +341,7 @@ func writePDFStream(ctx context.Context, w io.Writer, rows RowIterator, columns 
 	for _, column := range columns {
 		table.Headers = append(table.Headers, api.Text{Content: column.DisplayLabel()})
 		table.FieldNames = append(table.FieldNames, column.Name)
-		table.Columns = append(table.Columns, api.PrettyField{Name: column.Name, Label: column.DisplayLabel(), Type: column.Type, Format: column.Format})
+		table.Columns = append(table.Columns, api.PrettyField{Name: column.Name, Label: column.DisplayLabel(), Type: column.Type, Format: column.Format, Unit: column.Unit})
 	}
 	count, err := streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
 		out := api.TableRow{}

--- a/formatters/tree_formatter.go
+++ b/formatters/tree_formatter.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/tree"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/flanksource/clicky/api"
-	"github.com/flanksource/clicky/api/tailwind"
 )
 
 type TextTree struct {
@@ -142,15 +141,18 @@ func buildNoTreeDataMessage(data *api.PrettyData) string {
 // node label is a single tree row's content, not a paragraph — blank-line
 // spacing that reads well in flat output is noise inside the tree.
 func normalizeTreeLabel(s string) string {
-	if !strings.ContainsAny(s, "\n \t") {
-		return s
-	}
+	return normalizeTreeLabelWidth(s, api.GetTerminalWidth())
+}
+
+func normalizeTreeLabelWidth(s string, maxWidth int) string {
 	lines := strings.Split(s, "\n")
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
-		if line = strings.TrimRight(line, " \t"); line != "" {
-			out = append(out, line)
+		line = strings.TrimRight(line, " \t")
+		if strings.TrimSpace(ansi.Strip(line)) == "" {
+			continue
 		}
+		out = append(out, ansi.Truncate(line, maxWidth, "…"))
 	}
 	return strings.Join(out, "\n")
 }
@@ -164,20 +166,17 @@ func (f *TreeFormatter) buildLipglossTree(node api.TreeNode, depth int) *tree.Tr
 	// All TreeNodes implement Pretty(), so use it for formatting
 	prettyText := node.Pretty()
 
-	// Build the node label with styling. Normalize the plain text before any
-	// lipgloss styling so trimming isn't fighting ANSI reset sequences and
-	// multi-line labels don't render stray "│"-gutter blank lines.
+	// Render the complete Text value so Textable children remain visible in
+	// tree labels, then bound each physical line to the terminal width left at
+	// this depth. ANSI-aware truncation preserves SGR state and prevents one
+	// long captured-output line from forcing lipgloss to pad every sibling.
 	var nodeLabel string
 	if f.NoColor {
-		nodeLabel = normalizeTreeLabel(prettyText.String())
+		nodeLabel = prettyText.String()
 	} else {
-		content := normalizeTreeLabel(prettyText.Content)
-		if prettyText.Style != "" {
-			nodeLabel = parseTailwindToLipgloss(prettyText.Style).Render(content)
-		} else {
-			nodeLabel = content
-		}
+		nodeLabel = prettyText.ANSI()
 	}
+	nodeLabel = normalizeTreeLabelWidth(nodeLabel, max(1, api.GetTerminalWidth()-depth*4-2))
 
 	// Handle compact list node specially
 	if compactNode, ok := node.(*api.CompactListNode); ok && f.Options.Compact {
@@ -223,41 +222,6 @@ func (f *TreeFormatter) FormatCompactList(items []string, separator string) stri
 	return strings.Join(items, separator)
 }
 
-// parseTailwindToLipgloss converts a Tailwind style string to a lipgloss.Style
-func parseTailwindToLipgloss(tailwindStyle string) lipgloss.Style {
-	style := lipgloss.NewStyle()
-
-	// Parse the Tailwind style string
-	classes := strings.Fields(tailwindStyle)
-	for _, class := range classes {
-		// Handle text colors
-		if strings.HasPrefix(class, "text-") {
-			if color, err := tailwind.ParseTailwindColor(class); err == nil && color != "" {
-				style = style.Foreground(lipgloss.Color(color))
-			}
-		}
-		// Handle background colors
-		if strings.HasPrefix(class, "bg-") {
-			if color, err := tailwind.ParseTailwindColor(class); err == nil && color != "" {
-				style = style.Background(lipgloss.Color(color))
-			}
-		}
-		// Handle font weights
-		switch class {
-		case "bold", "font-bold", "font-semibold":
-			style = style.Bold(true)
-		case "italic", "font-italic":
-			style = style.Italic(true)
-		case "underline":
-			style = style.Underline(true)
-		case "strikethrough", "line-through":
-			style = style.Strikethrough(true)
-		}
-	}
-
-	return style
-}
-
 // FormatTreeFromRoot formats a tree starting from the root node using lipgloss
 func (f *TreeFormatter) FormatTreeFromRoot(root api.TreeNode) string {
 	if root == nil {
@@ -288,7 +252,15 @@ func (f *TreeFormatter) FormatTreeFromRoot(root api.TreeNode) string {
 		})
 	}
 
-	return t.String()
+	return trimTreePadding(t.String())
+}
+
+func trimTreePadding(rendered string) string {
+	lines := strings.Split(rendered, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // FormatInlineTree formats a tree structure for inline display

--- a/formatters/tree_multiline_ginkgo_test.go
+++ b/formatters/tree_multiline_ginkgo_test.go
@@ -1,0 +1,37 @@
+package formatters
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/flanksource/clicky/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type multilineTreeNode struct {
+	label    api.Text
+	children []api.TreeNode
+}
+
+func (n multilineTreeNode) Pretty() api.Text            { return n.label }
+func (n multilineTreeNode) GetChildren() []api.TreeNode { return n.children }
+
+var _ = Describe("TreeFormatter multiline labels", func() {
+	It("renders Textable children and bounds every physical line", func() {
+		long := strings.Repeat("x", 2_000)
+		root := multilineTreeNode{
+			label: api.Text{}.Append("fixture").NewLine().Add(api.ANSIText{Content: "\x1b[31m" + long + "\x1b[0m"}),
+		}
+		formatter := NewTreeFormatter(api.DefaultTheme(), false, nil)
+
+		output := formatter.FormatTreeFromRoot(root)
+
+		Expect(output).To(ContainSubstring("fixture"))
+		Expect(output).To(ContainSubstring("\x1b[31m"))
+		for _, line := range strings.Split(output, "\n") {
+			Expect(lipgloss.Width(line)).To(BeNumerically("<", api.GetTerminalWidth()-1))
+			Expect(line).NotTo(HaveSuffix(" "))
+		}
+	})
+})

--- a/rpc/converter.go
+++ b/rpc/converter.go
@@ -121,7 +121,12 @@ func (c *Converter) ConvertCommand(cmd *cobra.Command) (*RPCOperation, error) {
 		default:
 			prop.Type = "string"
 			param.Type = "string"
-			if flag.DefValue != "" {
+			// pflag renders an empty slice default as the literal "[]". Emitting
+			// that as a schema default puts the two characters "[]" in every
+			// generated form field, and a client that posts the pre-filled value
+			// back sends a one-element slice containing "[]". A repeatable flag
+			// with no default simply has none.
+			if flag.DefValue != "" && !(isSliceFlag(flag) && flag.DefValue == "[]") {
 				prop.Default = flag.DefValue
 				param.Default = flag.DefValue
 			}
@@ -542,6 +547,13 @@ func (c *Converter) getParentCommandName(cmd *cobra.Command) string {
 		return cmd.Parent().Name()
 	}
 	return ""
+}
+
+// isSliceFlag reports whether a flag holds multiple values, i.e. whether pflag
+// would render its zero value as "[]".
+func isSliceFlag(flag *pflag.Flag) bool {
+	_, ok := flag.Value.(pflag.SliceValue)
+	return ok
 }
 
 // isFlagRequired checks if a flag is marked as required using reflection

--- a/rpc/converter_flags_test.go
+++ b/rpc/converter_flags_test.go
@@ -63,3 +63,38 @@ func TestConvertCommand_OmitsInheritedAndHiddenFlags(t *testing.T) {
 	assert.NotContains(t, op.Schema.Properties, "db-url",
 		"hidden flag db-url must NOT appear in schema properties")
 }
+
+// pflag stringifies an empty slice default as "[]". Publishing that as a schema
+// default pre-fills generated forms with the literal characters "[]", which a
+// client then posts back as a one-element slice — turning "no values" into one
+// bogus value. A repeatable flag with no default must advertise none.
+func TestConvertCommand_OmitsEmptySliceDefaults(t *testing.T) {
+	root := &cobra.Command{Use: "app"}
+	child := &cobra.Command{
+		Use:   "act",
+		Short: "Act",
+		RunE:  func(*cobra.Command, []string) error { return nil },
+	}
+	child.Flags().StringSlice("param", nil, "Repeatable key=value")
+	child.Flags().StringArray("header", nil, "Repeatable header")
+	child.Flags().StringSlice("tag", []string{"a", "b"}, "Repeatable tag with defaults")
+	child.Flags().String("name", "fallback", "Scalar with a default")
+	root.AddCommand(child)
+
+	op, err := NewConverter(DefaultConfig()).ConvertCommand(child)
+	require.NoError(t, err)
+
+	defaults := map[string]any{}
+	for _, p := range op.Parameters {
+		defaults[p.Name] = p.Default
+	}
+
+	assert.Nil(t, defaults["param"], "an empty slice flag must advertise no default")
+	assert.Nil(t, defaults["header"], "an empty array flag must advertise no default")
+	assert.Nil(t, op.Schema.Properties["param"].Default,
+		"the schema property must not carry the empty-slice default either")
+
+	// A slice flag with real defaults, and every scalar flag, keep theirs.
+	assert.Equal(t, "[a,b]", defaults["tag"])
+	assert.Equal(t, "fallback", defaults["name"])
+}

--- a/rpc/executor.go
+++ b/rpc/executor.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -390,9 +391,32 @@ func convertValueToString(value interface{}) string {
 		return fmt.Sprintf("%g", v)
 	case nil:
 		return ""
+	case []interface{}:
+		return csvRecord(v)
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+// csvRecord encodes a JSON array the way the CLI encodes a repeatable flag, so
+// a slice-typed flag decodes identically over HTTP and on the command line.
+// Without this a JSON body's ["a=1","b=2"] reaches the handler as Go's bracket
+// form `[a=1 b=2]` — one unparseable string instead of two values.
+func csvRecord(values []interface{}) string {
+	if len(values) == 0 {
+		return ""
+	}
+	items := make([]string, len(values))
+	for i, value := range values {
+		items[i] = convertValueToString(value)
+	}
+	var encoded strings.Builder
+	writer := csv.NewWriter(&encoded)
+	if err := writer.Write(items); err != nil {
+		return fmt.Sprintf("%v", values)
+	}
+	writer.Flush()
+	return strings.TrimSuffix(encoded.String(), "\n")
 }
 
 // extractExitCode extracts the exit code from a command execution error

--- a/rpc/executor_flags_test.go
+++ b/rpc/executor_flags_test.go
@@ -1,0 +1,55 @@
+package rpc
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/flanksource/clicky/flags"
+)
+
+// A repeatable flag reaches the CLI as a CSV record (pflag's stringSlice
+// encoding). A JSON body must produce the same encoding, or the same action
+// behaves differently over HTTP than on the command line.
+func TestConvertValueToStringEncodesArraysAsCSV(t *testing.T) {
+	cases := map[string]struct {
+		value any
+		want  string
+	}{
+		"string array":     {[]any{"path=/a", "id=2"}, "path=/a,id=2"},
+		"single element":   {[]any{"only=1"}, "only=1"},
+		"empty array":      {[]any{}, ""},
+		"embedded comma":   {[]any{"a=1,2", "b=3"}, `"a=1,2",b=3`},
+		"embedded quote":   {[]any{`a="q"`}, `"a=""q"""`},
+		"numeric elements": {[]any{float64(1), float64(2)}, "1,2"},
+		"plain string":     {"path=/a", "path=/a"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := convertValueToString(tc.value); got != tc.want {
+				t.Errorf("convertValueToString(%v) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// The encoding is only useful if the flag decoder reverses it, so assert the
+// full round trip rather than the encoding alone.
+func TestArrayFlagRoundTripsThroughPopulateFromRequest(t *testing.T) {
+	type actionFlags struct {
+		Select []string `flag:"select"`
+	}
+	want := []string{"path=/sink/B", "id=2"}
+
+	fields, err := flags.ParseStructFields(reflect.TypeOf(actionFlags{}))
+	if err != nil {
+		t.Fatalf("ParseStructFields: %v", err)
+	}
+	var decoded actionFlags
+	flagMap := map[string]string{"select": convertValueToString([]any{"path=/sink/B", "id=2"})}
+	if err := flags.PopulateFromRequest(reflect.ValueOf(&decoded).Elem(), fields, flagMap, nil); err != nil {
+		t.Fatalf("PopulateFromRequest: %v", err)
+	}
+	if !reflect.DeepEqual(decoded.Select, want) {
+		t.Errorf("decoded = %q, want %q", decoded.Select, want)
+	}
+}

--- a/rpc/filter_lookup_test.go
+++ b/rpc/filter_lookup_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -163,4 +164,30 @@ func TestSwaggerServer_FilterLookupRoutes(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 		assert.Equal(t, 0, bulkExecutions)
 	})
+}
+
+func TestLookupPreservesUndeclaredSiblingParameters(t *testing.T) {
+	var captured map[string]string
+	op := &RPCOperation{
+		ContextLookupFunc: func(_ context.Context, flags map[string]string, _ []string) (any, error) {
+			captured = flags
+			return map[string]any{"filters": map[string]any{}}, nil
+		},
+	}
+	server := &SwaggerServer{
+		executor: NewCommandExecutor(&RPCService{}, &ExecutorConfig{}),
+	}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/profile?region=prod&filter.service=api&__lookup=filters",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	server.handleLookupCommand(response, request, op)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "prod", captured["region"])
+	assert.Equal(t, "api", captured["filter.service"])
+	assert.NotContains(t, captured, "__lookup")
 }

--- a/rpc/http/timing.go
+++ b/rpc/http/timing.go
@@ -94,6 +94,49 @@ func (t *Timings) add(metric TimingMetric) {
 	}
 }
 
+// Metrics returns a snapshot of the accumulated metrics in insertion order, so
+// callers outside the HTTP path (benchmarks, CLI profiling) can read durations
+// and counters without parsing the header string back apart.
+func (t *Timings) Metrics() []TimingMetric {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	metrics := make([]TimingMetric, 0, len(t.order))
+	for _, name := range t.order {
+		total := t.metrics[name]
+		metric := TimingMetric{Name: name, Duration: total.duration}
+		for _, counter := range total.counterOrder {
+			metric.Counters = append(metric.Counters, TimingCounter{Name: counter, Value: total.counters[counter]})
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics
+}
+
+// Counter returns the accumulated value of a named counter on a named metric,
+// and whether that counter was recorded at all.
+func (t *Timings) Counter(metric, counter string) (int64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	total, ok := t.metrics[metric]
+	if !ok {
+		return 0, false
+	}
+	value, ok := total.counters[counter]
+	return value, ok
+}
+
+// Duration returns the accumulated wall time of a named metric, and whether the
+// metric was recorded at all.
+func (t *Timings) Duration(metric string) (time.Duration, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	total, ok := t.metrics[metric]
+	if !ok {
+		return 0, false
+	}
+	return total.duration, true
+}
+
 // Header renders the accumulated phases as a Server-Timing value fragment
 // (`find;dur=4.1, parse;dur=6.8`), durations in milliseconds to one decimal. It
 // returns an empty string when no phases were recorded.

--- a/rpc/http/timing_counter_spec_test.go
+++ b/rpc/http/timing_counter_spec_test.go
@@ -44,4 +44,54 @@ var _ = Describe("HTTP server timing counters", func() {
 			`redis;dur=0.0;desc="ops=0 hits=0 misses=0 errors=0"`,
 		))
 	})
+
+	It("reads accumulated metrics back in insertion order", func() {
+		ctx, timings := WithTimings(context.Background())
+
+		AddTiming(ctx, TimingMetric{
+			Name: "sql", Duration: 2 * time.Millisecond,
+			Counters: []TimingCounter{{Name: "queries", Value: 1}, {Name: "rows_returned", Value: 500}},
+		})
+		AddTiming(ctx, TimingMetric{Name: "formulas", Counters: []TimingCounter{{Name: "evaluated", Value: 3}}})
+		AddTiming(ctx, TimingMetric{
+			Name: "sql", Duration: 3 * time.Millisecond,
+			Counters: []TimingCounter{{Name: "queries", Value: 1}},
+		})
+
+		Expect(timings.Metrics()).To(Equal([]TimingMetric{
+			{
+				Name:     "sql",
+				Duration: 5 * time.Millisecond,
+				Counters: []TimingCounter{{Name: "queries", Value: 2}, {Name: "rows_returned", Value: 500}},
+			},
+			{
+				Name:     "formulas",
+				Counters: []TimingCounter{{Name: "evaluated", Value: 3}},
+			},
+		}))
+	})
+
+	It("reports a single counter and duration by name", func() {
+		ctx, timings := WithTimings(context.Background())
+
+		AddTiming(ctx, TimingMetric{
+			Name: "sql", Duration: 4 * time.Millisecond,
+			Counters: []TimingCounter{{Name: "queries", Value: 7}},
+		})
+
+		queries, ok := timings.Counter("sql", "queries")
+		Expect(ok).To(BeTrue())
+		Expect(queries).To(Equal(int64(7)))
+
+		elapsed, ok := timings.Duration("sql")
+		Expect(ok).To(BeTrue())
+		Expect(elapsed).To(Equal(4 * time.Millisecond))
+
+		_, ok = timings.Counter("sql", "rows_returned")
+		Expect(ok).To(BeFalse(), "a counter that was never recorded is absent, not zero")
+		_, ok = timings.Counter("redis", "ops")
+		Expect(ok).To(BeFalse())
+		_, ok = timings.Duration("redis")
+		Expect(ok).To(BeFalse())
+	})
 })

--- a/rpc/response_schema.go
+++ b/rpc/response_schema.go
@@ -1,0 +1,45 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ResponseSchema returns op's response body as a plain JSON-schema map, or nil
+// when the operation declares no static response type. It is the public entry
+// point for consumers that publish a schema alongside a tool or endpoint — the
+// chat tool catalog's outputSchema — instead of embedding it in a full OpenAPI
+// document.
+//
+// The result is self-contained: reflection inlines every nested type, so the map
+// never carries a $ref and can be interpreted standalone.
+//
+// A nil map is the honest signal that the operation declares no typed response.
+// Callers publish nothing rather than substitute a placeholder, and must not
+// coerce the result to an object — a ResponseArray operation is legitimately a
+// top-level array.
+func ResponseSchema(op RPCOperation) (map[string]any, error) {
+	if op.ResponseType == nil {
+		return nil, nil
+	}
+	return schemaToMap(NewOpenAPIGenerator(nil).responseSchemaForOperation(op))
+}
+
+// schemaToMap round-trips a schema through JSON. The detour is deliberate:
+// OpenAPISchema.MarshalJSON merges the Extensions map (x-clicky-*) into the
+// object, so marshalling is the only conversion that preserves vendor keys.
+// Mirrors schemaFromMap, which converts in the opposite direction.
+func schemaToMap(schema *OpenAPISchema) (map[string]any, error) {
+	if schema == nil {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal response schema: %w", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("decode response schema: %w", err)
+	}
+	return decoded, nil
+}

--- a/rpc/response_schema_test.go
+++ b/rpc/response_schema_test.go
@@ -1,0 +1,151 @@
+package rpc
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// responseNested is a struct field type that a component-based generator would
+// emit as a $ref. Clicky inlines it instead, which is what lets a published
+// schema be interpreted standalone.
+type responseNested struct {
+	Count int `json:"count"`
+}
+
+type responseRow struct {
+	ID     string         `json:"id"`
+	Name   string         `json:"name,omitempty"`
+	Nested responseNested `json:"nested"`
+}
+
+type responseTagged struct {
+	Region string `json:"region" clicky:"type=region-selector,order=3"`
+}
+
+// assertNoRefs walks a decoded schema and fails on any $ref key. Self-containment
+// is the property that makes ResponseSchema consumable without an accompanying
+// components section.
+func assertNoRefs(t *testing.T, value any) {
+	t.Helper()
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if key == "$ref" {
+				t.Errorf("schema must be self-contained, found $ref = %v", child)
+			}
+			assertNoRefs(t, child)
+		}
+	case []any:
+		for _, child := range typed {
+			assertNoRefs(t, child)
+		}
+	}
+}
+
+func mustObject(t *testing.T, value any, path string) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	require.True(t, ok, "%s should be an object, got %T", path, value)
+	return object
+}
+
+func TestResponseSchema_StructResponse(t *testing.T) {
+	schema, err := ResponseSchema(RPCOperation{
+		Name:         "row-get",
+		ResponseType: reflect.TypeOf(responseRow{}),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	assertNoRefs(t, schema)
+
+	assert.Equal(t, "object", schema["type"])
+	properties := mustObject(t, schema["properties"], "properties")
+	assert.Equal(t, "string", mustObject(t, properties["id"], "properties.id")["type"])
+
+	nested := mustObject(t, properties["nested"], "properties.nested")
+	assert.Equal(t, "object", nested["type"], "a nested struct is inlined, not referenced")
+	assert.Contains(t, mustObject(t, nested["properties"], "properties.nested.properties"), "count")
+}
+
+func TestResponseSchema_PagedResponse(t *testing.T) {
+	schema, err := ResponseSchema(RPCOperation{
+		Name:          "row-list",
+		ResponseType:  reflect.TypeOf(responseRow{}),
+		ResponsePaged: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	assertNoRefs(t, schema)
+
+	assert.Equal(t, "object", schema["type"])
+	assert.ElementsMatch(t, []any{"data", "page"}, schema["required"])
+
+	properties := mustObject(t, schema["properties"], "properties")
+	data := mustObject(t, properties["data"], "properties.data")
+	assert.Equal(t, "array", data["type"])
+
+	items := mustObject(t, data["items"], "properties.data.items")
+	assert.Equal(t, "object", items["type"])
+	assert.Contains(t, mustObject(t, items["properties"], "properties.data.items.properties"), "id")
+
+	page := mustObject(t, properties["page"], "properties.page")
+	assert.Equal(t, "object", page["type"])
+	pageProperties := mustObject(t, page["properties"], "properties.page.properties")
+	for _, key := range []string{"limit", "offset", "total"} {
+		assert.Contains(t, pageProperties, key)
+	}
+}
+
+func TestResponseSchema_ArrayResponse(t *testing.T) {
+	schema, err := ResponseSchema(RPCOperation{
+		Name:          "row-all",
+		ResponseType:  reflect.TypeOf(responseRow{}),
+		ResponseArray: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	assertNoRefs(t, schema)
+
+	assert.Equal(t, "array", schema["type"], "an array response stays a top-level array")
+	assert.NotContains(t, schema, "properties")
+	assert.Equal(t, "object", mustObject(t, schema["items"], "items")["type"])
+}
+
+func TestResponseSchema_NilResponseType(t *testing.T) {
+	schema, err := ResponseSchema(RPCOperation{Name: "untyped"})
+	require.NoError(t, err)
+	assert.Nil(t, schema, "an operation with no declared response type publishes no schema")
+}
+
+func TestResponseSchema_EntityIDResponse(t *testing.T) {
+	schema, err := ResponseSchema(RPCOperation{
+		Name:             "row-list",
+		ResponseType:     reflect.TypeOf(responseRow{}),
+		ResponsePaged:    true,
+		ResponseEntityID: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	properties := mustObject(t, schema["properties"], "properties")
+	data := mustObject(t, properties["data"], "properties.data")
+	items := mustObject(t, data["items"], "properties.data.items")
+	assert.Contains(t, mustObject(t, items["properties"], "properties.data.items.properties"), "_id")
+}
+
+func TestResponseSchema_PreservesExtensions(t *testing.T) {
+	schema, err := ResponseSchema(RPCOperation{
+		Name:         "tagged-get",
+		ResponseType: reflect.TypeOf(responseTagged{}),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	properties := mustObject(t, schema["properties"], "properties")
+	region := mustObject(t, properties["region"], "properties.region")
+	assert.Equal(t, "region-selector", region["x-clicky-component"], "vendor keys survive the marshal round-trip")
+	assert.Equal(t, float64(3), region["x-clicky-order"])
+}

--- a/rpc/serve.go
+++ b/rpc/serve.go
@@ -772,6 +772,17 @@ func (s *SwaggerServer) handleLookupCommand(w http.ResponseWriter, r *http.Reque
 	if v := r.URL.Query().Get("__lookup_q"); v != "" {
 		req.Flags["__lookup_q"] = v
 	}
+	// Live operation metadata can add cascading filter parameters after the
+	// Cobra operation was generated. Preserve those raw sibling values for the
+	// FilterContext without changing normal command execution extraction.
+	for key, values := range r.URL.Query() {
+		if strings.HasPrefix(key, "__") || len(values) == 0 {
+			continue
+		}
+		if _, declared := req.Flags[key]; !declared {
+			req.Flags[key] = values[0]
+		}
+	}
 
 	var data any
 	if op.ContextLookupFunc != nil {

--- a/task/api.go
+++ b/task/api.go
@@ -104,34 +104,77 @@ func RunControlHandler() http.Handler {
 // RunControlHandlerWithSource routes controls to the live owner of a run.
 func RunControlHandlerWithSource(source RunSource) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var request struct {
-			Action ControlAction `json:"action"`
-		}
-		decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10))
-		decoder.DisallowUnknownFields()
-		if err := decoder.Decode(&request); err != nil {
-			http.Error(w, "invalid control request: "+err.Error(), http.StatusBadRequest)
+		action, ok := decodeControlAction(w, r)
+		if !ok {
 			return
 		}
 		id := r.PathValue("id")
 		var err error
 		if groupByID(id) != nil {
-			err = ControlRun(r.Context(), id, request.Action)
+			err = ControlRun(r.Context(), id, action)
 		} else if source != nil {
-			err = source.Control(r.Context(), id, request.Action)
+			err = source.Control(r.Context(), id, action)
 		} else {
-			err = ControlRun(r.Context(), id, request.Action)
+			err = ControlRun(r.Context(), id, action)
 		}
 		if err != nil {
-			status := http.StatusConflict
-			if strings.Contains(err.Error(), "not found") {
-				status = http.StatusNotFound
-			}
-			http.Error(w, err.Error(), status)
+			writeControlError(w, err)
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
+}
+
+// TaskControlHandler performs a lifecycle action advertised by a child task.
+func TaskControlHandler() http.Handler {
+	return TaskControlHandlerWithSource(nil)
+}
+
+// TaskControlHandlerWithSource routes child controls to the live owner of a
+// run, including runs owned by an external source.
+func TaskControlHandlerWithSource(source RunSource) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action, ok := decodeControlAction(w, r)
+		if !ok {
+			return
+		}
+		runID := r.PathValue("id")
+		taskID := r.PathValue("taskID")
+		var err error
+		if groupByID(runID) != nil {
+			err = ControlTask(r.Context(), runID, taskID, action)
+		} else if external, ok := source.(TaskControlSource); ok {
+			err = external.ControlTask(r.Context(), runID, taskID, action)
+		} else {
+			err = ControlTask(r.Context(), runID, taskID, action)
+		}
+		if err != nil {
+			writeControlError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func decodeControlAction(w http.ResponseWriter, r *http.Request) (ControlAction, bool) {
+	var request struct {
+		Action ControlAction `json:"action"`
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		http.Error(w, "invalid control request: "+err.Error(), http.StatusBadRequest)
+		return "", false
+	}
+	return request.Action, true
+}
+
+func writeControlError(w http.ResponseWriter, err error) {
+	status := http.StatusConflict
+	if strings.Contains(err.Error(), "not found") {
+		status = http.StatusNotFound
+	}
+	http.Error(w, err.Error(), status)
 }
 
 // TaskStdinHandler writes live stdin to a task. Input is deliberately not
@@ -166,6 +209,7 @@ func TaskStdinHandler() http.Handler {
 //	GET {prefix}/tasks/runs/stream persistent SSE stream of RunMeta listings
 //	GET {prefix}/tasks/{id}    id-scoped snapshot (group + tasks)
 //	POST {prefix}/tasks/{id}/control lifecycle action
+//	POST {prefix}/tasks/{id}/tasks/{taskID}/control child lifecycle action
 //	POST {prefix}/tasks/{id}/tasks/{taskID}/stdin live stdin (never persisted)
 //
 // The {id} route reuses Go 1.22 net/http path-value routing; the stream route is
@@ -181,6 +225,7 @@ func RegisterHandlersWithSource(mux *http.ServeMux, prefix string, source RunSou
 	mux.Handle("GET "+prefix+"/tasks/stream", SSEHandlerWithSource(source))
 	mux.Handle("GET "+prefix+"/tasks/runs/stream", RunsSSEHandlerWithSource(source))
 	mux.Handle("POST "+prefix+"/tasks/{id}/control", RunControlHandlerWithSource(source))
+	mux.Handle("POST "+prefix+"/tasks/{id}/tasks/{taskID}/control", TaskControlHandlerWithSource(source))
 	mux.Handle("POST "+prefix+"/tasks/{id}/tasks/{taskID}/stdin", TaskStdinHandler())
 	mux.Handle("GET "+prefix+"/tasks/{id}", RunHandlerWithSource(source))
 	timeseries := Metrics()

--- a/task/context_logger.go
+++ b/task/context_logger.go
@@ -1,0 +1,48 @@
+package task
+
+import "github.com/flanksource/commons/logger"
+
+// taskContextLogger is installed as the Logger on a task's flanksource
+// context, so lines logged through ctx.Logger land in the task's buffered
+// logger and render under the task's line in the tree instead of
+// interleaving with global logger output. Emits go through the Task's log
+// methods, which also mark the task dirty at streaming levels so plain
+// mode prints them promptly. Everything else — level queries, verbosity
+// checks, derived loggers — comes from the embedded buffered logger;
+// loggers derived via Named/WithValues still write to the buffer but skip
+// the dirty marking.
+type taskContextLogger struct {
+	logger.Logger
+	task *Task
+}
+
+func (l taskContextLogger) Tracef(format string, args ...interface{}) {
+	l.task.Tracef(format, args...)
+}
+
+func (l taskContextLogger) Debugf(format string, args ...interface{}) {
+	l.task.Debugf(format, args...)
+}
+
+func (l taskContextLogger) Infof(format string, args ...interface{}) {
+	l.task.Infof(format, args...)
+}
+
+func (l taskContextLogger) Warnf(format string, args ...interface{}) {
+	l.task.Warnf(format, args...)
+}
+
+func (l taskContextLogger) Errorf(format string, args ...interface{}) {
+	l.task.Errorf(format, args...)
+}
+
+func (l taskContextLogger) Fatalf(format string, args ...interface{}) {
+	l.task.Fatalf(format, args...)
+}
+
+// contextLogger returns the Logger to install on the task's context. It
+// initializes the buffered logger first (while ctx.Logger still points at
+// the previous logger, whose level seeds the buffer's level).
+func (t *Task) contextLogger() logger.Logger {
+	return taskContextLogger{Logger: t.getBufferedLogger(), task: t}
+}

--- a/task/context_logger_test.go
+++ b/task/context_logger_test.go
@@ -1,0 +1,146 @@
+package task
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	flanksourceContext "github.com/flanksource/commons/context"
+
+	"github.com/flanksource/clicky/text"
+)
+
+func bufferedLogMessages(task *Task) []string {
+	logs := task.getBufferedLogger().GetLogs()
+	msgs := make([]string, 0, len(logs))
+	for _, l := range logs {
+		msgs = append(msgs, l.Message)
+	}
+	return msgs
+}
+
+// F13: lines logged through the task context's Logger land in the task's
+// buffered logger — rendering under the task line in the tree — instead of
+// interleaving with global logger output.
+func TestContextLoggerRoutesToTaskBuffer(t *testing.T) {
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+
+	task := tm.newTask("ctx-log-task")
+	task.FlanksourceContext().Logger.Infof("via-context %d", 42)
+
+	if msgs := bufferedLogMessages(task); !strings.Contains(strings.Join(msgs, "\n"), "via-context 42") {
+		t.Fatalf("context log line must land in the task buffer, got %v", msgs)
+	}
+	if !task.PopDirty() {
+		t.Errorf("a context log append at Info must mark the task dirty for streaming")
+	}
+}
+
+// F13: the context handed to runFunc routes to the task buffer, including on
+// the taskTimeout path where the worker rebuilds the flanksource context.
+func TestRunFuncContextLoggerRoutesToTaskBuffer(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []Option
+	}{
+		{name: "plain context", opts: nil},
+		{name: "task timeout context", opts: []Option{WithTaskTimeout(5 * time.Second)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := newTestManager(1)
+			t.Cleanup(func() { close(tm.shutdown) })
+
+			task := tm.newTask("runfunc-ctx-task", tc.opts...)
+			task.runFunc = func(ctx flanksourceContext.Context, tk *Task) error {
+				ctx.Logger.Infof("from-run-func")
+				tk.Success()
+				return nil
+			}
+			tm.enqueue(task)
+			select {
+			case <-task.doneChan:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for task to complete")
+			}
+
+			if msgs := bufferedLogMessages(task); !strings.Contains(strings.Join(msgs, "\n"), "from-run-func") {
+				t.Fatalf("runFunc ctx.Logger line must land in the task buffer, got %v", msgs)
+			}
+		})
+	}
+}
+
+// F14: appends at streaming levels (Info and more severe) mark the task
+// dirty so plain mode emits them on the next tick; Debug/Trace stay batched
+// until the next status transition.
+func TestLogAppendMarksDirtyAtStreamingLevels(t *testing.T) {
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	task := tm.newTask("dirty-log-task")
+	task.PopDirty()
+
+	task.Debugf("debug line")
+	if task.PopDirty() {
+		t.Errorf("Debugf must not mark the task dirty (stays batched)")
+	}
+	task.Tracef("trace line")
+	if task.PopDirty() {
+		t.Errorf("Tracef must not mark the task dirty (stays batched)")
+	}
+	task.Infof("info line")
+	if !task.PopDirty() {
+		t.Errorf("Infof must mark the task dirty for streaming")
+	}
+	task.Warnf("warn line")
+	if !task.PopDirty() {
+		t.Errorf("Warnf must mark the task dirty for streaming")
+	}
+	task.Errorf("error line")
+	if !task.PopDirty() {
+		t.Errorf("Errorf must mark the task dirty for streaming")
+	}
+}
+
+// F14: a running task that logs without any status change streams the line
+// on the next plain tick instead of batching until completion.
+func TestPlainRenderStreamsLogAppends(t *testing.T) {
+	originalStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	capture := &bytes.Buffer{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(capture, r)
+		close(done)
+	}()
+
+	tm := newTestManager(1)
+	task := tm.newTask("stream-task")
+	task.SetStatus(StatusRunning)
+	tm.mu.Lock()
+	tm.tasks = append(tm.tasks, task)
+	tm.mu.Unlock()
+	task.PopDirty()
+
+	task.Infof("streamed-mid-run")
+	tm.PlainRender()
+
+	os.Stderr = originalStderr
+	_ = w.Close()
+	<-done
+	_ = r.Close()
+
+	if out := text.StripANSI(capture.String()); !strings.Contains(out, "streamed-mid-run") {
+		t.Errorf("plain tick must stream the appended log line, got:\n%s", out)
+	}
+	close(tm.shutdown)
+}

--- a/task/control.go
+++ b/task/control.go
@@ -72,25 +72,48 @@ func ControlRun(ctx context.Context, id string, action ControlAction) error {
 	return controller.Control(ctx, action)
 }
 
-// WriteTaskStdin writes bytes to a live task that advertises stdin support.
-func WriteTaskStdin(runID, taskID string, data []byte) error {
+// ControlTask performs one advertised lifecycle action for a child task in a
+// live run.
+func ControlTask(ctx context.Context, runID, taskID string, action ControlAction) error {
+	t, err := taskByID(runID, taskID)
+	if err != nil {
+		return err
+	}
+	t.mu.Lock()
+	controller := t.controller
+	t.mu.Unlock()
+	if controller == nil || !actionAllowed(controller.Actions(), action) {
+		return fmt.Errorf("task %q does not support %q", taskID, action)
+	}
+	return controller.Control(ctx, action)
+}
+
+func taskByID(runID, taskID string) (*Task, error) {
 	group := groupByID(runID)
 	if group == nil {
-		return fmt.Errorf("run %q not found", runID)
+		return nil, fmt.Errorf("run %q not found", runID)
 	}
 	for _, item := range group.GetTasks() {
 		t := item.GetTask()
-		if t.ID() != taskID {
-			continue
+		if t.ID() == taskID {
+			return t, nil
 		}
-		t.mu.Lock()
-		controller := t.controller
-		t.mu.Unlock()
-		stdin, ok := controller.(StdinController)
-		if !ok {
-			return fmt.Errorf("task %q does not support stdin", taskID)
-		}
-		return stdin.WriteStdin(data)
 	}
-	return fmt.Errorf("task %q not found in run %q", taskID, runID)
+	return nil, fmt.Errorf("task %q not found in run %q", taskID, runID)
+}
+
+// WriteTaskStdin writes bytes to a live task that advertises stdin support.
+func WriteTaskStdin(runID, taskID string, data []byte) error {
+	t, err := taskByID(runID, taskID)
+	if err != nil {
+		return err
+	}
+	t.mu.Lock()
+	controller := t.controller
+	t.mu.Unlock()
+	stdin, ok := controller.(StdinController)
+	if !ok {
+		return fmt.Errorf("task %q does not support stdin", taskID)
+	}
+	return stdin.WriteStdin(data)
 }

--- a/task/log_serializer.go
+++ b/task/log_serializer.go
@@ -12,55 +12,70 @@ import (
 //  1. Interleaving — every Write holds the manager's output mutex so log
 //     lines cannot land mid-frame between a ClearLines and the fresh
 //     content that follows.
-//  2. Line accounting — the renderer's ClearLines(lastLines) clears the
-//     region occupied by the previous tick's content. When a log line
-//     lands between ticks, the cursor advances past the tracked region
-//     and the next tick's ClearLines undercounts, leaving the top of the
-//     previous frame stacked above the new one. We count newlines we
-//     write so the next tick can add them to lastLines.
+//  2. Persistence — in interactive mode (buffered), log lines written
+//     between ticks are held in pending and emitted by the next tick after
+//     it clears the old frame and before it paints the new one, so they
+//     persist in scrollback above the live frame (the bubbletea
+//     tea.Println pattern) instead of being erased with the frame.
 //
 // The writer delegates to `next` — whatever writer the logger was targeting
 // before the renderer took over (normally os.Stderr, but a caller-installed
 // wrapper is equally fine). Delegating preserves the caller's logging
-// pipeline; we only add ordering and accounting, never change destination.
+// pipeline; we only add ordering and positioning, never change destination.
 type logSerializingWriter struct {
 	mu   *sync.Mutex
 	next io.Writer
 
-	// linesWritten counts newlines emitted through this writer since the
-	// last TakeLinesWritten call. The next interactiveRender adds this to
-	// its lastLines input so ClearLines covers the log lines too. Access
-	// only while holding mu.
-	linesWritten int
+	// buffered is true in interactive render mode: writes accumulate in
+	// pending until the next tick's FlushPending emits them above the
+	// repainted frame. In plain mode writes pass straight through to next.
+	buffered bool
+
+	// pending holds log bytes awaiting the next tick's FlushPending.
+	// Access only while holding mu.
+	pending bytes.Buffer
 }
 
-func newLogSerializingWriter(mu *sync.Mutex, next io.Writer) *logSerializingWriter {
+func newLogSerializingWriter(mu *sync.Mutex, next io.Writer, buffered bool) *logSerializingWriter {
 	if mu == nil {
 		mu = &sync.Mutex{}
 	}
-	return &logSerializingWriter{mu: mu, next: next}
+	return &logSerializingWriter{mu: mu, next: next, buffered: buffered}
 }
 
 // Write serializes one log message against concurrent tick renders on the
-// same underlying mutex. Short holds: a single Write of the fully-formatted
-// log line. No re-entry into the renderer.
+// same underlying mutex. Interactive mode buffers the bytes for the next
+// tick; plain mode delegates immediately. Short holds, no re-entry into
+// the renderer.
 func (l *logSerializingWriter) Write(p []byte) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	if l.buffered {
+		l.pending.Write(p)
+		return len(p), nil
+	}
 	if l.next == nil {
 		return len(p), nil
 	}
-	n, err := l.next.Write(p)
-	l.linesWritten += bytes.Count(p[:n], []byte{'\n'})
-	return n, err
+	return l.next.Write(p)
 }
 
-// TakeLinesWritten returns the accumulated newline count and resets it to
-// zero. The renderer calls this under mu immediately before ClearLines so
-// the cleared region covers log lines emitted since the last tick. Caller
-// must hold mu (interactiveRender does).
-func (l *logSerializingWriter) TakeLinesWritten() int {
-	n := l.linesWritten
-	l.linesWritten = 0
-	return n
+// FlushPending writes buffered log bytes to the underlying writer, ensuring
+// they end on a fresh line so the frame repainted after them starts at
+// column 0. The renderer calls this between clearing the old frame and
+// painting the new one; uninstallLogSerializer calls it so a line that
+// landed after the final tick is emitted rather than dropped. Caller must
+// hold mu (interactiveRender does).
+func (l *logSerializingWriter) FlushPending() {
+	if l.pending.Len() == 0 {
+		return
+	}
+	if l.next != nil {
+		b := l.pending.Bytes()
+		_, _ = l.next.Write(b)
+		if b[len(b)-1] != '\n' {
+			_, _ = io.WriteString(l.next, "\n")
+		}
+	}
+	l.pending.Reset()
 }

--- a/task/log_serializer_test.go
+++ b/task/log_serializer_test.go
@@ -14,7 +14,7 @@ import (
 func TestLogSerializingWriter_DelegatesToNext(t *testing.T) {
 	var buf bytes.Buffer
 	var mu sync.Mutex
-	w := newLogSerializingWriter(&mu, &buf)
+	w := newLogSerializingWriter(&mu, &buf, false)
 
 	if _, err := w.Write([]byte("hello\n")); err != nil {
 		t.Fatalf("Write returned error: %v", err)
@@ -28,7 +28,7 @@ func TestLogSerializingWriter_DelegatesToNext(t *testing.T) {
 // crash — we drop the bytes silently (better than panicking in shutdown).
 func TestLogSerializingWriter_NilNextIsNoop(t *testing.T) {
 	var mu sync.Mutex
-	w := newLogSerializingWriter(&mu, nil)
+	w := newLogSerializingWriter(&mu, nil, false)
 	n, err := w.Write([]byte("ignored"))
 	if err != nil || n != len("ignored") {
 		t.Fatalf("nil-next Write: n=%d err=%v, want 7 nil", n, err)
@@ -45,7 +45,7 @@ func TestLogSerializer_HoldsMutexDuringWrite(t *testing.T) {
 	// serializer holds the mutex during the Write, the competing TryLock
 	// must fail until the Write returns.
 	slow := &signalWriter{}
-	w := newLogSerializingWriter(&mu, slow)
+	w := newLogSerializingWriter(&mu, slow, false)
 
 	slow.entered = make(chan struct{})
 	slow.release = make(chan struct{})
@@ -69,6 +69,56 @@ func (s *signalWriter) Write(p []byte) (int, error) {
 	close(s.entered)
 	<-s.release
 	return len(p), nil
+}
+
+// TestLogSerializingWriter_BufferedHoldsUntilFlush verifies interactive-mode
+// buffering: writes accumulate in pending and reach the underlying writer
+// only when FlushPending runs (the tick's above-frame emission point).
+func TestLogSerializingWriter_BufferedHoldsUntilFlush(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	w := newLogSerializingWriter(&mu, &buf, true)
+
+	if _, err := w.Write([]byte("held\n")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("buffered write must not reach next before FlushPending, got %q", buf.String())
+	}
+
+	mu.Lock()
+	w.FlushPending()
+	mu.Unlock()
+	if got := buf.String(); got != "held\n" {
+		t.Fatalf("FlushPending: got %q want %q", got, "held\n")
+	}
+
+	// Flush is one-shot: a second flush with nothing pending emits nothing.
+	mu.Lock()
+	w.FlushPending()
+	mu.Unlock()
+	if got := buf.String(); got != "held\n" {
+		t.Fatalf("second FlushPending must be a no-op, got %q", got)
+	}
+}
+
+// TestLogSerializingWriter_FlushEndsOnFreshLine verifies a pending fragment
+// without a trailing newline gets one on flush, so the frame repainted right
+// after starts at column 0 instead of merging into the log line.
+func TestLogSerializingWriter_FlushEndsOnFreshLine(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	w := newLogSerializingWriter(&mu, &buf, true)
+
+	if _, err := w.Write([]byte("partial")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	mu.Lock()
+	w.FlushPending()
+	mu.Unlock()
+	if got := buf.String(); got != "partial\n" {
+		t.Fatalf("FlushPending must terminate the line: got %q want %q", got, "partial\n")
+	}
 }
 
 // TestInstallUninstall_RoundTripsLoggerOutput verifies the lifecycle hooks

--- a/task/managed_run.go
+++ b/task/managed_run.go
@@ -16,6 +16,12 @@ type ManagedRun struct {
 func StartManagedRun(name string, opts ...TaskGroupOption) *ManagedRun {
 	group := StartGroup[any](name, opts...)
 	t := global.newTask(name, WithGroup(group.Group))
+	group.mu.RLock()
+	controller := group.controller
+	group.mu.RUnlock()
+	if controller != nil {
+		t.SetController(controller)
+	}
 	attachTaskableToGroup(t, t)
 	now := time.Now()
 	t.mu.Lock()

--- a/task/managed_run_ginkgo_test.go
+++ b/task/managed_run_ginkgo_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	commonscontext "github.com/flanksource/commons/context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -22,10 +23,11 @@ type recordingController struct {
 }
 
 type recordingRunSource struct {
-	runs       []task.RunMeta
-	snapshots  map[string][]task.TaskSnapshot
-	controlled string
-	points     []metrics.Point
+	runs           []task.RunMeta
+	snapshots      map[string][]task.TaskSnapshot
+	controlled     string
+	controlledTask string
+	points         []metrics.Point
 }
 
 func (s *recordingRunSource) Runs(_ context.Context, filter task.RunFilter) ([]task.RunMeta, error) {
@@ -44,6 +46,11 @@ func (s *recordingRunSource) Snapshot(_ context.Context, id string) ([]task.Task
 
 func (s *recordingRunSource) Control(_ context.Context, id string, action task.ControlAction) error {
 	s.controlled = id + ":" + string(action)
+	return nil
+}
+
+func (s *recordingRunSource) ControlTask(_ context.Context, runID, taskID string, action task.ControlAction) error {
+	s.controlledTask = runID + ":" + taskID + ":" + string(action)
 	return nil
 }
 
@@ -94,9 +101,12 @@ var _ = Describe("Managed task runs", func() {
 		Expect(snapshots[0].Details).To(Equal(map[string]any{"pid": 1234.0, "status": "running"}))
 		Expect(snapshots[1].Stdout).To(Equal("ready\n"))
 		Expect(snapshots[1].Stderr).To(Equal("warning\n"))
+		Expect(snapshots[1].Controls).To(Equal([]task.ControlAction{task.ControlStop, task.ControlRestart}))
 
 		Expect(task.ControlRun(context.Background(), run.ID(), task.ControlRestart)).To(Succeed())
 		Expect(controller.called).To(Equal(task.ControlRestart))
+		Expect(task.ControlTask(context.Background(), run.ID(), run.TaskID(), task.ControlStop)).To(Succeed())
+		Expect(controller.called).To(Equal(task.ControlStop))
 	})
 
 	It("freezes terminal output and details and aggregates cancellation correctly", func() {
@@ -163,6 +173,46 @@ var _ = Describe("Managed task runs", func() {
 		Eventually(done).Should(BeClosed())
 	})
 
+	It("controls an advertised child task through the task API", func() {
+		controller := &recordingController{actions: []task.ControlAction{task.ControlStop}}
+		group := task.StartGroup[struct{}]("commit project", task.WithGroupID("commit-project-1"))
+		child := group.Add("commit one.go", func(_ commonscontext.Context, _ *task.Task) (struct{}, error) {
+			return struct{}{}, nil
+		}, task.WithTaskController(controller))
+		Eventually(child.Status).Should(Equal(task.StatusSuccess))
+
+		mux := http.NewServeMux()
+		task.RegisterHandlers(mux, "/api")
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/tasks/"+group.ID()+"/tasks/"+child.ID()+"/control",
+			bytes.NewBufferString(`{"action":"stop"}`),
+		)
+		response := httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+
+		Expect(response.Code).To(Equal(http.StatusNoContent), response.Body.String())
+		Expect(controller.called).To(Equal(task.ControlStop))
+
+		request = httptest.NewRequest(
+			http.MethodPost,
+			"/api/tasks/"+group.ID()+"/tasks/"+child.ID()+"/control",
+			bytes.NewBufferString(`{"action":"restart"}`),
+		)
+		response = httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+		Expect(response.Code).To(Equal(http.StatusConflict), response.Body.String())
+
+		request = httptest.NewRequest(
+			http.MethodPost,
+			"/api/tasks/"+group.ID()+"/tasks/missing/control",
+			bytes.NewBufferString(`{"action":"stop"}`),
+		)
+		response = httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+		Expect(response.Code).To(Equal(http.StatusNotFound), response.Body.String())
+	})
+
 	It("merges externally-owned runs into list, detail, stream, and control routes", func() {
 		source := &recordingRunSource{
 			runs: []task.RunMeta{{ID: "remote-1", Name: "api", Kind: "supervised-process", Status: "running"}},
@@ -189,6 +239,12 @@ var _ = Describe("Managed task runs", func() {
 		mux.ServeHTTP(response, request)
 		Expect(response.Code).To(Equal(http.StatusNoContent), response.Body.String())
 		Expect(source.controlled).To(Equal("remote-1:restart"))
+
+		request = httptest.NewRequest(http.MethodPost, "/api/tasks/remote-1/tasks/commit-1/control", bytes.NewBufferString(`{"action":"stop"}`))
+		response = httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+		Expect(response.Code).To(Equal(http.StatusNoContent), response.Body.String())
+		Expect(source.controlledTask).To(Equal("remote-1:commit-1:stop"))
 
 		response = httptest.NewRecorder()
 		mux.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/tasks/metrics/remote-1%3Acpu?since=1h", nil))

--- a/task/manager.go
+++ b/task/manager.go
@@ -49,8 +49,9 @@ type Manager struct {
 	savedLogOutput io.Writer
 
 	// logSerializer is the writer installed while the renderer owns the
-	// terminal. Tick renders read TakeLinesWritten from it to widen the
-	// next ClearLines to cover any log lines that landed between ticks.
+	// terminal. In interactive mode it buffers log lines between ticks;
+	// each tick clears the old frame, flushes the pending lines above it,
+	// then repaints, so log output persists in scrollback.
 	logSerializer *logSerializingWriter
 
 	// liveRenderer, when set, replaces the default task-tree content for live
@@ -84,8 +85,13 @@ type Manager struct {
 	// Terminal state
 	originalTermState *term.State
 
-	// Output buffering
+	// Output buffering. outputBuffer is bounded: once it reaches
+	// captureLimit (default defaultCaptureBufferLimit) the oldest entries
+	// are dropped and outputDropped counts them so the stop flush can
+	// report the truncation explicitly. Both guarded by bufferMutex.
 	outputBuffer    []OutputEntry
+	outputDropped   int
+	captureLimit    int
 	bufferMutex     sync.Mutex
 	originalStdout  *os.File
 	originalStderr  *os.File
@@ -394,7 +400,6 @@ func (tm *Manager) newTask(name string, opts ...Option) *Task {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	flanksourceCtx := flanksourceContext.NewContext(ctx)
-	flanksourceCtx.Logger = logger.GetSlogLogger().Named(fmt.Sprintf("task.%s", name))
 
 	task := &Task{
 		name:           name,
@@ -416,8 +421,16 @@ func (tm *Manager) newTask(name string, opts ...Option) *Task {
 		opt(task)
 	}
 
+	// Route ctx.Logger into the task's buffered logger so context-logged
+	// lines render under the task's line (and stream in plain mode) instead
+	// of interleaving with global logger output. Set on both context copies;
+	// the timeout clone below inherits it via WithTimeout.
+	taskLog := task.contextLogger()
+	task.ctx.Logger = taskLog
+	task.flanksourceCtx.Logger = taskLog
+
 	if task.timeout > 0 {
-		timeoutCtx, timeoutCancel := flanksourceCtx.WithTimeout(task.timeout)
+		timeoutCtx, timeoutCancel := task.flanksourceCtx.WithTimeout(task.timeout)
 		task.ctx = timeoutCtx
 		task.flanksourceCtx = timeoutCtx
 

--- a/task/manager_lifecycle.go
+++ b/task/manager_lifecycle.go
@@ -67,7 +67,7 @@ func (tm *Manager) startRenderLoop() {
 func (tm *Manager) installLogSerializer() {
 	prev := logger.GetOutput()
 	tm.savedLogOutput = prev
-	ser := newLogSerializingWriter(&tm.bufferMutex, prev)
+	ser := newLogSerializingWriter(&tm.bufferMutex, prev, tm.isInteractive.Load())
 	tm.logSerializer = ser
 	logger.SetOutput(ser)
 }
@@ -78,6 +78,11 @@ func (tm *Manager) uninstallLogSerializer() {
 	if tm.savedLogOutput == nil {
 		return
 	}
+	// A log line can land after the loop's final tick; emit it below the
+	// final frame rather than dropping it.
+	tm.bufferMutex.Lock()
+	tm.logSerializer.FlushPending()
+	tm.bufferMutex.Unlock()
 	logger.SetOutput(tm.savedLogOutput)
 	tm.savedLogOutput = nil
 	tm.logSerializer = nil
@@ -103,7 +108,7 @@ func (tm *Manager) renderLoop() {
 		tm.bufferMutex.Unlock()
 	}
 
-	var lastLines int
+	lastLines := -1
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -116,15 +121,17 @@ func (tm *Manager) renderLoop() {
 				// interactiveRender atomically ClearLines(lastLines) then
 				// writes the fresh content, avoiding the double-emit that
 				// would occur if we cleared here and also called
-				// renderFinal below in stopRender.
-				tm.interactiveRender(lastLines)
+				// renderFinal below in stopRender. final=true lifts the
+				// terminal-height cap so problem tasks are never clipped
+				// in the frame that persists in scrollback.
+				tm.interactiveRender(lastLines, true)
 			} else {
 				tm.PlainRender()
 			}
 			return
 		case <-ticker.C:
 			if tm.isInteractive.Load() {
-				lastLines = tm.interactiveRender(lastLines)
+				lastLines = tm.interactiveRender(lastLines, false)
 			} else {
 				tm.PlainRender()
 			}
@@ -198,6 +205,11 @@ func (tm *Manager) finishRenderTeardown(loopWasRunning bool) {
 	tm.mu.Unlock()
 	if teardown {
 		tm.releaseRenderTerminal()
+		// The renderer no longer owns the TTY: emit stderr writes that
+		// GatedStderr buffered during the render window (F4). They appear
+		// below the final frame, still in arrival order and already
+		// secret-redacted by the upstream log writer.
+		flushGatedStderr()
 	}
 }
 
@@ -245,6 +257,9 @@ func (tm *Manager) renderFinal(loopRan bool) {
 		rendered = plainSummaryText(taskSnapshot)
 	} else {
 		rendered = tm.prettyFromTasks(taskSnapshot)
+	}
+	if rendered.IsEmpty() {
+		return
 	}
 	// Write through renderer.Output (original stderr captured at init) so
 	// the final summary joins the live render stream and doesn't land in

--- a/task/manager_output.go
+++ b/task/manager_output.go
@@ -14,6 +14,40 @@ type OutputEntry struct {
 	Line      string
 }
 
+const (
+	// defaultCaptureBufferLimit bounds the captured-output line buffer so a
+	// chatty long-running capture cannot grow memory without limit. Oldest
+	// lines are dropped first; the drop count is reported at flush time.
+	defaultCaptureBufferLimit = 10_000
+
+	// captureTailLines is how many of the newest captured lines the live
+	// interactive frame shows while tasks are running.
+	captureTailLines = 5
+)
+
+// captureBufferLimit returns the effective buffer bound. Caller must hold
+// bufferMutex (it reads captureLimit, which tests override).
+func (tm *Manager) captureBufferLimit() int {
+	if tm.captureLimit > 0 {
+		return tm.captureLimit
+	}
+	return defaultCaptureBufferLimit
+}
+
+// appendOutputLocked appends one captured line, evicting the oldest entries
+// once the buffer hits its bound. Eviction happens in batches (a tenth of
+// the limit) so the memmove cost is amortized; outputDropped stays exact.
+// Caller must hold bufferMutex.
+func (tm *Manager) appendOutputLocked(entry OutputEntry) {
+	limit := tm.captureBufferLimit()
+	if len(tm.outputBuffer) >= limit {
+		drop := max(1, limit/10)
+		tm.outputBuffer = tm.outputBuffer[:copy(tm.outputBuffer, tm.outputBuffer[drop:])]
+		tm.outputDropped += drop
+	}
+	tm.outputBuffer = append(tm.outputBuffer, entry)
+}
+
 // bufferingWriter captures writes to a buffer with timestamps.
 // It accumulates partial lines between Write calls so that a logical
 // line split across multiple reads is emitted as a single OutputEntry.
@@ -39,7 +73,7 @@ func (w *bufferingWriter) Write(p []byte) (n int, err error) {
 			w.remainder = line
 			break
 		}
-		w.manager.outputBuffer = append(w.manager.outputBuffer, OutputEntry{
+		w.manager.appendOutputLocked(OutputEntry{
 			Timestamp: time.Now(),
 			Stream:    w.stream,
 			Line:      line,
@@ -55,7 +89,7 @@ func (w *bufferingWriter) Flush() {
 	defer w.manager.bufferMutex.Unlock()
 
 	if w.remainder != "" {
-		w.manager.outputBuffer = append(w.manager.outputBuffer, OutputEntry{
+		w.manager.appendOutputLocked(OutputEntry{
 			Timestamp: time.Now(),
 			Stream:    w.stream,
 			Line:      w.remainder,
@@ -76,6 +110,7 @@ func (tm *Manager) StartCapturingOutput() {
 	tm.originalStdout = os.Stdout
 	tm.originalStderr = os.Stderr
 	tm.outputBuffer = []OutputEntry{}
+	tm.outputDropped = 0
 
 	// Create pipes for stdout and stderr
 	var err error
@@ -189,8 +224,13 @@ func (tm *Manager) StopCapturingOutput() {
 	tm.bufferMutex.Lock()
 	buffer := make([]OutputEntry, len(tm.outputBuffer))
 	copy(buffer, tm.outputBuffer)
+	dropped := tm.outputDropped
+	limit := tm.captureBufferLimit()
 	tm.bufferMutex.Unlock()
 
+	if dropped > 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "[task] captured output truncated: %d oldest lines dropped (buffer limit %d)\n", dropped, limit)
+	}
 	for _, entry := range buffer {
 		if entry.Stream == "stdout" {
 			_, _ = fmt.Fprintln(os.Stdout, entry.Line)

--- a/task/manager_output_test.go
+++ b/task/manager_output_test.go
@@ -172,6 +172,64 @@ func TestWaitFlushesAndStopsCapture(t *testing.T) {
 	}
 }
 
+// F6: the capture buffer is bounded — once the limit is reached the oldest
+// lines are dropped (and counted) while the newest are retained.
+func TestCaptureBufferBounded(t *testing.T) {
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.captureLimit = 10
+
+	w := &bufferingWriter{stream: "stdout", manager: tm}
+	for i := 0; i < 25; i++ {
+		_, _ = fmt.Fprintf(w, "line-%d\n", i)
+	}
+
+	tm.bufferMutex.Lock()
+	defer tm.bufferMutex.Unlock()
+	if len(tm.outputBuffer) > 10 {
+		t.Fatalf("buffer must stay within the limit, got %d entries", len(tm.outputBuffer))
+	}
+	if got := tm.outputDropped + len(tm.outputBuffer); got != 25 {
+		t.Errorf("dropped+retained must account for every line: got %d want 25", got)
+	}
+	if last := tm.outputBuffer[len(tm.outputBuffer)-1].Line; last != "line-24" {
+		t.Errorf("newest line must be retained, got %q", last)
+	}
+	if first := tm.outputBuffer[0].Line; first != fmt.Sprintf("line-%d", tm.outputDropped) {
+		t.Errorf("retained lines must be the contiguous newest ones: first=%q dropped=%d", first, tm.outputDropped)
+	}
+}
+
+// F6: truncation is reported explicitly — the stop flush announces how many
+// lines were dropped instead of silently emitting a hole.
+func TestStopReportsTruncation(t *testing.T) {
+	outR, errR, closeWriters := swapTestPipes(t)
+
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.captureLimit = 5
+
+	tm.StartCapturingOutput()
+	for i := 0; i < 12; i++ {
+		fmt.Fprintf(os.Stdout, "cap-%d\n", i)
+	}
+	tm.StopCapturingOutput()
+	closeWriters()
+
+	stdoutBytes, _ := io.ReadAll(outR)
+	stderrBytes, _ := io.ReadAll(errR)
+
+	if !bytes.Contains(stderrBytes, []byte("7 oldest lines dropped")) {
+		t.Errorf("stop must report the exact drop count, got %q", stderrBytes)
+	}
+	if !bytes.Contains(stdoutBytes, []byte("cap-11")) {
+		t.Errorf("newest captured lines must be flushed, got %q", stdoutBytes)
+	}
+	if bytes.Contains(stdoutBytes, []byte("cap-6\n")) {
+		t.Errorf("dropped lines must not reappear in the flush, got %q", stdoutBytes)
+	}
+}
+
 // TestStopWithoutStartIsSafe ensures StopCapturingOutput is a no-op when
 // StartCapturingOutput was never called — gavel relies on this to use
 // defer StopCapturingOutput() across code paths that may not have

--- a/task/pretty_short_ginkgo_test.go
+++ b/task/pretty_short_ginkgo_test.go
@@ -1,0 +1,44 @@
+package task_test
+
+import (
+	"errors"
+
+	"github.com/flanksource/clicky/api"
+	"github.com/flanksource/clicky/task"
+	flanksourceContext "github.com/flanksource/commons/context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type shortAndFullResult struct{}
+
+func (shortAndFullResult) Pretty() api.Text          { return api.Text{}.Append("full\nstdout") }
+func (shortAndFullResult) PrettyShort() api.Textable { return api.Text{}.Append("short") }
+
+var _ = Describe("Task result rendering", func() {
+	BeforeEach(func() {
+		task.SetNoRender(true)
+	})
+
+	AfterEach(func() {
+		task.SetNoRender(false)
+	})
+
+	It("prefers PrettyShort over Pretty", func() {
+		running := task.StartTask("fixture", func(flanksourceContext.Context, *task.Task) (shortAndFullResult, error) {
+			return shortAndFullResult{}, nil
+		})
+		_, err := running.GetResult()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(running.Pretty().String()).To(Equal("short"))
+	})
+
+	It("still returns task failures", func() {
+		running := task.StartTask("fixture", func(flanksourceContext.Context, *task.Task) (shortAndFullResult, error) {
+			return shortAndFullResult{}, errors.New("failed")
+		})
+		_, err := running.GetResult()
+		Expect(err).To(MatchError("failed"))
+	})
+})

--- a/task/render.go
+++ b/task/render.go
@@ -43,6 +43,9 @@ func (tm *Manager) PlainRender() {
 	for _, task := range taskSnapshot {
 		if task.PopDirty() {
 			rendered := task.prettyPlainDelta()
+			if rendered.IsEmpty() {
+				continue
+			}
 			tm.bufferMutex.Lock()
 			if tm.noColor.Load() {
 				fmt.Fprintf(output, "%s\n", rendered.String())
@@ -59,6 +62,9 @@ func (tm *Manager) PlainRender() {
 // the block.
 func (tm *Manager) plainRenderLive(r LiveRenderer) {
 	rendered := r.RenderLive(tm.snapshotTasks())
+	if rendered.IsEmpty() {
+		return
+	}
 	output := tm.renderer.Output()
 	tm.bufferMutex.Lock()
 	defer tm.bufferMutex.Unlock()
@@ -78,11 +84,62 @@ func (tm *Manager) Pretty() api.Text {
 
 // renderLiveText produces the content for one live tick: the installed
 // LiveRenderer's output when set, otherwise the default task-tree formatting.
+// While output capture is active and work is still running, a tail of the
+// newest captured lines is appended below either block so a long-running
+// capture isn't a black hole until the stop flush.
 func (tm *Manager) renderLiveText() api.Text {
+	tasks := tm.snapshotTasks()
+	var text api.Text
 	if r := tm.getLiveRenderer(); r != nil {
-		return r.RenderLive(tm.snapshotTasks())
+		text = r.RenderLive(tasks)
+	} else {
+		text = tm.prettyFromTasks(tasks)
 	}
-	return tm.Pretty()
+	if tail := tm.captureTailText(tasks); tail.Content != "" {
+		text.Children = append(text.Children, tail)
+	}
+	return text
+}
+
+// captureTailText renders the last captureTailLines captured stdout/stderr
+// lines as a dim block for the live frame. Empty unless capture is active
+// and at least one task is running — the running gate keeps the final frame
+// free of lines StopCapturingOutput is about to replay in full, and the
+// header's "last N of M" total includes lines already dropped by the
+// bounded buffer.
+func (tm *Manager) captureTailText(tasks []*Task) api.Text {
+	running := false
+	for _, t := range tasks {
+		if t.Status() == StatusRunning {
+			running = true
+			break
+		}
+	}
+	if !running {
+		return api.Text{}
+	}
+
+	tm.bufferMutex.Lock()
+	capturing := tm.capturingOutput
+	total := tm.outputDropped + len(tm.outputBuffer)
+	n := min(captureTailLines, len(tm.outputBuffer))
+	entries := make([]OutputEntry, n)
+	copy(entries, tm.outputBuffer[len(tm.outputBuffer)-n:])
+	tm.bufferMutex.Unlock()
+
+	if !capturing || n == 0 {
+		return api.Text{}
+	}
+
+	header := "captured output"
+	if total > n {
+		header = fmt.Sprintf("captured output (last %d of %d lines)", n, total)
+	}
+	text := api.Text{Content: header + "\n", Style: "text-gray-400"}.Indent(2)
+	for _, e := range entries {
+		text.Children = append(text.Children, api.Text{Content: e.Line + "\n", Style: "text-gray-500"}.Indent(4))
+	}
+	return text
 }
 
 // prettyFromTasks formats a snapshot of tasks without needing locks.
@@ -107,17 +164,21 @@ func (tm *Manager) prettyFromTasks(tasks []*Task) api.Text {
 		return api.Text{}
 	}
 
-	var problemTasks, runningTasks, successTasks, pendingTasks []*Task
+	var problemTasks, runningTasks, successTasks, pendingTasks []api.Text
 	for _, task := range tasks {
+		rendered := task.Pretty()
+		if rendered.IsEmpty() {
+			continue
+		}
 		switch task.Status() {
 		case StatusPending:
-			pendingTasks = append(pendingTasks, task)
+			pendingTasks = append(pendingTasks, rendered)
 		case StatusRunning:
-			runningTasks = append(runningTasks, task)
+			runningTasks = append(runningTasks, rendered)
 		case StatusFailed, StatusWarning, StatusCancelled, StatusFAIL, StatusERR:
-			problemTasks = append(problemTasks, task)
+			problemTasks = append(problemTasks, rendered)
 		default:
-			successTasks = append(successTasks, task)
+			successTasks = append(successTasks, rendered)
 		}
 	}
 
@@ -136,8 +197,8 @@ func (tm *Manager) prettyFromTasks(tasks []*Task) api.Text {
 	successBudget := termHeight - len(problemTasks) - len(runningTasks) - pendingLines
 	successBudget = max(successBudget, 3)
 
-	appendTask := func(t *Task) {
-		text.Children = append(text.Children, t.Pretty().Append("\n", "").Indent(2))
+	appendTask := func(rendered api.Text) {
+		text.Children = append(text.Children, rendered.Append("\n", "").Indent(2))
 	}
 	appendSummary := func(content string) {
 		text.Children = append(text.Children, api.Text{
@@ -222,9 +283,20 @@ func plainSummaryText(tasks []*Task) api.Text {
 }
 
 // interactiveRender renders tasks in-place using ANSI clear lines.
-// Returns the number of lines rendered for the next cycle's ClearLines call.
-func (tm *Manager) interactiveRender(lastLines int) int {
+// Returns the ClearLines argument for the next cycle, or -1 when no frame was
+// rendered. ClearLines(0) clears one terminal row, so zero cannot represent an
+// absent frame.
+// Live ticks are capped to the terminal height so the in-place redraw fits
+// the screen; the final frame (final=true) is uncapped — rendering has
+// stopped, scrollback can hold everything, and clipping failed tasks at
+// exit hides exactly what the user needs most.
+func (tm *Manager) interactiveRender(lastLines int, final bool) int {
 	rendered := tm.renderLiveText()
+	if final {
+		if renderer := tm.getLiveRenderer(); renderer != nil {
+			rendered = renderer.RenderFinal(tm.snapshotTasks())
+		}
+	}
 	var out string
 	if tm.noColor.Load() {
 		out = rendered.String()
@@ -232,7 +304,9 @@ func (tm *Manager) interactiveRender(lastLines int) int {
 		out = rendered.ANSI()
 	}
 
-	out = lipgloss.NewStyle().MaxHeight(api.GetTerminalLines()).Render(out)
+	if !final {
+		out = lipgloss.NewStyle().MaxHeight(api.GetTerminalLines()).Render(out)
+	}
 
 	// Strip trailing whitespace that lipgloss adds for line normalization.
 	// This prevents bloated output in .cast recordings and piped output.
@@ -249,24 +323,31 @@ func (tm *Manager) interactiveRender(lastLines int) int {
 	// the same mutex; the render side holds it for the brief duration of
 	// the clear + Fprint, well under a 250ms tick.
 	tm.bufferMutex.Lock()
-	// Widen the clear to cover any log lines the serializer emitted since
-	// the last tick. Without this, a logger.Infof between ticks advances
-	// the cursor past the tracked region; the next ClearLines(lastLines)
-	// undercounts and leaves the top of the previous frame stacked above
-	// the new one.
-	extra := 0
-	if tm.logSerializer != nil {
-		extra = tm.logSerializer.TakeLinesWritten()
+	// Clear only the previous frame, then emit log lines the serializer
+	// buffered since the last tick before painting the new frame below
+	// them. The log lines land above the frame and stay in scrollback
+	// (bubbletea's tea.Println pattern) instead of being erased by the
+	// next tick's clear.
+	if lastLines >= 0 {
+		output.ClearLines(lastLines)
+		fmt.Fprint(output, "\r")
 	}
-	output.ClearLines(lastLines + extra)
+	if tm.logSerializer != nil {
+		tm.logSerializer.FlushPending()
+	}
 	// Write content through the renderer's Output, which holds the original
 	// stderr captured at manager init. Routing through bare os.Stderr here
 	// would split writes across two sinks — the ClearLines bytes go direct
 	// to the terminal while the content goes into StartCapturingOutput's
 	// buffer and gets flushed at shutdown, stripping the clears from the
 	// content and leaving every rendered frame stacked in the final output.
-	fmt.Fprint(output, out)
+	if out != "" {
+		fmt.Fprint(output, out)
+	}
 	tm.bufferMutex.Unlock()
+	if out == "" {
+		return -1
+	}
 
 	// Return PHYSICAL rows, not logical lines. A line wider than the terminal
 	// soft-wraps onto multiple rows; counting newlines (strings.Count) would

--- a/task/render_custom_final_test.go
+++ b/task/render_custom_final_test.go
@@ -1,0 +1,33 @@
+package task
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestInteractiveRenderUsesCustomFinalContent(t *testing.T) {
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.isInteractive.Store(true)
+
+	buf := &syncBuffer{}
+	tm.renderer = lipgloss.NewRenderer(buf)
+	tm.setLiveRenderer(&fakeLiveRenderer{live: "LIVE-ONLY", final: "FINAL-SUMMARY"})
+	addCompletedTask(tm, "fixture")
+
+	rows := tm.interactiveRender(0, false)
+	tm.interactiveRender(rows, true)
+
+	output := buf.String()
+	if strings.Count(output, "LIVE-ONLY") != 1 {
+		t.Fatalf("final render must not repeat live content, got %q", output)
+	}
+	if !strings.Contains(output, "FINAL-SUMMARY") {
+		t.Fatalf("final render must use RenderFinal content, got %q", output)
+	}
+	if !strings.Contains(output, "\x1b[2K\rFINAL-SUMMARY") {
+		t.Fatalf("final render must restart at the first terminal column, got %q", output)
+	}
+}

--- a/task/render_empty_ginkgo_test.go
+++ b/task/render_empty_ginkgo_test.go
@@ -1,0 +1,123 @@
+package task
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/flanksource/clicky/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type emptyPrettyShortResult struct{}
+
+func (emptyPrettyShortResult) PrettyShort() api.Textable {
+	return api.Text{}
+}
+
+var _ = Describe("Empty task rendering", func() {
+	newEmptyResultTask := func(tm *Manager, name string) *Task {
+		task := tm.newTask(name)
+		task.result = emptyPrettyShortResult{}
+		task.SetStatus(StatusSuccess)
+		task.completed.Store(true)
+		task.dirty.Store(true)
+		return task
+	}
+
+	It("does not allocate rows to hidden task results", func() {
+		tm := newTestManager(1)
+		DeferCleanup(func() { close(tm.shutdown) })
+
+		hiddenBefore := newEmptyResultTask(tm, "hidden-before")
+		visible := tm.newTask("visible-failure")
+		visible.SetStatus(StatusFailed)
+		visible.completed.Store(true)
+		hiddenAfter := newEmptyResultTask(tm, "hidden-after")
+
+		rendered := tm.prettyFromTasks([]*Task{hiddenBefore, visible, hiddenAfter}).String()
+		lines := strings.Split(strings.TrimRight(rendered, " \t\r\n"), "\n")
+
+		Expect(lines).To(HaveLen(1))
+		Expect(lines[0]).To(ContainSubstring("visible-failure"))
+		Expect(rendered).NotTo(ContainSubstring("hidden-before"))
+		Expect(rendered).NotTo(ContainSubstring("hidden-after"))
+	})
+
+	It("returns an empty task tree when every task result is hidden", func() {
+		tm := newTestManager(1)
+		DeferCleanup(func() { close(tm.shutdown) })
+
+		rendered := tm.prettyFromTasks([]*Task{
+			newEmptyResultTask(tm, "hidden-one"),
+			newEmptyResultTask(tm, "hidden-two"),
+		})
+
+		Expect(rendered.IsEmpty()).To(BeTrue())
+		Expect(rendered.String()).To(BeEmpty())
+	})
+
+	It("does not print an empty plain task delta", func() {
+		tm := newTestManager(1)
+		DeferCleanup(func() { close(tm.shutdown) })
+		output := &syncBuffer{}
+		tm.renderer = lipgloss.NewRenderer(output)
+		tm.tasks = append(tm.tasks, newEmptyResultTask(tm, "hidden"))
+
+		tm.PlainRender()
+
+		Expect(output.String()).To(BeEmpty())
+	})
+
+	It("does not print empty plain live or final blocks", func() {
+		tm := newTestManager(1)
+		DeferCleanup(func() { close(tm.shutdown) })
+		output := &syncBuffer{}
+		tm.renderer = lipgloss.NewRenderer(output)
+		tm.setLiveRenderer(&fakeLiveRenderer{})
+		tm.tasks = append(tm.tasks, newEmptyResultTask(tm, "hidden"))
+
+		tm.PlainRender()
+		tm.renderFinal(false)
+
+		Expect(output.String()).To(BeEmpty())
+	})
+
+	It("emits no terminal bytes for an empty frame without a previous frame", func() {
+		tm := newTestManager(1)
+		DeferCleanup(func() { close(tm.shutdown) })
+		tm.isInteractive.Store(true)
+		output := &syncBuffer{}
+		tm.renderer = lipgloss.NewRenderer(output)
+		tm.setLiveRenderer(&fakeLiveRenderer{})
+
+		lastLines := tm.interactiveRender(-1, false)
+
+		Expect(lastLines).To(Equal(-1))
+		Expect(output.String()).To(BeEmpty())
+	})
+
+	It("clears a populated frame once when the next frame is empty", func() {
+		tm := newTestManager(1)
+		DeferCleanup(func() { close(tm.shutdown) })
+		tm.isInteractive.Store(true)
+		output := &syncBuffer{}
+		tm.renderer = lipgloss.NewRenderer(output)
+		renderer := &fakeLiveRenderer{live: "visible"}
+		tm.setLiveRenderer(renderer)
+
+		lastLines := tm.interactiveRender(-1, false)
+		firstTickBytes := len(output.String())
+		renderer.live = ""
+		lastLines = tm.interactiveRender(lastLines, false)
+		clearingTick := output.String()[firstTickBytes:]
+
+		Expect(lastLines).To(Equal(-1))
+		Expect(clearingTick).To(Equal("\x1b[2K\r"))
+
+		bytesAfterClear := len(output.String())
+		lastLines = tm.interactiveRender(lastLines, false)
+		Expect(lastLines).To(Equal(-1))
+		Expect(output.String()).To(HaveLen(bytesAfterClear))
+	})
+})

--- a/task/render_hook_test.go
+++ b/task/render_hook_test.go
@@ -184,23 +184,32 @@ func TestSetLiveRenderer_RoundTrip(t *testing.T) {
 	}
 }
 
-// With a custom renderer active, a logger line emitted between ticks is still
-// accounted for by the serializer, so the next ClearLines widens to cover it.
-// This is the property that fixes the original corruption: the hook must not
-// bypass the line-accounting that keeps the redraw in sync.
-func TestLiveRenderer_LoggerLinesStillAccounted(t *testing.T) {
+// With a custom renderer active the serializer contract still holds: in
+// interactive mode a logger line emitted between ticks is buffered and
+// emitted above the next frame (FlushPending) rather than written mid-frame
+// or erased by the next ClearLines.
+func TestLiveRenderer_LoggerLinesBufferedForNextTick(t *testing.T) {
 	tm := &Manager{}
+	tm.isInteractive.Store(true)
+
+	var next bytes.Buffer
+	origLog := logger.GetOutput()
+	logger.SetOutput(&next)
+	t.Cleanup(func() { logger.SetOutput(origLog) })
 	tm.installLogSerializer()
 	t.Cleanup(tm.uninstallLogSerializer)
 
 	tm.setLiveRenderer(&fakeLiveRenderer{live: "block"})
 
 	logger.Infof("between-ticks log line")
+	if next.Len() != 0 {
+		t.Fatalf("interactive log write must be buffered until the next tick, got %q", next.String())
+	}
 
-	// The serializer counted the newline the logger emitted; a tick reads it
-	// via TakeLinesWritten to widen ClearLines. Without accounting this is 0
-	// and the next frame would stack.
-	if got := tm.logSerializer.TakeLinesWritten(); got < 1 {
-		t.Errorf("expected logger line to be counted for ClearLines widening, got %d", got)
+	tm.bufferMutex.Lock()
+	tm.logSerializer.FlushPending()
+	tm.bufferMutex.Unlock()
+	if !strings.Contains(next.String(), "between-ticks log line") {
+		t.Errorf("FlushPending must emit the buffered logger line, got %q", next.String())
 	}
 }

--- a/task/render_log_persist_test.go
+++ b/task/render_log_persist_test.go
@@ -1,0 +1,217 @@
+package task
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/flanksource/commons/logger"
+
+	"github.com/flanksource/clicky/api"
+)
+
+// F5: logger lines emitted between interactive ticks must persist in
+// scrollback above the live frame. The tick clears only the old frame,
+// prints the pending log lines, then repaints the frame below them (the
+// bubbletea tea.Println pattern) — the log lines are never cleared.
+func TestInteractiveRender_LogLinesPersistAboveFrame(t *testing.T) {
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.isInteractive.Store(true)
+
+	// Route the renderer and the logger into the same recording buffer so
+	// write ordering across both sinks is observable (in production both
+	// are stderr).
+	buf := &syncBuffer{}
+	tm.renderer = lipgloss.NewRenderer(buf)
+
+	origLog := logger.GetOutput()
+	logger.SetOutput(buf)
+	tm.installLogSerializer()
+	t.Cleanup(func() {
+		tm.uninstallLogSerializer()
+		logger.SetOutput(origLog)
+	})
+
+	task := tm.newTask("frame-task")
+	task.SetStatus(StatusSuccess)
+	task.completed.Store(true)
+	tm.mu.Lock()
+	tm.tasks = append(tm.tasks, task)
+	tm.mu.Unlock()
+
+	frameRows := tm.interactiveRender(0, false)
+	tick1 := buf.String()
+
+	if _, err := tm.logSerializer.Write([]byte("LOG-BETWEEN-TICKS\n")); err != nil {
+		t.Fatalf("serializer write: %v", err)
+	}
+	if got := buf.String(); got != tick1 {
+		t.Fatalf("interactive log write must be buffered until the next tick; wrote %q", got[len(tick1):])
+	}
+
+	tm.interactiveRender(frameRows, false)
+	tick2 := buf.String()[len(tick1):]
+
+	logIdx := strings.Index(tick2, "LOG-BETWEEN-TICKS")
+	frameIdx := strings.Index(tick2, "frame-task")
+	if logIdx < 0 || frameIdx < 0 {
+		t.Fatalf("tick must emit both the log line and the frame; got:\n%q", tick2)
+	}
+	if logIdx > frameIdx {
+		t.Errorf("log line must be printed above the repainted frame; got:\n%q", tick2)
+	}
+
+	// The clear must cover only the old frame's rows; widening it would
+	// erase the log line the moment the next tick fires.
+	if ups := strings.Count(tick2, "\x1b[1A"); ups != frameRows {
+		t.Errorf("tick cleared %d rows, want %d (previous frame only)", ups, frameRows)
+	}
+
+	tm.interactiveRender(frameRows, false)
+	tick3 := buf.String()[len(tick1)+len(tick2):]
+	if strings.Contains(tick3, "LOG-BETWEEN-TICKS") {
+		t.Errorf("log line must be emitted exactly once, found again in tick 3:\n%q", tick3)
+	}
+}
+
+// newTailTestManager builds an interactive manager whose renderer writes to
+// a recording buffer, with fabricated capture state: entries "cap-line-0"
+// .. "cap-line-7" in the buffer and 3 lines already dropped (11 total).
+func newTailTestManager(t *testing.T, capturing bool) (*Manager, *syncBuffer) {
+	t.Helper()
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.isInteractive.Store(true)
+
+	buf := &syncBuffer{}
+	tm.renderer = lipgloss.NewRenderer(buf)
+
+	tm.bufferMutex.Lock()
+	tm.capturingOutput = capturing
+	tm.outputDropped = 3
+	for i := 0; i < 8; i++ {
+		tm.outputBuffer = append(tm.outputBuffer, OutputEntry{Stream: "stdout", Line: "cap-line-" + string(rune('0'+i))})
+	}
+	tm.bufferMutex.Unlock()
+	t.Cleanup(func() {
+		tm.bufferMutex.Lock()
+		tm.capturingOutput = false
+		tm.bufferMutex.Unlock()
+	})
+	return tm, buf
+}
+
+func addTailTask(tm *Manager, name string, status Status) {
+	task := tm.newTask(name)
+	task.SetStatus(status)
+	if status != StatusPending && status != StatusRunning {
+		task.completed.Store(true)
+	}
+	tm.mu.Lock()
+	tm.tasks = append(tm.tasks, task)
+	tm.mu.Unlock()
+}
+
+// F6: while capture is active and work is running, the live frame shows a
+// tail of the newest captured lines with an explicit "last N of M" header
+// counting dropped lines too.
+func TestInteractiveRender_ShowsCaptureTail(t *testing.T) {
+	tm, buf := newTailTestManager(t, true)
+	addTailTask(tm, "runner", StatusRunning)
+
+	tm.interactiveRender(0, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "cap-line-7") {
+		t.Errorf("live frame must show the newest captured line, got:\n%q", out)
+	}
+	if strings.Contains(out, "cap-line-2") {
+		t.Errorf("live tail must show only the last lines, got:\n%q", out)
+	}
+	if !strings.Contains(out, "last 5 of 11 lines") {
+		t.Errorf("tail header must report tail size and total (incl. dropped), got:\n%q", out)
+	}
+}
+
+// The tail disappears once nothing is running: the final frame must not
+// duplicate lines the stop flush is about to replay in full.
+func TestInteractiveRender_TailHiddenWhenNothingRunning(t *testing.T) {
+	tm, buf := newTailTestManager(t, true)
+	addTailTask(tm, "done-task", StatusSuccess)
+
+	tm.interactiveRender(0, false)
+	if out := buf.String(); strings.Contains(out, "cap-line") {
+		t.Errorf("tail must be hidden when no task is running, got:\n%q", out)
+	}
+}
+
+// No tail when capture isn't active, buffer residue notwithstanding.
+func TestInteractiveRender_TailHiddenWhenNotCapturing(t *testing.T) {
+	tm, buf := newTailTestManager(t, false)
+	addTailTask(tm, "runner", StatusRunning)
+
+	tm.interactiveRender(0, false)
+	if out := buf.String(); strings.Contains(out, "cap-line") {
+		t.Errorf("tail must be hidden when capture is inactive, got:\n%q", out)
+	}
+}
+
+// F16: live ticks stay capped to the terminal height, but the final frame
+// escapes the cap so problem tasks are never clipped at exit.
+func TestFinalInteractiveRenderUncapped(t *testing.T) {
+	api.SetTerminalLines(6)
+	t.Cleanup(func() { api.SetTerminalLines(-1) })
+
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.isInteractive.Store(true)
+	buf := &syncBuffer{}
+	tm.renderer = lipgloss.NewRenderer(buf)
+
+	for i := 0; i < 10; i++ {
+		addTailTask(tm, fmt.Sprintf("fail-%d", i), StatusFailed)
+	}
+
+	tm.interactiveRender(0, false)
+	tick := buf.String()
+	if strings.Contains(tick, "fail-9") {
+		t.Fatalf("live tick must stay height-capped (fail-9 should be clipped), got:\n%q", tick)
+	}
+
+	tm.interactiveRender(0, true)
+	final := buf.String()[len(tick):]
+	for i := 0; i < 10; i++ {
+		if !strings.Contains(final, fmt.Sprintf("fail-%d", i)) {
+			t.Errorf("final frame must include fail-%d despite the terminal height cap", i)
+		}
+	}
+}
+
+// A log line that lands after the loop's final tick must be flushed by
+// uninstallLogSerializer (below the final frame), not dropped.
+func TestUninstallLogSerializer_FlushesPending(t *testing.T) {
+	tm := &Manager{}
+	tm.isInteractive.Store(true)
+
+	buf := &syncBuffer{}
+	origLog := logger.GetOutput()
+	logger.SetOutput(buf)
+	t.Cleanup(func() { logger.SetOutput(origLog) })
+	tm.installLogSerializer()
+
+	logger.Infof("late log line")
+	if strings.Contains(buf.String(), "late log line") {
+		t.Fatalf("interactive log write must be buffered until flushed, got %q", buf.String())
+	}
+
+	tm.uninstallLogSerializer()
+	if !strings.Contains(buf.String(), "late log line") {
+		t.Errorf("uninstall must flush pending log lines, got %q", buf.String())
+	}
+	if logger.GetOutput() != io.Writer(buf) {
+		t.Errorf("uninstall must restore the previous logger output")
+	}
+}

--- a/task/source.go
+++ b/task/source.go
@@ -15,6 +15,12 @@ type RunSource interface {
 	Control(context.Context, string, ControlAction) error
 }
 
+// TaskControlSource is implemented by run sources that can route lifecycle
+// controls to child tasks owned outside this process.
+type TaskControlSource interface {
+	ControlTask(context.Context, string, string, ControlAction) error
+}
+
 // MetricSource is optionally implemented by a RunSource that owns live metrics.
 type MetricSource interface {
 	QueryMetric(context.Context, metrics.QueryRequest) ([]metrics.Point, error)

--- a/task/stderr_gate.go
+++ b/task/stderr_gate.go
@@ -1,33 +1,69 @@
 package task
 
 import (
+	"bytes"
 	"io"
 	"os"
+	"sync"
 )
 
 // stderrGate forwards writes to os.Stderr unless the interactive task
-// renderer currently owns the TTY, in which case the write is silently
-// dropped. Used by callers that emit log-style content to stderr (e.g.
-// clicky.Infof's logWriter, ai/cache debug prints) so their output
-// cannot corrupt the renderer's in-place frame.
+// renderer currently owns the TTY, in which case the write is buffered and
+// flushed to os.Stderr right after the renderer releases the terminal
+// (stopRender's teardown calls flushGatedStderr). Used by callers that emit
+// log-style content to stderr (e.g. clicky.Infof's logWriter, ai/cache
+// debug prints) so their output cannot corrupt the renderer's in-place
+// frame yet is never lost.
 //
-// Drops are silent by design: the user opted in by starting the
-// interactive renderer. If you need writes preserved across the render
-// window, route through commons/logger (already serialized via
-// logSerializingWriter) or use StartCapturingOutput.
+// Content arrives already secret-redacted — clicky's logWriter wraps this
+// gate in text.LineFilter(RedactSecrets) — so flushing the raw buffered
+// bytes preserves redaction.
 type stderrGate struct{}
 
-func (stderrGate) Write(p []byte) (int, error) {
-	if IsInteractiveRenderActive() {
-		return len(p), nil
-	}
-	return os.Stderr.Write(p)
+// gatedStderrBuf holds writes that arrived while the interactive renderer
+// owned the TTY, in arrival order, until flushGatedStderr runs.
+var gatedStderrBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
 }
 
-// GatedStderr returns a writer that wraps os.Stderr but drops writes
-// while the interactive task renderer owns the TTY. The writer is
-// stateless; each Write rechecks ownership, so a writer captured before
-// the renderer started still gates correctly.
+func (stderrGate) Write(p []byte) (int, error) {
+	if !IsInteractiveRenderActive() {
+		return os.Stderr.Write(p)
+	}
+	gatedStderrBuf.mu.Lock()
+	defer gatedStderrBuf.mu.Unlock()
+	gatedStderrBuf.buf.Write(p)
+	if !IsInteractiveRenderActive() {
+		// The renderer released the TTY between the gate check and taking
+		// the lock; the teardown flush may already have run, so flush now
+		// rather than stranding the bytes until a future render cycle.
+		flushGatedStderrLocked()
+	}
+	return len(p), nil
+}
+
+// flushGatedStderr emits everything buffered during the render window to
+// os.Stderr and empties the buffer. Called by finishRenderTeardown right
+// after the renderer releases the terminal.
+func flushGatedStderr() {
+	gatedStderrBuf.mu.Lock()
+	defer gatedStderrBuf.mu.Unlock()
+	flushGatedStderrLocked()
+}
+
+func flushGatedStderrLocked() {
+	if gatedStderrBuf.buf.Len() == 0 {
+		return
+	}
+	_, _ = os.Stderr.Write(gatedStderrBuf.buf.Bytes())
+	gatedStderrBuf.buf.Reset()
+}
+
+// GatedStderr returns a writer that wraps os.Stderr but buffers writes
+// while the interactive task renderer owns the TTY, flushing them once it
+// lets go. The writer is stateless; each Write rechecks ownership, so a
+// writer captured before the renderer started still gates correctly.
 func GatedStderr() io.Writer {
 	return stderrGate{}
 }

--- a/task/stderr_gate_test.go
+++ b/task/stderr_gate_test.go
@@ -77,6 +77,19 @@ func withGlobalRenderState(t *testing.T, interactive, ownsTTY bool) func() {
 	}
 }
 
+// resetGatedStderr clears the package-level gate buffer so buffered bytes
+// from one test cannot leak into another's flush assertions.
+func resetGatedStderr(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		gatedStderrBuf.mu.Lock()
+		gatedStderrBuf.buf.Reset()
+		gatedStderrBuf.mu.Unlock()
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
 func TestStderrGate(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -100,10 +113,10 @@ func TestStderrGate(t *testing.T) {
 			wantWritten: "before render\n",
 		},
 		{
-			name:        "interactive and renderer owns tty drops",
+			name:        "interactive and renderer owns tty buffers",
 			interactive: true,
 			ownsTTY:     true,
-			input:       "should be dropped\n",
+			input:       "held until flush\n",
 			wantWritten: "",
 		},
 		{
@@ -117,6 +130,7 @@ func TestStderrGate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			resetGatedStderr(t)
 			collect, cleanup := withSwappedStderr(t)
 			defer cleanup()
 			restore := withGlobalRenderState(t, tc.interactive, tc.ownsTTY)
@@ -141,8 +155,10 @@ func TestStderrGate(t *testing.T) {
 // TestStderrGate_RechecksPerWrite confirms a writer captured before the
 // renderer takes over still gates correctly when the renderer later
 // acquires the TTY — this is the format.go logWriter scenario, where
-// the writer is bound at package init.
+// the writer is bound at package init. The write that lands during the
+// render window is buffered and appears once the teardown flush runs.
 func TestStderrGate_RechecksPerWrite(t *testing.T) {
+	resetGatedStderr(t)
 	collect, cleanup := withSwappedStderr(t)
 	defer cleanup()
 
@@ -155,14 +171,58 @@ func TestStderrGate_RechecksPerWrite(t *testing.T) {
 	restore2 := withGlobalRenderState(t, true, true)
 	_, _ = fmt.Fprint(w, "during\n")
 	restore2()
+	flushGatedStderr() // what stopRender's teardown does
 
 	restore3 := withGlobalRenderState(t, false, false)
 	_, _ = fmt.Fprint(w, "post\n")
 	restore3()
 
 	got := collect()
-	want := "pre\npost\n"
+	want := "pre\nduring\npost\n"
 	if got != want {
 		t.Fatalf("captured stderr = %q, want %q", got, want)
+	}
+}
+
+// F4: writes that land while the renderer owns the TTY are buffered, not
+// dropped, and flushGatedStderr emits them once the renderer lets go.
+func TestStderrGate_BuffersAndFlushesAfterRender(t *testing.T) {
+	resetGatedStderr(t)
+	collect, cleanup := withSwappedStderr(t)
+	defer cleanup()
+
+	restore := withGlobalRenderState(t, true, true)
+	_, _ = io.WriteString(GatedStderr(), "first buffered\n")
+	_, _ = io.WriteString(GatedStderr(), "second buffered\n")
+	restore()
+
+	flushGatedStderr()
+	// A second flush with nothing pending must not re-emit.
+	flushGatedStderr()
+
+	got := collect()
+	want := "first buffered\nsecond buffered\n"
+	if got != want {
+		t.Fatalf("captured stderr = %q, want %q", got, want)
+	}
+}
+
+// stopRender's teardown is the production flush point: bytes buffered during
+// the render window must reach stderr once the render lifecycle tears down.
+func TestStopRender_FlushesGatedStderr(t *testing.T) {
+	resetGatedStderr(t)
+	collect, cleanup := withSwappedStderr(t)
+	defer cleanup()
+
+	restore := withGlobalRenderState(t, true, true)
+	_, _ = io.WriteString(GatedStderr(), "flushed by stopRender\n")
+	restore()
+
+	tm := newTestManager(1)
+	t.Cleanup(func() { close(tm.shutdown) })
+	tm.stopRender()
+
+	if got := collect(); !bytes.Contains([]byte(got), []byte("flushed by stopRender\n")) {
+		t.Fatalf("stopRender teardown must flush the gated stderr buffer, got %q", got)
 	}
 }

--- a/task/task.go
+++ b/task/task.go
@@ -326,16 +326,27 @@ func (t *Task) PopDirty() bool {
 // Infof logs an info message (only shown in verbose mode)
 func (t *Task) Infof(format string, args ...interface{}) {
 	t.getBufferedLogger().Infof(format, args...)
+	t.markLogForStreaming()
 }
 
 // Errorf logs an error message
 func (t *Task) Errorf(format string, args ...interface{}) {
 	t.getBufferedLogger().Errorf(format, args...)
+	t.markLogForStreaming()
 }
 
 // Warnf logs a warning message
 func (t *Task) Warnf(format string, args ...interface{}) {
 	t.getBufferedLogger().Warnf(format, args...)
+	t.markLogForStreaming()
+}
+
+// markLogForStreaming flags the task dirty so the plain render loop emits a
+// just-appended log line on its next tick instead of batching it until the
+// next status transition. Called for Info and more-severe appends only —
+// Debug/Trace lines stay batched.
+func (t *Task) markLogForStreaming() {
+	t.dirty.Store(true)
 }
 
 // SetName sets the task name
@@ -815,6 +826,7 @@ func (t *Task) Tracef(format string, args ...interface{}) {
 // Fatalf logs a fatal message (implements Logger interface)
 func (t *Task) Fatalf(format string, args ...interface{}) {
 	t.getBufferedLogger().Fatalf(format, args...)
+	t.markLogForStreaming()
 }
 
 // WithValues returns a logger with additional key-value pairs (implements Logger interface)

--- a/task/task_log_display_test.go
+++ b/task/task_log_display_test.go
@@ -11,15 +11,13 @@ import (
 
 const logDisplayMessage = "log-display-probe"
 
-// newTaskAtLogLevel creates an unqueued task whose context logger (which
-// Pretty() consults for the display filter) and buffered logger (which gates
-// Debugf/Tracef at append time) are both set to the given level, without
-// touching global logger state.
+// newTaskAtLogLevel creates an unqueued task at the given log level without
+// touching global logger state. The context logger routes into the task's
+// buffered logger, so one SetLogLevel controls both the append-time gate
+// (Debugf/Tracef) and the render-time display filter Pretty() consults.
 func newTaskAtLogLevel(tm *Manager, name string, level logger.LogLevel) *Task {
 	task := tm.newTask(name)
-	ctxLogger := logger.NewBufferedLogger(1)
-	ctxLogger.SetLogLevel(level)
-	task.ctx.Logger = ctxLogger
+	task.SetLogLevel(level)
 	return task
 }
 

--- a/task/task_logs_render.go
+++ b/task/task_logs_render.go
@@ -18,6 +18,13 @@ import (
 // the buffer. Pretty() delegates with from=0 for the full history. Caller must
 // hold t.mu.
 func (t *Task) prettyWithLogOffset(from int) (api.Text, int) {
+	if pretty, ok := t.result.(api.PrettyShort); ok {
+		rv := reflect.ValueOf(pretty)
+		if rv.Kind() != reflect.Ptr || (!rv.IsNil() && rv.Pointer() != reflect.ValueOf(t).Pointer()) {
+			return api.Text{}.Add(pretty.PrettyShort()), from
+		}
+	}
+
 	if pretty, ok := t.result.(formatters.PrettyMixin); ok {
 		rv := reflect.ValueOf(pretty)
 		if rv.Kind() != reflect.Ptr || (!rv.IsNil() && rv.Pointer() != reflect.ValueOf(t).Pointer()) {

--- a/task/worker.go
+++ b/task/worker.go
@@ -155,7 +155,10 @@ func (w *worker) executeTask(task *Task) {
 		originalCtx := task.ctx
 		originalCancel := task.cancel
 
-		task.flanksourceCtx = flanksourcecontext.NewContext(timeoutCtx)
+		// Rebuild around the timeout context but keep the original context's
+		// Logger — it routes into the task's buffered logger; a bare
+		// NewContext would silently reset it to the global standard logger.
+		task.flanksourceCtx = flanksourcecontext.NewContext(timeoutCtx, flanksourcecontext.WithLogger(originalCtx.Logger))
 		task.ctx = task.flanksourceCtx
 		task.cancel = func() {
 			timeoutCancel()
@@ -167,7 +170,7 @@ func (w *worker) executeTask(task *Task) {
 		defer func() {
 			task.mu.Lock()
 			task.ctx = originalCtx
-			task.flanksourceCtx = flanksourcecontext.NewContext(originalCtx)
+			task.flanksourceCtx = originalCtx
 			task.cancel = originalCancel
 			task.mu.Unlock()
 		}()


### PR DESCRIPTION
## What
- Support schema-independent named filters and propagate lookup errors.
- Add ANSI text rendering and schema-driven formatting across exports.
- Expand RPC response schemas and task runtime controls.

## Notes
- Dynamic filter APIs now return errors.
- Schema-declared filters use their bound request key, a breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ANSI-aware text rendering with HTML, Markdown, plain-text, and visible-line outputs.
  * Added schema-driven column formatting for units, percentages, bytes, rates, durations, and compact numbers.
  * Added configurable filter keys and preservation of raw filter values.
  * Added task lifecycle controls for child tasks, including externally managed tasks.
  * Added response schemas to operation catalogs and improved array parameter handling.
* **Bug Fixes**
  * Improved live task log delivery, stderr buffering, output truncation reporting, and terminal-width handling.
  * Improved lookup error reporting and preservation of related filter parameters.
  * Improved task result presentation and empty-output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->