### PR TITLE
feat(entity): expose paths and omit data

### DIFF
--- a/api/icons/icons.go
+++ b/api/icons/icons.go
@@ -19,14 +19,21 @@ func (i Icon) String() string {
 	return i.Unicode
 }
 
-// ANSI returns the Unicode representation with color styling applied
+// ANSI returns the Unicode representation with color styling applied.
+//
+// The profile is pinned rather than auto-detected so icons colour on the same
+// terms as api.formatANSI, which every other Text segment goes through.
+// termenv.DefaultOutput() degrades to the Ascii profile whenever stdout is not
+// a TTY, which left piped output with coloured labels beside monochrome
+// status icons. Colour is suppressed wholesale one level up, by rendering
+// String() instead of ANSI() when NO_COLOR is set.
 func (i Icon) ANSI() string {
 	if i.Style == "" {
 		return i.Unicode
 	}
 
 	style := tailwind.ParseStyle(i.Style)
-	output := termenv.DefaultOutput()
+	output := termenv.NewOutput(termenv.DefaultOutput().Writer(), termenv.WithProfile(termenv.ANSI))
 	styled := output.String(i.Unicode)
 
 	if style.Foreground != "" {

--- a/api/resize_unix.go
+++ b/api/resize_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package api
+
+import (
+	"os"
+	"os/signal"
+
+	"golang.org/x/sys/unix"
+)
+
+// watchTerminalResize drops the cached terminal size whenever the window
+// changes, so the next render re-measures instead of laying out for the size
+// the process started with.
+func watchTerminalResize() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, unix.SIGWINCH)
+	go func() {
+		for range ch {
+			InvalidateTerminalSize()
+		}
+	}()
+}

--- a/api/resize_windows.go
+++ b/api/resize_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package api
+
+// watchTerminalResize is a no-op on Windows, which has no SIGWINCH. The size is
+// measured once and callers can re-measure via InvalidateTerminalSize.
+func watchTerminalResize() {}

--- a/api/terminal_size_test.go
+++ b/api/terminal_size_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// A pty created without a window size makes term.GetSize return (0, 0, nil).
+// Before the fix that zero was cached and returned, and every width-aware
+// renderer collapsed to a single column.
+func TestTerminalSizeNeverNonPositive(t *testing.T) {
+	t.Cleanup(InvalidateTerminalSize)
+
+	for _, pinned := range []int{0, -1, -80} {
+		SetTerminalWidth(pinned)
+		if got := GetTerminalWidth(); got <= 0 {
+			t.Errorf("GetTerminalWidth() = %d after pinning %d, want a positive width", got, pinned)
+		}
+		SetTerminalLines(pinned)
+		if got := GetTerminalLines(); got <= 0 {
+			t.Errorf("GetTerminalLines() = %d after pinning %d, want a positive height", got, pinned)
+		}
+	}
+}
+
+func TestSetTerminalWidthIsUsedAndInvalidated(t *testing.T) {
+	t.Cleanup(InvalidateTerminalSize)
+
+	SetTerminalWidth(97)
+	if got := GetTerminalWidth(); got != 97 {
+		t.Errorf("GetTerminalWidth() = %d, want the pinned 97", got)
+	}
+
+	InvalidateTerminalSize()
+	if got := GetTerminalWidth(); got == 97 {
+		t.Error("GetTerminalWidth() still returned the pinned width after InvalidateTerminalSize")
+	}
+}
+
+// A tree label must survive an unmeasurable terminal. With a zero width the
+// label budget went negative, clamped to one column, and rendered as "…".
+func TestTreeLabelSurvivesUnmeasurableWidth(t *testing.T) {
+	t.Cleanup(InvalidateTerminalSize)
+	SetTerminalWidth(0)
+
+	const label = "View full results: https://github.com/acme/widgets/actions/runs/31387133937"
+	tree := TextTree{
+		Node:     Text{Content: "gavel"},
+		Children: []TextTree{{Node: Text{Content: label}}},
+	}
+
+	rendered := tree.String()
+	if !strings.Contains(rendered, label) {
+		t.Errorf("tree label was truncated at width 0:\n%q", rendered)
+	}
+
+	// Negative control: the renderer really is width-sensitive, so the check
+	// above passes because the width fell back, not because width is ignored.
+	SetTerminalWidth(20)
+	if narrow := tree.String(); strings.Contains(narrow, label) {
+		t.Errorf("tree label was not truncated at width 20, so the width-0 case proves nothing:\n%q", narrow)
+	}
+}

--- a/api/text.go
+++ b/api/text.go
@@ -489,13 +489,18 @@ func (t Text) ANSI() string {
 		return result
 	}
 
-	// Apply tailwind styles using ANSI escape codes
-	content := transformedText
+	// Style this node's own content only, then append each child's rendered
+	// output beside it. Folding children into the styled content instead would
+	// open this node's SGR before them and close it after the last one, so a
+	// `font-bold` header leaks bold onto its whole subtree — and the first
+	// child that emits its own \x1b[0m cancels the parent's attribute for
+	// everything after it.
+	result := formatANSI(transformedText, style)
 	for _, child := range t.Children {
-		content += child.ANSI()
+		result += child.ANSI()
 	}
 
-	return formatANSI(content, style)
+	return result
 }
 
 // KeyValuePair represents a single key-value pair that can be rendered to multiple output formats.

--- a/api/text_style_scope_test.go
+++ b/api/text_style_scope_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+const sgrReset = "\x1b[0m"
+
+// A node's style must cover its own content only. Folding children into the
+// styled content opened the node's SGR before them and closed it after the
+// last one, so a `font-bold` section header rendered its entire subtree bold —
+// and the first child emitting its own reset silently cancelled the header's
+// attribute for everything that followed.
+func TestANSIStyleDoesNotLeakOntoChildren(t *testing.T) {
+	header := Text{
+		Content:  "Workflows:",
+		Style:    "font-bold",
+		Children: []Textable{Text{Content: "\n  child", Style: "text-gray-500"}},
+	}
+
+	got := header.ANSI()
+
+	styled, _, ok := strings.Cut(got, sgrReset)
+	if !ok {
+		t.Fatalf("ANSI() emitted no reset sequence: %q", got)
+	}
+	if !strings.Contains(styled, "Workflows:") {
+		t.Errorf("header content is not inside the first styled span: %q", got)
+	}
+	if strings.Contains(styled, "child") {
+		t.Errorf("child content is inside the header's styled span, so the header style leaks: %q", got)
+	}
+}
+
+// The child keeps its own styling; scoping the parent must not strip it.
+func TestANSIChildKeepsItsOwnStyle(t *testing.T) {
+	parent := Text{
+		Content:  "head",
+		Style:    "font-bold",
+		Children: []Textable{Text{Content: "tail", Style: "text-gray-500"}},
+	}
+
+	got := parent.ANSI()
+	want := formatANSI("head", styleOf("font-bold")) + formatANSI("tail", styleOf("text-gray-500"))
+	if got != want {
+		t.Errorf("ANSI() = %q, want each node styled independently: %q", got, want)
+	}
+}
+
+func styleOf(class string) TailwindStyle {
+	_, style := ApplyTailwindStyle("", class)
+	return style
+}

--- a/api/themes.go
+++ b/api/themes.go
@@ -212,41 +212,76 @@ func AutoTheme() Theme {
 	return LightTheme()
 }
 
-var terminalWidth atomic.Int32
+const (
+	// unmeasuredTerminalSize marks the cache as empty. Any non-positive size
+	// reported by the terminal is treated as unmeasured too — see
+	// GetTerminalWidth.
+	unmeasuredTerminalSize = -1
+
+	defaultTerminalWidth = 120
+	defaultTerminalLines = 40
+)
+
+var (
+	terminalWidth  atomic.Int32
+	terminalHeight atomic.Int32
+)
 
 func init() {
-	terminalWidth.Store(-1)
-	terminalHeight.Store(-1)
+	InvalidateTerminalSize()
 	tailwind.TerminalWidthFunc = GetTerminalWidth
 	tailwind.TerminalHeightFunc = GetTerminalLines
+	watchTerminalResize()
 }
 
+// InvalidateTerminalSize drops the cached terminal size so the next read
+// re-measures. Called on SIGWINCH; the size is otherwise sampled once per
+// process and a resize would leave every frame laid out for the old width.
+func InvalidateTerminalSize() {
+	terminalWidth.Store(unmeasuredTerminalSize)
+	terminalHeight.Store(unmeasuredTerminalSize)
+}
+
+func SetTerminalWidth(width int) {
+	terminalWidth.Store(int32(width))
+}
+
+// GetTerminalWidth returns the terminal width, always positive: it falls back
+// to defaultTerminalWidth whenever the width cannot be measured.
+//
+// term.GetSize reports (0, 0, nil) — success, zero size — for a pty created
+// without a window size, which every non-interactive `script`/CI capture hits.
+// Caching that zero pinned the width at 0 for the whole process, and
+// width-aware renderers (api/meta.go buildLipglossTree) then truncated every
+// label to a single `…`. A non-positive size is unmeasured, never a real width,
+// so it is neither returned nor cached.
 func GetTerminalWidth() int {
-	if w := terminalWidth.Load(); w != -1 {
+	if w := terminalWidth.Load(); w > 0 {
 		return int(w)
 	}
 	width, _, err := term.GetSize(int(os.Stderr.Fd()))
-	if err != nil {
-		return 120 // Default width
+	if err != nil || width <= 0 {
+		return defaultTerminalWidth
 	}
 	terminalWidth.Store(int32(width))
 
 	return width
 }
 
-var terminalHeight atomic.Int32
-
 func SetTerminalLines(height int) {
 	terminalHeight.Store(int32(height))
 }
 
+// GetTerminalLines returns the terminal height, always positive, falling back
+// to defaultTerminalLines. Non-positive sizes are unmeasured — see
+// GetTerminalWidth.
 func GetTerminalLines() int {
-	if h := terminalHeight.Load(); h != -1 {
+	if h := terminalHeight.Load(); h > 0 {
 		return int(h)
 	}
 	_, height, err := term.GetSize(int(os.Stderr.Fd()))
-	if err != nil {
-		return 40 // Default height
+	if err != nil || height <= 0 {
+		return defaultTerminalLines
 	}
 	terminalHeight.Store(int32(height))
 	return height

--- a/api/themes.go
+++ b/api/themes.go
@@ -242,7 +242,14 @@ func InvalidateTerminalSize() {
 	terminalHeight.Store(unmeasuredTerminalSize)
 }
 
+// SetTerminalWidth pins the width every width-aware renderer lays out against.
+// A non-positive width is not a width: it clears the cache, so the next read
+// re-measures rather than laying every frame out against a bogus size.
 func SetTerminalWidth(width int) {
+	if width <= 0 {
+		terminalWidth.Store(unmeasuredTerminalSize)
+		return
+	}
 	terminalWidth.Store(int32(width))
 }
 
@@ -268,7 +275,13 @@ func GetTerminalWidth() int {
 	return width
 }
 
+// SetTerminalLines pins the height, with the same rule as SetTerminalWidth: a
+// non-positive height clears the cache instead of being stored as one.
 func SetTerminalLines(height int) {
+	if height <= 0 {
+		terminalHeight.Store(unmeasuredTerminalSize)
+		return
+	}
 	terminalHeight.Store(int32(height))
 }
 

--- a/entity/action_result_test.go
+++ b/entity/action_result_test.go
@@ -1,0 +1,55 @@
+package entity
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type actionPayload struct {
+	ConnectionID string `json:"connectionId"`
+	Provider     string `json:"provider"`
+}
+
+// A failing typed handler must contribute no data. Boxing its zero value into
+// the `any` return makes it non-nil, and the RPC executor then serializes that
+// zero struct as the response body instead of the error.
+var _ = Describe("typed handler results", func() {
+	failure := fmt.Errorf("refresh xero token: tenant name %q matches 2 entities", "Acme")
+
+	It("drops the zero value when a context action fails", func() {
+		info := ActionWithContext("refresh", func(context.Context, string, map[string]string) (actionPayload, error) {
+			return actionPayload{}, failure
+		}).actionInfo()
+
+		data, err := info.ContextDataFunc(context.Background(), map[string]string{"id": "conn-1"}, nil)
+
+		Expect(err).To(MatchError(failure))
+		Expect(data).To(BeNil())
+	})
+
+	It("returns the value when a context action succeeds", func() {
+		want := actionPayload{ConnectionID: "conn-1", Provider: "xero"}
+		info := ActionWithContext("refresh", func(context.Context, string, map[string]string) (actionPayload, error) {
+			return want, nil
+		}).actionInfo()
+
+		data, err := info.ContextDataFunc(context.Background(), map[string]string{"id": "conn-1"}, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(want))
+	})
+
+	It("drops the zero value when a flag action fails", func() {
+		info := Action("refresh", func(string, map[string]string) (actionPayload, error) {
+			return actionPayload{}, failure
+		}).actionInfo()
+
+		data, err := info.DataFunc(map[string]string{"id": "conn-1"}, nil)
+
+		Expect(err).To(MatchError(failure))
+		Expect(data).To(BeNil())
+	})
+})

--- a/entity/annotations.go
+++ b/entity/annotations.go
@@ -13,6 +13,7 @@ const (
 	annotationClickyEntityAliases      = "clicky/entity-aliases"
 	annotationClickyEntityAdmin        = "clicky/entity-admin"
 	annotationClickyEntityIcon         = "clicky/entity-icon"
+	annotationClickyEntityPath         = "clicky/entity-path"
 	annotationClickyEntityTitle        = "clicky/entity-title"
 	annotationClickyOperationVerb      = "clicky/operation-verb"
 	annotationClickyOperationMethod    = "clicky/operation-method"
@@ -58,6 +59,8 @@ type CommandOpenAPIMeta struct {
 	// Icon is an opaque UI icon name (e.g. "database"); clicky never interprets
 	// it — it is emitted verbatim on the surface for the frontend to resolve.
 	Icon string
+	// Path is the entity's hierarchy position within Parent, PathSeparator-joined.
+	Path string
 	// Title overrides the auto-generated surface title when non-empty.
 	Title              string
 	Verb               string
@@ -116,6 +119,7 @@ func GetCommandOpenAPIMeta(cmd *cobra.Command) *CommandOpenAPIMeta {
 		Aliases:            splitAnnotationList(cmd.Annotations[annotationClickyEntityAliases]),
 		Admin:              parseAnnotationBool(cmd.Annotations[annotationClickyEntityAdmin]),
 		Icon:               cmd.Annotations[annotationClickyEntityIcon],
+		Path:               cmd.Annotations[annotationClickyEntityPath],
 		Title:              cmd.Annotations[annotationClickyEntityTitle],
 		Verb:               cmd.Annotations[annotationClickyOperationVerb],
 		Method:             cmd.Annotations[annotationClickyOperationMethod],
@@ -146,6 +150,7 @@ func annotateEntityCommand(cmd *cobra.Command, entity EntityInfo) {
 	setCommandAnnotation(cmd, annotationClickyEntityAliases, strings.Join(entity.Aliases, ","))
 	setCommandAnnotation(cmd, annotationClickyEntityAdmin, strconv.FormatBool(entity.IsAdmin))
 	setCommandAnnotation(cmd, annotationClickyEntityIcon, entity.Icon)
+	setCommandAnnotation(cmd, annotationClickyEntityPath, entity.Path)
 	setCommandAnnotation(cmd, annotationClickyEntityTitle, entity.Title)
 	hints := entity.ToolHints
 	if hints.Group == "" {
@@ -223,6 +228,7 @@ func inheritEntityAnnotations(cmd *cobra.Command, parent *cobra.Command) {
 	setCommandAnnotation(cmd, annotationClickyEntityAliases, strings.Join(meta.Aliases, ","))
 	setCommandAnnotation(cmd, annotationClickyEntityAdmin, strconv.FormatBool(meta.Admin))
 	setCommandAnnotation(cmd, annotationClickyEntityIcon, meta.Icon)
+	setCommandAnnotation(cmd, annotationClickyEntityPath, meta.Path)
 	setCommandAnnotation(cmd, annotationClickyEntityTitle, meta.Title)
 	AnnotateTool(cmd, meta.ToolHints)
 }

--- a/entity/annotations.go
+++ b/entity/annotations.go
@@ -33,7 +33,38 @@ const (
 	annotationClickyToolOpenWorld      = "clicky/tool-open-world-hint"
 	annotationClickyToolPermission     = "clicky/tool-default-permission"
 	annotationClickyToolStrict         = "clicky/tool-strict"
+	annotationClickyLocalOnly          = "clicky/local-only"
 )
+
+// MarkLocalOnly keeps a command off the generated HTTP surface.
+//
+// Publishing a CLI as an API publishes every runnable command in the tree, which
+// is wrong for the ones that administer the process rather than serve a
+// resource: `serve` would start a nested server, and `migrate` would let an
+// unauthenticated request alter the schema. Such commands stay in `--help` and
+// on the CLI — they are simply not routes.
+//
+// It marks the whole subtree: marking a parent covers every subcommand under it.
+func MarkLocalOnly(cmd *cobra.Command) {
+	if cmd == nil {
+		return
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[annotationClickyLocalOnly] = "true"
+}
+
+// IsLocalOnly reports whether a command, or any command it is nested under, is
+// marked local-only.
+func IsLocalOnly(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Annotations != nil && parseAnnotationBool(c.Annotations[annotationClickyLocalOnly]) {
+			return true
+		}
+	}
+	return false
+}
 
 const (
 	AnnotationClickyToolGroup             = annotationClickyToolGroup

--- a/entity/attach.go
+++ b/entity/attach.go
@@ -54,6 +54,9 @@ func (a *attachedFilter[ListOpts]) FilterName() string { return a.nf.Name }
 // inferred bool/number/date/multi-filter type in place).
 func (a *attachedFilter[ListOpts]) LookupType() string { return a.nf.Type }
 
+// LookupLimit returns the filter's own option cap, or zero to take the default.
+func (a *attachedFilter[ListOpts]) LookupLimit() int { return a.nf.Limit }
+
 // Lookup labels the currently-selected value(s) of the bound field. It does not
 // mutate opts — named filters carry no backend transform.
 func (a *attachedFilter[ListOpts]) Lookup(opts *ListOpts) (map[string]api.Textable, error) {

--- a/entity/builder.go
+++ b/entity/builder.go
@@ -142,6 +142,11 @@ func (b *EntityBuilder[T, ListOpts, R]) Filters(filters ...Filter[ListOpts]) *En
 	return b
 }
 
+func (b *EntityBuilder[T, ListOpts, R]) WithPrimaryAction(action EntityAction) *EntityBuilder[T, ListOpts, R] {
+	b.entity.PrimaryAction = action
+	return b
+}
+
 func (b *EntityBuilder[T, ListOpts, R]) WithAction(action EntityAction) *EntityBuilder[T, ListOpts, R] {
 	b.entity.Actions = append(b.entity.Actions, action)
 	return b

--- a/entity/builder.go
+++ b/entity/builder.go
@@ -32,6 +32,14 @@ func (b *EntityBuilder[T, ListOpts, R]) Aliases(aliases ...string) *EntityBuilde
 	return b
 }
 
+// Path sets the entity's hierarchy position within its parent, joined by
+// PathSeparator, and surfaced as x-clicky.surfaces[].path. Pass segments through
+// JoinPath rather than concatenating them by hand.
+func (b *EntityBuilder[T, ListOpts, R]) Path(segments ...string) *EntityBuilder[T, ListOpts, R] {
+	b.entity.Path = JoinPath(segments)
+	return b
+}
+
 // ToolGroup names the group this entity's operations belong to. Every generated
 // operation inherits it (an action can override it via WithToolGroup). AI
 // tool-preference layers use the group to enable/disable related tools together.

--- a/entity/command.go
+++ b/entity/command.go
@@ -309,7 +309,7 @@ func addNamedCommand[T any, R any](
 			if err := flags.PopulateFromRequest(optsValue, capturedFields, flagMap, args); err != nil {
 				return nil, err
 			}
-			return fnCtx(ctx, optsValue.Interface().(T))
+			return dataOrError(fnCtx(ctx, optsValue.Interface().(T)))
 		})
 	} else {
 		dataFuncRegistry.Store(cmd, func(flagMap map[string]string, args []string) (any, error) {
@@ -317,7 +317,7 @@ func addNamedCommand[T any, R any](
 			if err := flags.PopulateFromRequest(optsValue, capturedFields, flagMap, args); err != nil {
 				return nil, err
 			}
-			return fn(optsValue.Interface().(T))
+			return dataOrError(fn(optsValue.Interface().(T)))
 		})
 	}
 

--- a/entity/dynamic.go
+++ b/entity/dynamic.go
@@ -83,6 +83,7 @@ func (b *DynamicEntityBuilder) Register() {
 		Parent:     ps.Parent,
 		Aliases:    ps.Aliases,
 		Icon:       ps.Icon,
+		Path:       ps.Path,
 		Title:      ps.Title,
 		ListType:   ps.listType(),
 		ItemType:   ps.itemType(),

--- a/entity/dynamic_family.go
+++ b/entity/dynamic_family.go
@@ -1,0 +1,129 @@
+package entity
+
+import (
+	"context"
+	"net/http"
+	"sync"
+)
+
+// DynamicEntityFamily is a route for entities that do not exist yet.
+//
+// The registry pipeline — entityRegistry, GenerateCLI, Cobra, NewSwaggerServer,
+// RegisterRoutes — is one snapshot taken at startup, so an entity that comes
+// into being while the server runs has no route and no way to acquire one. A
+// consumer whose entities are database rows is locked out of it entirely.
+//
+// A family registers one route for the whole shape — {prefix}/{Name}/{name} —
+// and resolves the instance per request. Nothing is cached, so an entity created
+// a moment ago is immediately reachable and none of the startup pipeline has to
+// be re-run or invalidated.
+type DynamicEntityFamily struct {
+	// Name is the family's path segment: "profile" serves one route,
+	// {prefix}/profile/{name}, for every profile that will ever exist.
+	Name string
+
+	// Parent groups the family's surfaces, as EntityInfo.Parent does.
+	Parent string
+
+	// Resolve returns the spec for one instance. It runs in front of every
+	// request to the family, so it has to be cheap enough to sit there. A name
+	// that does not exist is UnknownDynamicEntity rather than a zero spec: "no
+	// such profile" and "a profile that does nothing" are different answers and a
+	// caller has to be able to tell them apart.
+	Resolve func(ctx context.Context, name string) (DynamicEntitySpec, error)
+
+	// List enumerates the instances that exist right now, so the OpenAPI document
+	// can describe them. It is called per request for the same reason Resolve is:
+	// a document rendered once at startup would describe a set that has since
+	// changed.
+	List func(ctx context.Context) ([]DynamicEntitySpec, error)
+
+	// Paged serves one page or one export of a resolved instance, putting a
+	// family instance on the same export contract as RPCOperation.PagedFunc.
+	//
+	// It hangs off the family rather than off DynamicEntitySpec because the spec
+	// says what the entity is and this says how the transport reads it, and
+	// because one implementation serves every instance. Nil falls back to the
+	// instance's List, served the way every other operation's data is.
+	Paged func(ctx context.Context, spec DynamicEntitySpec, req PageRequest, flags map[string]string) (PageResponse, error)
+}
+
+var (
+	dynamicFamilyMu sync.RWMutex
+	dynamicFamilies []DynamicEntityFamily
+)
+
+// RegisterDynamicEntityFamily registers a family, replacing any family already
+// registered under the same Name.
+//
+// Replacing rather than appending is deliberate: a family is a route, not an
+// instance, and two families claiming one path segment is a wiring bug that
+// would otherwise surface as whichever registration happened to be found first.
+func RegisterDynamicEntityFamily(family DynamicEntityFamily) {
+	if family.Name == "" {
+		panic("clicky.RegisterDynamicEntityFamily: Name must not be empty")
+	}
+	if family.Resolve == nil {
+		panic("clicky.RegisterDynamicEntityFamily: family " + family.Name + " has no Resolve func")
+	}
+
+	dynamicFamilyMu.Lock()
+	defer dynamicFamilyMu.Unlock()
+	for index := range dynamicFamilies {
+		if dynamicFamilies[index].Name == family.Name {
+			dynamicFamilies[index] = family
+			return
+		}
+	}
+	dynamicFamilies = append(dynamicFamilies, family)
+}
+
+// UnregisterDynamicEntityFamily removes a family by name, reporting whether one
+// was registered. A family whose backing store is gone — a tenant disconnected,
+// a plugin unloaded — has to be able to take its route with it.
+func UnregisterDynamicEntityFamily(name string) bool {
+	dynamicFamilyMu.Lock()
+	defer dynamicFamilyMu.Unlock()
+	for index := range dynamicFamilies {
+		if dynamicFamilies[index].Name != name {
+			continue
+		}
+		dynamicFamilies = append(dynamicFamilies[:index], dynamicFamilies[index+1:]...)
+		return true
+	}
+	return false
+}
+
+// GetDynamicEntityFamilies returns the registered families.
+//
+// Nil when none are registered, rather than an empty slice: this is consulted on
+// the way into every executor request, and a consumer that registers no family
+// must not pay an allocation for the feature it does not use.
+func GetDynamicEntityFamilies() []DynamicEntityFamily {
+	dynamicFamilyMu.RLock()
+	defer dynamicFamilyMu.RUnlock()
+	if len(dynamicFamilies) == 0 {
+		return nil
+	}
+	return append([]DynamicEntityFamily{}, dynamicFamilies...)
+}
+
+// UnknownDynamicEntity is the answer to a name a family cannot resolve.
+func UnknownDynamicEntity(family, name string) *StatusError {
+	return NewStatusErrorf(http.StatusNotFound, "not_found", "no %s named %q", family, name)
+}
+
+// ResolveDynamicLookup answers a filter-metadata lookup from a resolved spec.
+//
+// A registered entity reaches this resolution through the LookupFunc the
+// registry built for it. A family instance never enters the registry, so the
+// transport has to enter the same resolution from the spec it just resolved —
+// otherwise a runtime entity would be the one kind that cannot describe its own
+// filters.
+func ResolveDynamicLookup(ctx context.Context, spec DynamicEntitySpec, flags map[string]string) (any, error) {
+	response, err := resolveDynamicLookup(ctx, spec.Filters, flags)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}

--- a/entity/dynamic_family.go
+++ b/entity/dynamic_family.go
@@ -59,6 +59,18 @@ var (
 // Replacing rather than appending is deliberate: a family is a route, not an
 // instance, and two families claiming one path segment is a wiring bug that
 // would otherwise surface as whichever registration happened to be found first.
+//
+// Register every family before the server builds its mux (rpc.RegisterRoutes).
+// The mux pattern for a family is written once, from the families registered at
+// that moment: a family registered afterwards is described by the OpenAPI
+// document — which is resolved per request — but has no pattern, so the mux
+// answers 404 before the family dispatch is ever reached. Unregistering has the
+// mirror shape: the pattern stays, and the path falls through to ordinary
+// operation lookup and 404s there.
+//
+// Name must not collide with the first path segment of a registered operation.
+// The dispatch resolves a registered operation first, so a colliding family is
+// simply never reached for the paths the operation owns.
 func RegisterDynamicEntityFamily(family DynamicEntityFamily) {
 	if family.Name == "" {
 		panic("clicky.RegisterDynamicEntityFamily: Name must not be empty")

--- a/entity/dynamic_family_test.go
+++ b/entity/dynamic_family_test.go
@@ -79,11 +79,11 @@ func TestResolveDynamicLookup_AnswersFromASpecThatWasNeverRegistered(t *testing.
 			Searchable: true,
 			Options: func(_ context.Context, _ map[string]string, query string, _ int) (map[string]api.Textable, int, error) {
 				if query == "pr" {
-					return map[string]api.Textable{"prod": api.Text{Content: "Production"}}, 1, nil
+					return map[string]api.Textable{"prod": api.Text{}.Append("Production")}, 1, nil
 				}
 				return map[string]api.Textable{
-					"prod": api.Text{Content: "Production"},
-					"dev":  api.Text{Content: "Development"},
+					"prod": api.Text{}.Append("Production"),
+					"dev":  api.Text{}.Append("Development"),
 				}, 2, nil
 			},
 		}},

--- a/entity/dynamic_family_test.go
+++ b/entity/dynamic_family_test.go
@@ -1,0 +1,106 @@
+package entity
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/flanksource/clicky/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testFamily(t *testing.T, name string) DynamicEntityFamily {
+	t.Helper()
+	t.Cleanup(func() { UnregisterDynamicEntityFamily(name) })
+	return DynamicEntityFamily{
+		Name: name,
+		Resolve: func(_ context.Context, instance string) (DynamicEntitySpec, error) {
+			return DynamicEntitySpec{Name: instance}, nil
+		},
+	}
+}
+
+func TestRegisterDynamicEntityFamily_ReplacesRatherThanShadows(t *testing.T) {
+	family := testFamily(t, "report")
+	family.Parent = "first"
+	RegisterDynamicEntityFamily(family)
+
+	family.Parent = "second"
+	RegisterDynamicEntityFamily(family)
+
+	registered := GetDynamicEntityFamilies()
+	matches := 0
+	for _, candidate := range registered {
+		if candidate.Name == "report" {
+			matches++
+			assert.Equal(t, "second", candidate.Parent)
+		}
+	}
+	assert.Equal(t, 1, matches, "one path segment cannot be owned by two families")
+}
+
+func TestRegisterDynamicEntityFamily_RejectsAnUnusableFamily(t *testing.T) {
+	assert.Panics(t, func() { RegisterDynamicEntityFamily(DynamicEntityFamily{}) },
+		"a family with no name owns no path")
+	assert.Panics(t, func() { RegisterDynamicEntityFamily(DynamicEntityFamily{Name: "report"}) },
+		"a family that cannot resolve an instance can never answer a request")
+}
+
+// The registry is read on the way into every executor request, so a consumer
+// that registers no family must not pay for the feature.
+func TestGetDynamicEntityFamilies_IsNilWhenEmpty(t *testing.T) {
+	require.Nil(t, GetDynamicEntityFamilies())
+
+	RegisterDynamicEntityFamily(testFamily(t, "report"))
+	require.Len(t, GetDynamicEntityFamilies(), 1)
+
+	assert.True(t, UnregisterDynamicEntityFamily("report"))
+	assert.False(t, UnregisterDynamicEntityFamily("report"))
+	assert.Nil(t, GetDynamicEntityFamilies())
+}
+
+func TestUnknownDynamicEntity_IsA404WithAStableCode(t *testing.T) {
+	err := UnknownDynamicEntity("profile", "missing")
+
+	assert.Equal(t, http.StatusNotFound, err.StatusCode())
+	assert.Equal(t, "not_found", err.Code)
+	assert.Equal(t, `no profile named "missing"`, err.Message)
+}
+
+// A family instance never enters the registry, so this is the only way its
+// filters can describe themselves.
+func TestResolveDynamicLookup_AnswersFromASpecThatWasNeverRegistered(t *testing.T) {
+	spec := DynamicEntitySpec{
+		Name: "daily",
+		Filters: []DynamicFilter{{
+			Key:        "env",
+			Label:      "Environment",
+			Searchable: true,
+			Options: func(_ context.Context, _ map[string]string, query string, _ int) (map[string]api.Textable, int, error) {
+				if query == "pr" {
+					return map[string]api.Textable{"prod": api.Text{Content: "Production"}}, 1, nil
+				}
+				return map[string]api.Textable{
+					"prod": api.Text{Content: "Production"},
+					"dev":  api.Text{Content: "Development"},
+				}, 2, nil
+			},
+		}},
+	}
+
+	head, err := ResolveDynamicLookup(context.Background(), spec, map[string]string{})
+	require.NoError(t, err)
+	response, ok := head.(entityLookupResponse)
+	require.True(t, ok)
+	assert.Len(t, response.Filters["env"].Options, 2)
+	assert.Equal(t, "Environment", response.Filters["env"].Label)
+
+	searched, err := ResolveDynamicLookup(context.Background(), spec, map[string]string{
+		lookupFilterKeyParam: "env",
+		lookupQueryParam:     "pr",
+	})
+	require.NoError(t, err)
+	assert.Len(t, searched.(entityLookupResponse).Filters["env"].Options, 1,
+		"__lookup_filter/__lookup_q reach the filter that searches on them")
+}

--- a/entity/dynamic_spec.go
+++ b/entity/dynamic_spec.go
@@ -35,6 +35,8 @@ type DynamicEntitySpec struct {
 	Aliases []string
 	// Icon is an opaque UI icon name emitted on the surface (x-clicky.surfaces[].icon).
 	Icon string
+	// Path is the hierarchy position emitted on the surface (x-clicky.surfaces[].path).
+	Path string
 	// Title overrides the auto-generated surface title when non-empty.
 	Title    string
 	ListType reflect.Type // generated struct type: flag binding + OpenAPI params
@@ -77,6 +79,7 @@ func RegisterDynamicEntity(spec DynamicEntitySpec) {
 		Parent:     spec.Parent,
 		Aliases:    spec.Aliases,
 		Icon:       spec.Icon,
+		Path:       spec.Path,
 		Title:      spec.Title,
 		Type:       responseType,
 		ListType:   spec.ListType,

--- a/entity/dynamic_spec.go
+++ b/entity/dynamic_spec.go
@@ -17,6 +17,9 @@ type DynamicFilter struct {
 	Type       string
 	Multi      bool
 	Searchable bool
+	// Limit caps the option set this filter enumerates in one shot. Zero takes
+	// MaxLookupOptions, which is also the ceiling.
+	Limit int
 	// Options returns the head set (query == "") or search matches, plus the true
 	// total behind the head. Required.
 	Options func(ctx context.Context, flags map[string]string, query string, limit int) (map[string]api.Textable, int, error)
@@ -24,6 +27,8 @@ type DynamicFilter struct {
 	// Optional; nil means "no selection rendering".
 	Selected func(ctx context.Context, flags map[string]string) (map[string]api.Textable, error)
 }
+
+func describeDynamicFilter(f DynamicFilter) (string, bool) { return f.Key, f.Searchable }
 
 // DynamicEntitySpec is the type-erased description of a schema-driven entity,
 // assembled by the entity package's NewDynamicEntity builder. It reuses the
@@ -130,6 +135,13 @@ func resolveDynamicLookup(ctx context.Context, filters []DynamicFilter, flagMap 
 	delete(flagMap, lookupFilterKeyParam)
 	delete(flagMap, lookupQueryParam)
 
+	// Narrowed here as well as in resolveLookupCore, because Selected is resolved
+	// eagerly: a dynamic filter's selection labels can be a backend round trip of
+	// their own, and a targeted search discards every entry but one.
+	if target := searchTarget(filters, describeDynamicFilter, searchKey, searchQuery); target >= 0 {
+		filters = filters[target : target+1]
+	}
+
 	bound := make([]boundFilter, 0, len(filters))
 	for _, df := range filters {
 		df := df
@@ -147,6 +159,7 @@ func resolveDynamicLookup(ctx context.Context, filters []DynamicFilter, flagMap 
 			Type:       df.Type,
 			Multi:      df.Multi,
 			Searchable: df.Searchable,
+			Limit:      df.Limit,
 			Selected:   selected,
 			Options: func(query string, limit int) (map[string]api.Textable, int, error) {
 				return df.Options(ctx, flagMap, query, limit)

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -64,14 +64,15 @@ type EntityInfo struct {
 	// (x-clicky.surfaces[].path). Empty for entities that declare no hierarchy.
 	Path string
 	// Title overrides the auto-generated surface title when non-empty.
-	Title       string
-	Type        reflect.Type
-	ListType    reflect.Type
-	Operations  []EntityOperation
-	Actions     []ActionInfo
-	BulkActions []BulkActionInfo
-	ValidArgs   func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-	IsAdmin     bool
+	Title         string
+	Type          reflect.Type
+	ListType      reflect.Type
+	Operations    []EntityOperation
+	PrimaryAction *ActionInfo
+	Actions       []ActionInfo
+	BulkActions   []BulkActionInfo
+	ValidArgs     func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+	IsAdmin       bool
 	// FilterRefs maps a list filter's flag key to the name of the reusable named
 	// filter backing it (when the filter was attached via the entity package's
 	// Use/As helper). The OpenAPI layer uses it to emit an x-clicky-lookup $ref
@@ -177,6 +178,14 @@ type Filter[ListOpts any] interface {
 // lookup response should still advertise a from/to date-range control.
 type TypedFilter[ListOpts any] interface {
 	LookupType() string
+}
+
+// LimitedFilter is an OPTIONAL extension a Filter may implement to cap its own
+// option set below the package ceiling. It is unparameterized because the cap is
+// a property of the filter's cardinality, not of the entity it is attached to.
+type LimitedFilter interface {
+	// LookupLimit returns the head/search cap, or zero to take the default.
+	LookupLimit() int
 }
 
 // SearchableFilter is an OPTIONAL extension a Filter may implement when its
@@ -577,8 +586,9 @@ type Entity[T EntityItem, ListOpts any, R any] struct {
 	DeleteWithContext func(ctx context.Context, id string) error
 	Filters           []Filter[ListOpts]
 
-	Actions     []EntityAction
-	BulkActions []EntityBulkAction
+	PrimaryAction EntityAction
+	Actions       []EntityAction
+	BulkActions   []EntityBulkAction
 
 	// Admin groups admin-only operations (inspect, configure, etc.)
 	// that produce different views/columns from the main CRUD operations.
@@ -842,6 +852,11 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 		info.Operations = append(info.Operations, op)
 	}
 
+	if e.PrimaryAction != nil {
+		primary := e.PrimaryAction.actionInfo()
+		info.PrimaryAction = &primary
+	}
+
 	for _, action := range e.Actions {
 		if action == nil {
 			continue
@@ -1016,7 +1031,11 @@ func generateEntityCLI(parent *cobra.Command, entity EntityInfo) {
 		generateEntitySubcommand(entityCmd, entity, op)
 	}
 
-	promoteListToEntityRoot(entityCmd)
+	if entity.PrimaryAction != nil {
+		generatePrimaryAction(entityCmd, *entity.PrimaryAction)
+	} else {
+		promoteListToEntityRoot(entityCmd)
+	}
 
 	for _, action := range entity.Actions {
 		scope := "entity"
@@ -1542,7 +1561,16 @@ func resolveEntityOpts[T any](flagMap map[string]string, filters []Filter[T]) (T
 // both for the head set and per-search. SearchableFilter implementations enumerate
 // only this many; the UI shows "… and N more" against the reported total and
 // re-queries as the user types.
+//
+// It is a ceiling rather than a target: a filter that knows its own cardinality
+// says so with its own smaller Limit, and this is what remains for the ones that
+// do not.
 const lookupOptionsLimit = 200
+
+// MaxLookupOptions is lookupOptionsLimit exported, so a caller declaring a
+// per-filter Limit can validate it against the ceiling rather than discovering
+// at request time that it was silently reduced.
+const MaxLookupOptions = lookupOptionsLimit
 
 // Reserved flag keys the lookup handler injects from the request query so a
 // single filter can be searched server-side. They never collide with entity
@@ -1592,15 +1620,52 @@ type boundFilter struct {
 	Multi      bool
 	Searchable bool
 	Selected   map[string]api.Textable
+	// Limit caps this filter's option set. Zero takes lookupOptionsLimit, which
+	// is also the ceiling — a filter cannot ask for a larger head than the
+	// response is willing to carry.
+	Limit int
 	// Options returns the head set (query == "") or search matches, plus the true
 	// total behind the head. A non-positive limit means "no cap".
 	Options func(query string, limit int) (map[string]api.Textable, int, error)
 }
 
+// limit is the option cap for one filter: its own when it declares a smaller
+// one, the package ceiling otherwise.
+func (f boundFilter) limit() int {
+	if f.Limit > 0 && f.Limit < lookupOptionsLimit {
+		return f.Limit
+	}
+	return lookupOptionsLimit
+}
+
+// searchTarget reports which filter a targeted search names, or -1 when the
+// request is a plain head request over all of them.
+//
+// A search asks about one filter. Answering it by re-enumerating every other
+// filter's head set costs one backend round trip per filter per keystroke, and
+// the client reads only the filter it asked about — so the rest is work nobody
+// receives.
+func searchTarget[T any](filters []T, describe func(T) (key string, searchable bool), searchKey, searchQuery string) int {
+	if searchKey == "" || searchQuery == "" {
+		return -1
+	}
+	for i, filter := range filters {
+		if key, searchable := describe(filter); searchable && key == searchKey {
+			return i
+		}
+	}
+	return -1
+}
+
+func describeBoundFilter(f boundFilter) (string, bool) { return f.Key, f.Searchable }
+
 // resolveLookupCore renders bound filters into the lookup response, applying the
 // searchable head/search/total logic uniformly. It is the single place the
 // lookup wire shape is built, shared by the typed and dynamic entity paths.
 func resolveLookupCore(filters []boundFilter, searchKey, searchQuery string) (entityLookupResponse, error) {
+	if target := searchTarget(filters, describeBoundFilter, searchKey, searchQuery); target >= 0 {
+		filters = filters[target : target+1]
+	}
 	response := entityLookupResponse{
 		Filters: make(map[string]entityLookupFilter, len(filters)),
 	}
@@ -1613,16 +1678,21 @@ func resolveLookupCore(filters []boundFilter, searchKey, searchQuery string) (en
 		}
 		switch {
 		case f.Searchable && searchKey == f.Key && searchQuery != "":
-			// Targeted server-side search: return matches for this filter only.
-			options, _, err := f.Options(searchQuery, lookupOptionsLimit)
+			// Targeted server-side search: matches for this filter only, and how
+			// many there are behind the cap. A search can overflow just as a head
+			// set can — reporting the total is what stops a clipped result being
+			// rendered as the whole answer.
+			options, total, err := f.Options(searchQuery, f.limit())
 			if err != nil {
 				return entityLookupResponse{}, err
 			}
 			entry.Options = toClickyNodeMap(options)
+			entry.Total = total
+			entry.Truncated = total > len(options)
 		case f.Searchable:
 			// Head request: first N options plus the true distinct total so
 			// the UI can show "… and N more" and decide whether to search.
-			options, total, err := f.Options("", lookupOptionsLimit)
+			options, total, err := f.Options("", f.limit())
 			if err != nil {
 				return entityLookupResponse{}, err
 			}
@@ -1674,12 +1744,17 @@ func resolveLookup[T any](
 		}
 		f := filter
 		searchable := filterIsSearchable(f)
+		limit := 0
+		if limited, ok := filter.(LimitedFilter); ok {
+			limit = limited.LookupLimit()
+		}
 		bound = append(bound, boundFilter{
 			Key:        f.Key(),
 			Label:      f.Label(),
 			Type:       meta.Type,
 			Multi:      meta.Multi,
 			Searchable: searchable,
+			Limit:      limit,
 			Selected:   selected[f.Key()],
 			Options: func(query string, limit int) (map[string]api.Textable, int, error) {
 				if searchable {

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -551,8 +551,12 @@ type Entity[T EntityItem, ListOpts any, R any] struct {
 	Parent string
 	// Aliases applied to the generated entity cobra command.
 	Aliases []string
-	List    func(opts ListOpts) ([]T, error)
-	Get     func(id string) (R, error)
+	// Path is the entity's hierarchy position within Parent, PathSeparator-joined
+	// (x-clicky.surfaces[].path). Build it with JoinPath/SplitPath so the
+	// separator stays the wire convention. Empty declares no hierarchy.
+	Path string
+	List func(opts ListOpts) ([]T, error)
+	Get  func(id string) (R, error)
 	// ListWithContext / GetWithContext / GetWithFlagsAndContext are context-aware
 	// variants of List / Get / GetWithFlags. When set they take precedence over
 	// their non-context counterparts and receive the request-scoped
@@ -773,6 +777,7 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 		Name:       name,
 		Parent:     e.Parent,
 		Aliases:    e.Aliases,
+		Path:       e.Path,
 		Type:       reflect.TypeOf((*T)(nil)).Elem(),
 		ListType:   reflect.TypeOf((*ListOpts)(nil)).Elem(),
 		ValidArgs:  e.ValidArgs,
@@ -857,11 +862,20 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 		info.PrimaryAction = &primary
 	}
 
+	// An action's verb becomes a subcommand name, so two actions sharing one are a
+	// wiring bug: cobra keeps whichever was added first and the other silently
+	// never runs, however different their routes are.
+	verbs := make(map[string]bool, len(e.Actions))
 	for _, action := range e.Actions {
 		if action == nil {
 			continue
 		}
-		info.Actions = append(info.Actions, action.actionInfo())
+		actionInfo := action.actionInfo()
+		if verbs[actionInfo.Name] {
+			panic("clicky.RegisterEntity: entity " + name + " declares two actions with the verb " + actionInfo.Name)
+		}
+		verbs[actionInfo.Name] = true
+		info.Actions = append(info.Actions, actionInfo)
 	}
 
 	listType := reflect.TypeOf((*ListOpts)(nil)).Elem()

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -60,6 +60,9 @@ type EntityInfo struct {
 	// Icon is an opaque UI icon name carried through to the OpenAPI surface
 	// (x-clicky.surfaces[].icon). Empty for entities that declare no icon.
 	Icon string
+	// Path is the entity's hierarchy position within Parent, PathSeparator-joined
+	// (x-clicky.surfaces[].path). Empty for entities that declare no hierarchy.
+	Path string
 	// Title overrides the auto-generated surface title when non-empty.
 	Title       string
 	Type        reflect.Type
@@ -320,6 +323,18 @@ type ActionSpec[R any] struct {
 	toolHints  MCPToolHints
 }
 
+// dataOrError type-erases a typed handler result, dropping the value when the
+// handler failed. Without it a failed handler's zero R is boxed into a non-nil
+// `any`, and callers that branch on `data != nil` (the RPC executor serializing
+// partial results) render a zero struct as the response body — hiding the error
+// behind `{"field": "", ...}`.
+func dataOrError[R any](result R, err error) (any, error) {
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // Action creates a typed custom operation on a single entity by ID.
 func Action[R any](name string, fn func(id string, flags map[string]string) (R, error)) *ActionSpec[R] {
 	return &ActionSpec[R]{name: name, run: fn}
@@ -420,7 +435,7 @@ func (a *ActionSpec[R]) actionInfo() ActionInfo {
 			if err != nil {
 				return nil, err
 			}
-			return a.runCtx(ctx, id, flagMap)
+			return dataOrError(a.runCtx(ctx, id, flagMap))
 		}
 	} else {
 		info.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
@@ -428,7 +443,7 @@ func (a *ActionSpec[R]) actionInfo() ActionInfo {
 			if err != nil {
 				return nil, err
 			}
-			return a.run(id, flagMap)
+			return dataOrError(a.run(id, flagMap))
 		}
 	}
 	return info
@@ -497,7 +512,7 @@ func (b *BulkActionSpec[R]) bulkActionInfo(resolveOpts func(map[string]string) (
 	}
 	if b.run != nil {
 		info.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
-			return b.run(args, flagMap)
+			return dataOrError(b.run(args, flagMap))
 		}
 	} else {
 		info.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
@@ -510,7 +525,7 @@ func (b *BulkActionSpec[R]) bulkActionInfo(resolveOpts func(map[string]string) (
 			if err != nil {
 				return nil, err
 			}
-			return b.filterFunc(opts, flagMap)
+			return dataOrError(b.filterFunc(opts, flagMap))
 		}
 	}
 	return info
@@ -700,7 +715,7 @@ func entityGetOperation[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts,
 			if err != nil {
 				return nil, err
 			}
-			return e.GetWithFlagsAndContext(ctx, id, flagMap)
+			return dataOrError(e.GetWithFlagsAndContext(ctx, id, flagMap))
 		}
 	case e.GetWithFlags != nil:
 		op.FlagsType = actionFlagsType(e.GetFlags)
@@ -709,7 +724,7 @@ func entityGetOperation[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts,
 			if err != nil {
 				return nil, err
 			}
-			return e.GetWithFlags(id, flagMap)
+			return dataOrError(e.GetWithFlags(id, flagMap))
 		}
 	case e.GetWithContext != nil:
 		op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
@@ -717,7 +732,7 @@ func entityGetOperation[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts,
 			if err != nil {
 				return nil, err
 			}
-			return e.GetWithContext(ctx, id)
+			return dataOrError(e.GetWithContext(ctx, id))
 		}
 	case e.Get != nil:
 		op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
@@ -725,7 +740,7 @@ func entityGetOperation[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts,
 			if err != nil {
 				return nil, err
 			}
-			return e.Get(id)
+			return dataOrError(e.Get(id))
 		}
 	default:
 		return EntityOperation{}, false
@@ -773,11 +788,11 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 		op := EntityOperation{Verb: "create", ResponseType: responseTypeOf[R]()}
 		if e.CreateWithContext != nil {
 			op.ContextDataFunc = func(ctx context.Context, flagMap map[string]string, args []string) (any, error) {
-				return e.CreateWithContext(ctx, entityBody(flagMap))
+				return dataOrError(e.CreateWithContext(ctx, entityBody(flagMap)))
 			}
 		} else {
 			op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
-				return e.Create(entityBody(flagMap))
+				return dataOrError(e.Create(entityBody(flagMap)))
 			}
 		}
 		info.Operations = append(info.Operations, op)
@@ -791,7 +806,7 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 				if err != nil {
 					return nil, err
 				}
-				return e.UpdateWithContext(ctx, id, entityBodyExcludingID(flagMap))
+				return dataOrError(e.UpdateWithContext(ctx, id, entityBodyExcludingID(flagMap)))
 			}
 		} else {
 			op.DataFunc = func(flagMap map[string]string, args []string) (any, error) {
@@ -799,7 +814,7 @@ func RegisterEntity[T EntityItem, ListOpts any, R any](e Entity[T, ListOpts, R])
 				if err != nil {
 					return nil, err
 				}
-				return e.Update(id, entityBodyExcludingID(flagMap))
+				return dataOrError(e.Update(id, entityBodyExcludingID(flagMap)))
 			}
 		}
 		info.Operations = append(info.Operations, op)

--- a/entity/entity_test.go
+++ b/entity/entity_test.go
@@ -200,8 +200,15 @@ func TestWrappedEntityClickyRowsIncludeHiddenID(t *testing.T) {
 		if len(doc.Node.Rows) != 1 {
 			t.Fatalf("%s expected one row, got %d", tt.name, len(doc.Node.Rows))
 		}
-		if got := doc.Node.Rows[0].Cells["_id"].Plain; got != tt.wantID {
-			t.Fatalf("%s _id plain = %q, want %q", tt.name, got, tt.wantID)
+		// Plain is omitted when it would only repeat Text, so the id is read the
+		// way every consumer reads it — plain first, then text.
+		cell := doc.Node.Rows[0].Cells["_id"]
+		got := cell.Plain
+		if got == "" {
+			got = cell.Text
+		}
+		if got != tt.wantID {
+			t.Fatalf("%s _id text = %q, want %q", tt.name, got, tt.wantID)
 		}
 		for _, column := range doc.Node.Columns {
 			if column.Name == "_id" {

--- a/entity/errors.go
+++ b/entity/errors.go
@@ -5,7 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/flanksource/commons/logger"
 )
+
+// InternalErrorMessage is the body message every unclassified failure is
+// reported with, so an internal detail can never reach a client by accident.
+const InternalErrorMessage = "internal server error"
 
 // StatusError is the body every failed HTTP operation returns.
 //
@@ -59,13 +65,17 @@ func (e *StatusError) Write(w http.ResponseWriter) {
 // choose between two error formats depending on where the failure came from.
 //
 // An error that did not state a status is a bug rather than a refusal, so it
-// becomes a 500 with an opaque code: the message is still forwarded because a
-// developer reading a browser console is the only person it can help.
+// becomes a 500 with an opaque code and a fixed message. Its own text is not
+// forwarded: an unclassified error is whatever the failing dependency said, and
+// that routinely names hosts, DSNs, file paths, or credentials. The detail stays
+// server-side in the log; a handler that wants the client to see a reason must
+// classify the failure with a StatusError.
 func WriteError(w http.ResponseWriter, err error) {
 	var status *StatusError
 	if errors.As(err, &status) {
 		status.Write(w)
 		return
 	}
-	NewStatusError(http.StatusInternalServerError, "internal_error", err.Error()).Write(w)
+	logger.Errorf("unclassified handler error: %v", err)
+	NewStatusError(http.StatusInternalServerError, "internal_error", InternalErrorMessage).Write(w)
 }

--- a/entity/errors.go
+++ b/entity/errors.go
@@ -1,0 +1,71 @@
+package entity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// StatusError is the body every failed HTTP operation returns.
+//
+// The 409 that asks for a connection has always been structured, and a client
+// that can branch on one code but has to string-match the rest is a client that
+// breaks when a message is reworded. Code is the stable part; Message is for a
+// person to read. It replaces http.Error, whose flat text body forces exactly
+// the string-matching this exists to avoid.
+type StatusError struct {
+	// Status is the HTTP status this error is written with. It never appears in
+	// the body: the status line already carries it, and repeating it invites the
+	// two to disagree.
+	Status int `json:"-"`
+
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewStatusError builds an error a handler can return and the transport can
+// write verbatim.
+func NewStatusError(status int, code, message string) *StatusError {
+	return &StatusError{Status: status, Code: code, Message: message}
+}
+
+// NewStatusErrorf is NewStatusError with a formatted message.
+func NewStatusErrorf(status int, code, format string, args ...any) *StatusError {
+	return &StatusError{Status: status, Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// StatusCode reports the status this error should be written with, defaulting
+// to 500 so a zero Status can never produce an invalid status line.
+func (e *StatusError) StatusCode() int {
+	if e.Status == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.Status
+}
+
+// Write renders the error as its JSON body at its status.
+func (e *StatusError) Write(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(e.StatusCode())
+	_ = json.NewEncoder(w).Encode(e)
+}
+
+// WriteError writes any error in the same shape, so a caller never has to
+// choose between two error formats depending on where the failure came from.
+//
+// An error that did not state a status is a bug rather than a refusal, so it
+// becomes a 500 with an opaque code: the message is still forwarded because a
+// developer reading a browser console is the only person it can help.
+func WriteError(w http.ResponseWriter, err error) {
+	var status *StatusError
+	if errors.As(err, &status) {
+		status.Write(w)
+		return
+	}
+	NewStatusError(http.StatusInternalServerError, "internal_error", err.Error()).Write(w)
+}

--- a/entity/errors_test.go
+++ b/entity/errors_test.go
@@ -1,0 +1,74 @@
+package entity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StatusError", func() {
+	It("renders only the two fields a client branches on", func() {
+		// The frontend reads code and switches on it; anything else in the body
+		// is a field it would have to learn to ignore. The status belongs to the
+		// status line, so it must not appear here and be able to disagree.
+		body, err := json.Marshal(NewStatusError(http.StatusConflict, "connection_required", "select a connection"))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).To(Equal(`{"code":"connection_required","message":"select a connection"}`))
+	})
+
+	DescribeTable("writes its code at its status",
+		func(status int, code, message string) {
+			w := httptest.NewRecorder()
+			NewStatusError(status, code, message).Write(w)
+
+			Expect(w.Code).To(Equal(status))
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			var body map[string]string
+			Expect(json.Unmarshal(w.Body.Bytes(), &body)).To(Succeed())
+			Expect(body).To(Equal(map[string]string{"code": code, "message": message}))
+		},
+		Entry("a stale cursor", http.StatusBadRequest, "cursor_stale", "the cursor no longer resolves"),
+		Entry("an unknown profile", http.StatusNotFound, "profile_not_found", `profile "invoices" not found`),
+		Entry("a missing connection", http.StatusConflict, "connection_required", "select a connection"),
+		Entry("a refused representation", http.StatusNotAcceptable, "not_acceptable", "no acceptable representation"),
+	)
+
+	It("reports its code and message when read as a plain error", func() {
+		Expect(NewStatusErrorf(http.StatusNotFound, "profile_not_found", "profile %q not found", "invoices").Error()).
+			To(Equal(`profile_not_found: profile "invoices" not found`))
+	})
+
+	It("falls back to 500 rather than writing an invalid status line", func() {
+		w := httptest.NewRecorder()
+		(&StatusError{Code: "unset", Message: "no status was stated"}).Write(w)
+
+		Expect(w.Code).To(Equal(http.StatusInternalServerError))
+	})
+
+	It("survives wrapping so a handler can add context to it", func() {
+		w := httptest.NewRecorder()
+		WriteError(w, fmt.Errorf("export invoices: %w", NewStatusError(http.StatusNotFound, "profile_not_found", "no such profile")))
+
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+		var body map[string]string
+		Expect(json.Unmarshal(w.Body.Bytes(), &body)).To(Succeed())
+		Expect(body["code"]).To(Equal("profile_not_found"))
+	})
+
+	It("gives an unclassified error the same shape at 500", func() {
+		w := httptest.NewRecorder()
+		WriteError(w, errors.New("connection refused"))
+
+		Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		var body map[string]string
+		Expect(json.Unmarshal(w.Body.Bytes(), &body)).To(Succeed())
+		Expect(body).To(Equal(map[string]string{"code": "internal_error", "message": "connection refused"}))
+	})
+})

--- a/entity/errors_test.go
+++ b/entity/errors_test.go
@@ -62,13 +62,17 @@ var _ = Describe("StatusError", func() {
 		Expect(body["code"]).To(Equal("profile_not_found"))
 	})
 
-	It("gives an unclassified error the same shape at 500", func() {
+	It("gives an unclassified error the same shape at 500 without leaking its text", func() {
+		// An unclassified error is whatever the failing dependency said — a DSN, a
+		// host, a path — so the client gets a fixed message and the detail stays in
+		// the server log.
 		w := httptest.NewRecorder()
-		WriteError(w, errors.New("connection refused"))
+		WriteError(w, errors.New("dial tcp 10.0.0.7:5432: connection refused"))
 
 		Expect(w.Code).To(Equal(http.StatusInternalServerError))
 		var body map[string]string
 		Expect(json.Unmarshal(w.Body.Bytes(), &body)).To(Succeed())
-		Expect(body).To(Equal(map[string]string{"code": "internal_error", "message": "connection refused"}))
+		Expect(body).To(Equal(map[string]string{"code": "internal_error", "message": InternalErrorMessage}))
+		Expect(w.Body.String()).ToNot(ContainSubstring("10.0.0.7"))
 	})
 })

--- a/entity/filter.go
+++ b/entity/filter.go
@@ -56,6 +56,11 @@ type NamedFilter struct {
 	Type string
 	// Multi reports whether the control accepts multiple selections.
 	Multi bool
+	// Limit caps the option set this filter enumerates in one shot. Zero takes
+	// MaxLookupOptions, which is also the ceiling. Declare a smaller one for a
+	// field whose cardinality makes a full head set useless to pick from: what
+	// is past it is reached by typing, not by scrolling.
+	Limit int
 	// Source resolves the filter's options.
 	Source FilterSource
 }

--- a/entity/lookup_limit_test.go
+++ b/entity/lookup_limit_test.go
@@ -1,0 +1,239 @@
+package entity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flanksource/clicky/api"
+)
+
+// countingFilter is a DynamicFilter over a fixed pool that records what it was
+// asked for. The counters are the point: a targeted search must leave every
+// other filter's Options and Selected untouched, and only a probe that can say
+// "never called" proves it.
+type countingFilter struct {
+	key           string
+	pool          []string
+	limit         int
+	optionsCalls  int
+	selectedCalls int
+	lastLimit     int
+	lastQuery     string
+}
+
+func (c *countingFilter) filter() DynamicFilter {
+	return DynamicFilter{
+		Key:        c.key,
+		Label:      c.key,
+		Type:       "multi-filter",
+		Multi:      true,
+		Searchable: true,
+		Limit:      c.limit,
+		Options: func(_ context.Context, _ map[string]string, query string, limit int) (map[string]api.Textable, int, error) {
+			c.optionsCalls++
+			c.lastLimit = limit
+			c.lastQuery = query
+			matched := make([]string, 0, len(c.pool))
+			for _, value := range c.pool {
+				if query == "" || contains(value, query) {
+					matched = append(matched, value)
+				}
+			}
+			out := make(map[string]api.Textable)
+			for _, value := range matched {
+				if limit > 0 && len(out) >= limit {
+					break
+				}
+				out[value] = api.Text{Content: value}
+			}
+			return out, len(matched), nil
+		},
+		Selected: func(context.Context, map[string]string) (map[string]api.Textable, error) {
+			c.selectedCalls++
+			return nil, nil
+		},
+	}
+}
+
+func resolveFilters(t *testing.T, flags map[string]string, filters ...DynamicFilter) entityLookupResponse {
+	t.Helper()
+	response, err := resolveDynamicLookup(context.Background(), filters, flags)
+	if err != nil {
+		t.Fatalf("resolveDynamicLookup: %v", err)
+	}
+	return response
+}
+
+func TestLookupHeadTakesTheFiltersOwnLimit(t *testing.T) {
+	probe := &countingFilter{key: "service", pool: makePool(400), limit: 50}
+
+	entry := resolveFilters(t, map[string]string{}, probe.filter()).Filters["service"]
+
+	if probe.lastLimit != 50 {
+		t.Fatalf("expected the filter to be asked for 50 options, got %d", probe.lastLimit)
+	}
+	if len(entry.Options) != 50 {
+		t.Fatalf("expected a head of 50, got %d", len(entry.Options))
+	}
+	if entry.Total != 400 || !entry.Truncated {
+		t.Fatalf("expected total=400 truncated=true, got total=%d truncated=%v", entry.Total, entry.Truncated)
+	}
+}
+
+// The declared limit is a request, not an override: a filter cannot ask for a
+// larger head than the response is willing to carry.
+func TestLookupHeadClampsADeclaredLimitToTheCeiling(t *testing.T) {
+	for name, declared := range map[string]int{
+		"above the ceiling": MaxLookupOptions + 300,
+		"undeclared":        0,
+	} {
+		t.Run(name, func(t *testing.T) {
+			probe := &countingFilter{key: "service", pool: makePool(1000), limit: declared}
+
+			entry := resolveFilters(t, map[string]string{}, probe.filter()).Filters["service"]
+
+			if probe.lastLimit != MaxLookupOptions {
+				t.Fatalf("expected the ceiling %d, got %d", MaxLookupOptions, probe.lastLimit)
+			}
+			if len(entry.Options) != MaxLookupOptions {
+				t.Fatalf("expected a head of %d, got %d", MaxLookupOptions, len(entry.Options))
+			}
+		})
+	}
+}
+
+// A search overflows its cap as readily as a head set does. Reporting the total
+// is what stops a clipped result being rendered as the whole answer.
+func TestLookupSearchReportsItsOwnTruncation(t *testing.T) {
+	probe := &countingFilter{key: "service", pool: makePool(400), limit: 50}
+	flags := map[string]string{lookupFilterKeyParam: "service", lookupQueryParam: "plan-0"}
+
+	entry := resolveFilters(t, flags, probe.filter()).Filters["service"]
+
+	// "plan-0" matches plan-0000..plan-0399 — every value in the pool.
+	if entry.Total != 400 {
+		t.Fatalf("expected the match count 400 behind the cap, got %d", entry.Total)
+	}
+	if !entry.Truncated {
+		t.Fatalf("expected truncated=true when 400 matches are served 50 at a time")
+	}
+	if len(entry.Options) != 50 {
+		t.Fatalf("expected 50 matches, got %d", len(entry.Options))
+	}
+}
+
+func TestLookupSearchThatFitsIsNotTruncated(t *testing.T) {
+	probe := &countingFilter{key: "service", pool: makePool(400), limit: 50}
+	flags := map[string]string{lookupFilterKeyParam: "service", lookupQueryParam: "plan-0042"}
+
+	entry := resolveFilters(t, flags, probe.filter()).Filters["service"]
+
+	if entry.Truncated || entry.Total != 1 {
+		t.Fatalf("expected one exact match reported untruncated, got total=%d truncated=%v", entry.Total, entry.Truncated)
+	}
+}
+
+// The cost this guards: a keystroke used to enumerate every filter on the
+// entity, so a profile with six filters paid six backend round trips per
+// debounce interval for five answers the client discards.
+func TestTargetedSearchLeavesTheOtherFiltersAlone(t *testing.T) {
+	searched := &countingFilter{key: "service", pool: makePool(400), limit: 50}
+	bystander := &countingFilter{key: "region", pool: makePool(10), limit: 50}
+	flags := map[string]string{lookupFilterKeyParam: "service", lookupQueryParam: "plan-01"}
+
+	response := resolveFilters(t, flags, searched.filter(), bystander.filter())
+
+	if bystander.optionsCalls != 0 {
+		t.Fatalf("expected the unsearched filter's options to go unread, got %d calls", bystander.optionsCalls)
+	}
+	if bystander.selectedCalls != 0 {
+		t.Fatalf("expected the unsearched filter's selection to go unresolved, got %d calls", bystander.selectedCalls)
+	}
+	if searched.optionsCalls != 1 {
+		t.Fatalf("expected the searched filter to be read once, got %d", searched.optionsCalls)
+	}
+	if _, present := response.Filters["region"]; present {
+		t.Fatalf("expected only the searched filter in the response, got %v", filterKeys(response))
+	}
+}
+
+func TestHeadRequestStillResolvesEveryFilter(t *testing.T) {
+	first := &countingFilter{key: "service", pool: makePool(5), limit: 50}
+	second := &countingFilter{key: "region", pool: makePool(5), limit: 50}
+
+	for name, flags := range map[string]map[string]string{
+		"no search at all":     {},
+		"a key with no query":  {lookupFilterKeyParam: "service"},
+		"a query with no key":  {lookupQueryParam: "plan"},
+		"a key nothing serves": {lookupFilterKeyParam: "nonexistent", lookupQueryParam: "plan"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			first.optionsCalls, second.optionsCalls = 0, 0
+			response := resolveFilters(t, flags, first.filter(), second.filter())
+
+			if len(response.Filters) != 2 {
+				t.Fatalf("expected every filter in the response, got %v", filterKeys(response))
+			}
+			if first.optionsCalls != 1 || second.optionsCalls != 1 {
+				t.Fatalf("expected both filters read once, got %d and %d", first.optionsCalls, second.optionsCalls)
+			}
+		})
+	}
+}
+
+// A filter that is not searchable enumerates in full and says nothing about a
+// total, which is the pre-existing contract for an option set that is complete
+// by construction.
+func TestUnsearchableFilterIsNeitherCappedNorTruncated(t *testing.T) {
+	probe := &countingFilter{key: "service", pool: makePool(400), limit: 50}
+	unsearchable := probe.filter()
+	unsearchable.Searchable = false
+
+	entry := resolveFilters(t, map[string]string{}, unsearchable).Filters["service"]
+
+	if probe.lastLimit != 0 {
+		t.Fatalf("expected an uncapped enumeration, got limit %d", probe.lastLimit)
+	}
+	if len(entry.Options) != 400 || entry.Truncated || entry.Total != 0 {
+		t.Fatalf("expected all 400 options with no total, got %d options total=%d truncated=%v",
+			len(entry.Options), entry.Total, entry.Truncated)
+	}
+}
+
+// limitedTestFilter is the typed-entity equivalent: a SearchableFilter that also
+// implements LimitedFilter.
+type limitedTestFilter struct {
+	*searchableTestFilter
+	limit int
+}
+
+func (f *limitedTestFilter) LookupLimit() int { return f.limit }
+
+func TestTypedFilterCarriesItsLimitThrough(t *testing.T) {
+	inner := &searchableTestFilter{pool: makePool(250)}
+	lookup := buildLookupFunc[searchableTestOpts]([]Filter[searchableTestOpts]{
+		&limitedTestFilter{searchableTestFilter: inner, limit: 25},
+	})
+
+	data, err := lookup(map[string]string{}, nil)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	entry := data.(entityLookupResponse).Filters["plan"]
+
+	if inner.lastLimit != 25 {
+		t.Fatalf("expected the declared limit 25 to reach the filter, got %d", inner.lastLimit)
+	}
+	if len(entry.Options) != 25 || entry.Total != 250 || !entry.Truncated {
+		t.Fatalf("expected 25 of 250 reported truncated, got %d options total=%d truncated=%v",
+			len(entry.Options), entry.Total, entry.Truncated)
+	}
+}
+
+func filterKeys(response entityLookupResponse) []string {
+	out := make([]string, 0, len(response.Filters))
+	for key := range response.Filters {
+		out = append(out, key)
+	}
+	return out
+}

--- a/entity/lookup_limit_test.go
+++ b/entity/lookup_limit_test.go
@@ -44,7 +44,7 @@ func (c *countingFilter) filter() DynamicFilter {
 				if limit > 0 && len(out) >= limit {
 					break
 				}
-				out[value] = api.Text{Content: value}
+				out[value] = api.Text{}.Append(value)
 			}
 			return out, len(matched), nil
 		},

--- a/entity/operation.go
+++ b/entity/operation.go
@@ -47,7 +47,13 @@ type ClickySurface struct {
 	Description string `json:"description,omitempty"`
 	// Icon is an opaque UI icon name (e.g. "database") the frontend resolves to
 	// a glyph. Emitted verbatim from the entity's x-clicky-icon annotation.
-	Icon  string `json:"icon,omitempty"`
+	Icon string `json:"icon,omitempty"`
+	// Path is this surface's position within its Parent group, always separated
+	// by PathSeparator (e.g. "jms/incoming/disbursements"). Producers split
+	// their own naming convention with SplitPath before emitting it, so the
+	// frontend never guesses a delimiter. Empty — the default for every surface
+	// that does not opt in — means the group renders as a flat list.
+	Path  string `json:"path,omitempty"`
 	Order int    `json:"-"`
 }
 
@@ -63,6 +69,7 @@ type ClickyOperationMeta struct {
 	Aliases            []string      `json:"-"`
 	Admin              bool          `json:"-"`
 	Icon               string        `json:"-"`
+	Path               string        `json:"-"`
 	Title              string        `json:"-"`
 	Verb               string        `json:"verb,omitempty"`
 	Scope              string        `json:"scope,omitempty"`

--- a/entity/operation.go
+++ b/entity/operation.go
@@ -23,6 +23,7 @@ type RPCOperation struct {
 	ToolHints         MCPToolHints         `json:"-"`                // MCP annotations and Clicky-specific tool metadata
 	DataFunc          DataFunc             `json:"-"`                // Direct data provider, bypasses stdout capture
 	ContextDataFunc   ContextDataFunc      `json:"-"`                // Context-aware data provider; preferred over DataFunc when set
+	PagedFunc         PagedFunc            `json:"-"`                // Paging/export data provider returning a PageResponse; preferred over ContextDataFunc when set. The operation supplies rows and the paging facts about them, and clicky owns the response: headers, content negotiation, streaming and the download name.
 	LookupFunc        DataFunc             `json:"-"`                // Direct filter metadata provider
 	ContextLookupFunc ContextLookupFunc    `json:"-"`                // Context-aware filter metadata provider; preferred over LookupFunc when set
 	Clicky            *ClickyOperationMeta `json:"-"`                // Entity semantics used for OpenAPI extensions

--- a/entity/paging.go
+++ b/entity/paging.go
@@ -207,6 +207,18 @@ func ExportResponseHeaders() map[string]ExportHeaderDoc {
 	return headers
 }
 
+// exportAllowedOrigin is the origin every export response is readable from.
+// Empty means the library states none, which is the "*" default.
+var exportAllowedOrigin string
+
+// SetExportAllowedOrigin narrows Access-Control-Allow-Origin on every export
+// response to a single origin. A consumer that serves its frontend from a known
+// origin should set it at startup; leaving it unset (or passing "") keeps the
+// permissive "*" a library with no knowledge of its host has to default to.
+func SetExportAllowedOrigin(origin string) {
+	exportAllowedOrigin = origin
+}
+
 // SetCORSHeaders permits a cross-origin caller to read this response, whatever
 // it turns out to be.
 //
@@ -215,8 +227,17 @@ func ExportResponseHeaders() map[string]ExportHeaderDoc {
 // success is what makes an error body unreadable in a browser — and an error
 // nobody can read is worse than the one it describes.
 func SetCORSHeaders(w http.ResponseWriter) {
+	origin := exportAllowedOrigin
+	if origin == "" {
+		origin = "*"
+	}
 	header := w.Header()
-	header.Set("Access-Control-Allow-Origin", "*")
+	header.Set("Access-Control-Allow-Origin", origin)
+	if origin != "*" {
+		// The response now varies by origin, so a shared cache must not serve one
+		// origin's copy to another.
+		header.Add("Vary", "Origin")
+	}
 	header.Set("Access-Control-Expose-Headers", strings.Join(ExportHeaderNames(), ", "))
 }
 

--- a/entity/paging.go
+++ b/entity/paging.go
@@ -1,0 +1,351 @@
+package entity
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/flanksource/clicky/formatters"
+)
+
+// PagedFunc supplies one page or one export of rows.
+//
+// It is preferred over ContextDataFunc when set, and the division is the point:
+// the operation answers only what the rows are and what is true about them —
+// how many exist, whether more can be asked for, where to resume — while clicky
+// owns the response. Content negotiation, every header below, streaming and the
+// download name are therefore identical across every operation that opts in,
+// rather than re-derived per command.
+type PagedFunc func(ctx context.Context, req PageRequest, flags map[string]string) (PageResponse, error)
+
+// Export scopes. A request either asks for one page or for everything up to the
+// operation's ceiling; there is no third answer, so anything else is refused
+// rather than quietly treated as a page.
+const (
+	ScopePage = "page"
+	ScopeAll  = "all"
+)
+
+// Export modes describe how the rows were produced, which is orthogonal to the
+// scope that was asked for: a scope=page request against an operation that has
+// to run its whole pipeline before any row is correct reports ModeBuffered.
+const (
+	ModePage      = "page"
+	ModeBuffered  = "buffered"
+	ModeStreaming = "streaming"
+)
+
+// DefaultExportFormat is what a caller that expressed no preference gets.
+const DefaultExportFormat = "json"
+
+// These are the library's own fallbacks, applied only when a caller states no
+// PageLimits. An application with a view on how much its backends can serve is
+// expected to pass its own; nothing here is claimed to match any consumer's.
+const (
+	// DefaultPageSize is the page an operation serves when the caller names none.
+	DefaultPageSize = 100
+	// DefaultMaxPageSize is the largest single page a caller may ask for. Past
+	// this, the answer is scope=all rather than a bigger page.
+	DefaultMaxPageSize = 1000
+)
+
+// PageLimits bound what one request may ask for. A zero value resolves to the
+// defaults, so a caller with no opinion does not have to state one.
+type PageLimits struct {
+	DefaultPageSize int
+	MaxPageSize     int
+}
+
+func (l PageLimits) resolve() PageLimits {
+	if l.DefaultPageSize <= 0 {
+		l.DefaultPageSize = DefaultPageSize
+	}
+	if l.MaxPageSize <= 0 {
+		l.MaxPageSize = DefaultMaxPageSize
+	}
+	if l.DefaultPageSize > l.MaxPageSize {
+		l.DefaultPageSize = l.MaxPageSize
+	}
+	return l
+}
+
+// PageRequest is one export: which rows, in what shape, and how far.
+type PageRequest struct {
+	// Scope is ScopePage or ScopeAll.
+	Scope string
+	// Format is the resolved export format, after ?format and Accept have been
+	// reconciled — the operation never has to look at either again.
+	Format string
+	// Cursor is an opaque position handed back by a previous page.
+	Cursor string
+	// Filename overrides the download name. Empty means derive one.
+	Filename string
+
+	Limit  int
+	Offset int
+
+	// Download asks for a Content-Disposition even when no filename was named.
+	Download bool
+
+	// SkipTotal waives the exact total. A backend asked for the size of the whole
+	// result has to produce the whole result first, which is the difference
+	// between an export that streams and one that hangs until the last row is
+	// found — so an all-rows export declines to ask.
+	SkipTotal bool
+}
+
+// Total is a result-set size together with how much the backend was willing to
+// promise about it.
+type Total struct {
+	Value int64
+	Exact bool
+}
+
+// Relation reports how X-Total-Count should be read.
+//
+// A nil Total is the third answer and the reason this is a pointer method: a
+// backend that states no total at all is different from one that reports zero,
+// and without a relation those two are the same absent header.
+func (t *Total) Relation() string {
+	switch {
+	case t == nil:
+		return "unknown"
+	case t.Exact:
+		return "eq"
+	default:
+		return "gte"
+	}
+}
+
+// PageResponse is everything the transport reports about the rows it is about
+// to write. Every field is resolved before the first byte of the body, because
+// a header cannot be corrected once the body has begun.
+//
+// It is unrelated to PagedResult[T], the buffered JSON envelope: this one is
+// what clicky turns into an HTTP response, and its rows are still unread.
+type PageResponse struct {
+	Rows formatters.RowIterator
+
+	// Mode is ModePage, ModeBuffered or ModeStreaming.
+	Mode string
+
+	// Total is nil when the backend states no size for the whole result.
+	Total   *Total
+	HasMore bool
+	// Next is the opaque position resuming after this page, when the provider
+	// issued one.
+	Next string
+
+	// Ceiling stops an all-rows export. Zero means the rows are already bounded,
+	// and therefore that nothing is left to discover by reading to the end.
+	Ceiling int
+
+	// MaxRows is the ceiling this export was bounded by, reported so a caller
+	// sees the same number the server enforced.
+	MaxRows int
+
+	// Truncated reports a cut this response already knows about — the operation's
+	// own size, or a cap the backend applied. A ceiling is not known to have
+	// bitten until the rows have been read, so that case is reported as a trailer.
+	Truncated bool
+
+	// Pageable reports whether the operation can serve a position past its first
+	// page. A response that cannot must not report one as available.
+	Pageable bool
+}
+
+// exportHeader is one paging fact a response carries, described once.
+//
+// Three consumers read this list and none of them may disagree: the
+// Access-Control-Expose-Headers value (a header a browser cannot read is a
+// header that does not exist), the OpenAPI response documentation (a contract
+// only the first-party UI knows is a contract no generated client can honour),
+// and the setters below.
+type exportHeader struct {
+	name        string
+	description string
+	kind        string
+}
+
+var exportHeaderSpecs = []exportHeader{
+	{"Content-Disposition", "Attachment filename; present when ?_download or ?filename is given", "string"},
+	{"X-Export-Mode", "How the rows were produced: page, buffered or streaming. Orthogonal to scope — a scope=page request against an operation that cannot stream reports buffered", "string"},
+	{"X-Page-Limit", "Rows this page was limited to. Present when scope=page", "integer"},
+	{"X-Page-Offset", "Rows skipped before this page. Present when scope=page and the operation can be paged", "integer"},
+	{"X-Total-Count", "Size of the whole result set. Absent when the backend does not report one — read X-Total-Relation to tell that from zero", "integer"},
+	{"X-Total-Relation", "How to read X-Total-Count: eq (exact), gte (lower bound), or unknown (the backend states no total)", "string"},
+	{"X-Has-More", "Whether a further page can be requested. False for an operation with no total order, which serves its first page and refuses every page after it", "boolean"},
+	{"X-Next-Cursor", "Opaque position resuming after this page. Present when scope=page and the provider issued one", "string"},
+	{"X-Truncated", "The rows were cut short. Present when scope=all and the cut is known before the body; otherwise sent as the declared trailer", "boolean"},
+	{"X-Max-Rows", "Ceiling this export was bounded by. Present when scope=all; a PDF reports its own lower ceiling", "integer"},
+}
+
+// ExportHeaderNames are the header names, for Access-Control-Expose-Headers.
+func ExportHeaderNames() []string {
+	names := make([]string, 0, len(exportHeaderSpecs))
+	for _, spec := range exportHeaderSpecs {
+		names = append(names, spec.name)
+	}
+	return names
+}
+
+// ExportHeaderDoc documents one response header for the OpenAPI spec. It is
+// deliberately not the rpc package's own header type: rpc imports entity, so
+// the description travels as plain data and rpc adapts it.
+type ExportHeaderDoc struct {
+	Description string
+	Type        string
+}
+
+// ExportResponseHeaders documents the same headers for the OpenAPI response.
+func ExportResponseHeaders() map[string]ExportHeaderDoc {
+	headers := make(map[string]ExportHeaderDoc, len(exportHeaderSpecs))
+	for _, spec := range exportHeaderSpecs {
+		headers[spec.name] = ExportHeaderDoc{Description: spec.description, Type: spec.kind}
+	}
+	return headers
+}
+
+// SetCORSHeaders permits a cross-origin caller to read this response, whatever
+// it turns out to be.
+//
+// It is deliberately independent of the response: none of it depends on the
+// rows, so it is set before the first thing that can fail. Setting it only on
+// success is what makes an error body unreadable in a browser — and an error
+// nobody can read is worse than the one it describes.
+func SetCORSHeaders(w http.ResponseWriter) {
+	header := w.Header()
+	header.Set("Access-Control-Allow-Origin", "*")
+	header.Set("Access-Control-Expose-Headers", strings.Join(ExportHeaderNames(), ", "))
+}
+
+// DeclaresTruncatedTrailer reports whether this response has to declare
+// Trailer: X-Truncated, and so whether it is a response that ends with trailers
+// at all.
+//
+// Only a ceiling that might still bite needs one. A buffered export has none to
+// hit, and one already known to have been cut has its answer in the headers —
+// declaring a trailer for either costs the response its Content-Length, forces
+// chunked encoding, and promises an answer that never comes.
+//
+// A trailer is a poor last resort: browsers do not expose them, so this reaches
+// CLI and library callers only. It is kept for the one case that is genuinely
+// unknowable up front — a stream whose backend states no total — rather than as
+// the primary channel.
+//
+// It is exported because the transport has to know the same thing to send the
+// trailer it declares, and to know whether anything else may ride along in the
+// trailer section it has already paid for. Two copies of this condition is the
+// worst outcome available: a declared trailer that never arrives leaves a client
+// waiting, and an undeclared one is dropped on the floor.
+func DeclaresTruncatedTrailer(req PageRequest, res PageResponse) bool {
+	return req.Scope != ScopePage && res.Ceiling > 0 && !res.Truncated
+}
+
+// SetExportHeaders writes every paging fact this response carries. It must be
+// called before the first byte of the body.
+func SetExportHeaders(w http.ResponseWriter, name string, req PageRequest, res PageResponse) {
+	header := w.Header()
+	SetCORSHeaders(w)
+	header.Set("Content-Type", ExportContentType(req.Format))
+	header.Set("X-Export-Mode", res.Mode)
+
+	if req.Scope == ScopePage {
+		header.Set("X-Page-Limit", strconv.Itoa(req.Limit))
+		// An operation with no total order serves its first page and refuses every
+		// page after it. Reporting rows behind that page would be true and
+		// useless: the only request it invites is one this server answers 400.
+		// Offset is withheld for the same reason — it names a position that
+		// cannot be asked for.
+		if res.Pageable {
+			header.Set("X-Page-Offset", strconv.Itoa(req.Offset))
+			header.Set("X-Has-More", strconv.FormatBool(res.HasMore))
+			if res.Next != "" {
+				header.Set("X-Next-Cursor", res.Next)
+			}
+		} else {
+			header.Set("X-Has-More", "false")
+		}
+	} else {
+		header.Set("X-Max-Rows", strconv.Itoa(res.MaxRows))
+		if DeclaresTruncatedTrailer(req, res) {
+			header.Set("Trailer", "X-Truncated")
+		}
+	}
+
+	// A total the backend could not state exactly is a lower bound, and a caller
+	// rendering it as a count would be reporting a number nobody promised. No
+	// total at all is a third answer: without it, a missing X-Total-Count reads
+	// the same as a zero one, so the relation is always stated.
+	header.Set("X-Total-Relation", res.Total.Relation())
+	if res.Total != nil {
+		header.Set("X-Total-Count", strconv.FormatInt(res.Total.Value, 10))
+	}
+	if res.Truncated {
+		header.Set("X-Truncated", "true")
+	}
+
+	if req.Download || req.Filename != "" {
+		filename := req.Filename
+		if filename == "" {
+			filename = name + ExportExtension(req.Format)
+		}
+		header.Set("Content-Disposition", ContentDisposition(filename))
+	}
+}
+
+// ParsePageRequest reads the transport half of a request: which rows, in what
+// shape, and how far. Every failure is a StatusError so the caller writes one
+// error shape rather than choosing between two.
+func ParsePageRequest(r *http.Request, limits PageLimits) (PageRequest, error) {
+	limits = limits.resolve()
+	query := r.URL.Query()
+
+	format, err := RequestedFormat(r)
+	if err != nil {
+		return PageRequest{}, err
+	}
+	request := PageRequest{
+		Format:   format,
+		Scope:    query.Get("scope"),
+		Limit:    limits.DefaultPageSize,
+		Cursor:   query.Get("cursor"),
+		Filename: query.Get("filename"),
+		Download: query.Has("_download"),
+	}
+	if request.Scope == "" {
+		request.Scope = ScopePage
+	}
+	if request.Scope != ScopePage && request.Scope != ScopeAll {
+		return request, NewStatusErrorf(http.StatusBadRequest, "invalid_scope", "invalid export scope %q", request.Scope)
+	}
+	if value := query.Get("limit"); value != "" {
+		limit, err := strconv.Atoi(value)
+		if err != nil || limit <= 0 || limit > limits.MaxPageSize {
+			return request, NewStatusErrorf(http.StatusBadRequest, "invalid_limit",
+				"limit must be between 1 and %d; export more with scope=all", limits.MaxPageSize)
+		}
+		request.Limit = limit
+	}
+	if value := query.Get("offset"); value != "" {
+		offset, err := strconv.Atoi(value)
+		if err != nil || offset < 0 {
+			return request, NewStatusError(http.StatusBadRequest, "invalid_offset", "offset must be zero or greater")
+		}
+		request.Offset = offset
+	}
+	if request.Scope == ScopeAll {
+		// An export reads forward to the ceiling and never jumps, so a position
+		// within the result is meaningless to it. It also waives the exact total:
+		// see PageRequest.SkipTotal.
+		request.Offset = 0
+		request.Cursor = ""
+		request.SkipTotal = true
+	}
+	if request.Cursor != "" && request.Offset != 0 {
+		return request, NewStatusError(http.StatusBadRequest, "invalid_cursor",
+			"a cursor already says where to resume, so it cannot be combined with an offset")
+	}
+	return request, nil
+}

--- a/entity/paging_formats.go
+++ b/entity/paging_formats.go
@@ -1,0 +1,258 @@
+package entity
+
+// Content negotiation and the download name: the half of the export contract
+// that decides what a response is, as opposed to how far it goes.
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// RequestedFormat resolves ?format, falling back to content negotiation.
+func RequestedFormat(r *http.Request) (string, error) {
+	format := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("format")))
+	switch format {
+	case "xlsx":
+		return "excel", nil
+	case "md":
+		return "markdown", nil
+	case "yml":
+		return "yaml", nil
+	case "":
+		return AcceptedFormat(r.Header.Get("Accept"))
+	}
+	if !SupportedExportFormat(format) {
+		return "", NewStatusErrorf(http.StatusBadRequest, "unsupported_format", "unsupported export format %q", format)
+	}
+	return format, nil
+}
+
+// AcceptedFormat picks the format an Accept header asks for.
+//
+// Accept is ranked, not ordered: a caller listing text/html first at q=0.1 and
+// the clicky envelope at q=0.9 is asking for the envelope. Reading the first
+// recognised entry answers with the one it weighted lowest. Ties keep the
+// earlier entry, which is the order the caller wrote them in.
+//
+// A q=0 is a refusal, not a low preference, and a refusal has to be able to
+// leave nothing acceptable behind. Seeding the search with the default format
+// would make `Accept: application/json;q=0` answer with the very thing it just
+// refused, so refusals are tracked and the fallback is withheld when the
+// default is among them — the honest answer there is 406. A wildcard resolves
+// to the default for exactly this reason, so `*/*;q=0` refuses everything
+// rather than silently accepting the default.
+//
+// A refusal only decides the answer when nothing else was acceptable, which is
+// what lets a named range override a blanket one: `*/*;q=0, text/csv` is a
+// caller that wants csv and nothing else.
+func AcceptedFormat(accept string) (string, error) {
+	best, bestQuality := "", -1.0
+	refused := map[string]bool{}
+	for _, part := range strings.Split(accept, ",") {
+		fields := strings.Split(part, ";")
+		format, ok := formatForMediaType(strings.ToLower(strings.TrimSpace(fields[0])))
+		if !ok {
+			continue
+		}
+		quality := acceptQuality(fields[1:])
+		if quality <= 0 {
+			refused[format] = true
+			continue
+		}
+		if quality <= bestQuality {
+			continue
+		}
+		best, bestQuality = format, quality
+	}
+	if best != "" {
+		return best, nil
+	}
+	if refused[DefaultExportFormat] {
+		return "", NewStatusErrorf(http.StatusNotAcceptable, "not_acceptable",
+			"no supported representation is acceptable to %q", accept)
+	}
+	return DefaultExportFormat, nil
+}
+
+// acceptQuality reads the q parameter of one Accept entry, defaulting to 1.
+func acceptQuality(parameters []string) float64 {
+	quality := 1.0
+	for _, parameter := range parameters {
+		name, value, found := strings.Cut(strings.TrimSpace(parameter), "=")
+		if !found || strings.ToLower(strings.TrimSpace(name)) != "q" {
+			continue
+		}
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			continue
+		}
+		quality = parsed
+	}
+	return quality
+}
+
+func formatForMediaType(media string) (string, bool) {
+	switch media {
+	case "application/json+clicky", "application/clicky+json":
+		return "clicky-json", true
+	case "application/x-ndjson", "application/ndjson":
+		return "ndjson", true
+	case "application/yaml", "application/x-yaml", "text/yaml":
+		return "yaml", true
+	case "text/csv", "application/csv":
+		return "csv", true
+	case "text/markdown":
+		return "markdown", true
+	case "text/html":
+		return "html", true
+	case "application/pdf":
+		return "pdf", true
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return "excel", true
+	case "application/json":
+		return "json", true
+	case "*/*":
+		// A wildcard is an opinion about the default, not an absence of one, and
+		// resolving it to the default is what makes it carry a q: `*/*;q=0` says
+		// nothing at all is acceptable and has to be able to reach the 406, which
+		// it cannot do while it looks like a media type nobody recognised.
+		//
+		// Subtype wildcards (application/*) are deliberately not read: honouring
+		// them means implementing RFC 7231's specificity precedence, and guessing
+		// at it is worse than treating them as unrecognised, which is what every
+		// caller sending one already gets.
+		return DefaultExportFormat, true
+	default:
+		return "", false
+	}
+}
+
+func SupportedExportFormat(format string) bool {
+	switch format {
+	case "clicky-json", "json", "ndjson", "yaml", "csv", "markdown", "html", "excel", "pdf":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsTabularExport reports whether a format renders rows as a table, and so has
+// to be written through formatters.WriteTableStream rather than serialized.
+func IsTabularExport(format string) bool {
+	switch format {
+	case "csv", "markdown", "html", "excel", "pdf":
+		return true
+	default:
+		return false
+	}
+}
+
+func ExportContentType(format string) string {
+	switch format {
+	case "clicky-json":
+		return "application/json+clicky"
+	case "json":
+		return "application/json"
+	case "ndjson":
+		return "application/x-ndjson"
+	case "yaml":
+		return "application/yaml"
+	case "csv":
+		return "text/csv; charset=utf-8"
+	case "markdown":
+		return "text/markdown; charset=utf-8"
+	case "html":
+		return "text/html; charset=utf-8"
+	case "excel":
+		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	case "pdf":
+		return "application/pdf"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func ExportExtension(format string) string {
+	switch format {
+	case "markdown":
+		return ".md"
+	case "excel":
+		return ".xlsx"
+	case "ndjson":
+		return ".ndjson"
+	default:
+		return "." + format
+	}
+}
+
+// SanitizeExportFilename reduces a caller-supplied name to something that can
+// only ever be a filename: no path to escape with, and nothing that could close
+// the header parameter it is about to be written into.
+func SanitizeExportFilename(filename string) string {
+	filename = strings.ReplaceAll(filename, "\\", "/")
+	parts := strings.Split(filename, "/")
+	filename = parts[len(parts)-1]
+	filename = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || strings.ContainsRune(`\";`, r) {
+			return '_'
+		}
+		return r
+	}, filename)
+	filename = strings.Trim(filename, " .")
+	if filename == "" {
+		return "export.json"
+	}
+	return filename
+}
+
+// ContentDisposition renders an attachment header for a filename.
+//
+// RFC 6266's plain filename= is a quoted-string, which is ISO-8859-1: a UTF-8
+// name written there travels as bytes the client is not obliged to decode, and
+// Go's own quoting is not the escaping that header defines either. filename*
+// names its charset, so it is the form that carries a non-ASCII name intact.
+// Both are emitted — a client that understands filename* is required to prefer
+// it, and one that does not still gets a usable, if flattened, name.
+func ContentDisposition(filename string) string {
+	name := SanitizeExportFilename(filename)
+	return "attachment; filename=\"" + asciiFilename(name) + "\"; filename*=UTF-8''" + encodeRFC8187(name)
+}
+
+// asciiFilename flattens what a quoted-string cannot carry. Sanitizing has
+// already removed the quote and backslash that would need escaping, so what is
+// left only has to be made ASCII.
+func asciiFilename(name string) string {
+	flattened := strings.Map(func(r rune) rune {
+		if r > unicode.MaxASCII {
+			return '_'
+		}
+		return r
+	}, name)
+	if strings.Trim(flattened, "_") == "" {
+		return "export" + ExportExtension(DefaultExportFormat)
+	}
+	return flattened
+}
+
+// attrChars are the characters RFC 8187 allows unencoded in an ext-value.
+const attrChars = "!#$&+-.^_`|~"
+
+func encodeRFC8187(name string) string {
+	const hex = "0123456789ABCDEF"
+	var encoded strings.Builder
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9',
+			strings.IndexByte(attrChars, c) >= 0:
+			encoded.WriteByte(c)
+		default:
+			encoded.WriteByte('%')
+			encoded.WriteByte(hex[c>>4])
+			encoded.WriteByte(hex[c&0x0f])
+		}
+	}
+	return encoded.String()
+}

--- a/entity/paging_test.go
+++ b/entity/paging_test.go
@@ -1,0 +1,307 @@
+package entity
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// headersFor runs the setter over one scenario and returns what it wrote.
+func headersFor(name string, req PageRequest, res PageResponse) http.Header {
+	w := httptest.NewRecorder()
+	SetExportHeaders(w, name, req, res)
+	return w.Header()
+}
+
+var _ = Describe("Total relation", func() {
+	DescribeTable("distinguishes an exact count, a lower bound and no count at all",
+		func(total *Total, expected string) {
+			Expect(total.Relation()).To(Equal(expected))
+		},
+		Entry("a backend that states no total", (*Total)(nil), "unknown"),
+		Entry("an exact count", &Total{Value: 42, Exact: true}, "eq"),
+		Entry("a zero count is still exact", &Total{Value: 0, Exact: true}, "eq"),
+		Entry("a lower bound", &Total{Value: 1000, Exact: false}, "gte"),
+	)
+})
+
+var _ = Describe("Export headers", func() {
+	It("sets every header it documents", func() {
+		// The specs are the contract three consumers read; a documented header
+		// nobody sets is the disagreement this guards against.
+		page := headersFor("report", PageRequest{
+			Scope: ScopePage, Format: "csv", Limit: 25, Offset: 50, Download: true,
+		}, PageResponse{
+			Mode: ModePage, Pageable: true, HasMore: true, Next: "cursor-1",
+			Total: &Total{Value: 500, Exact: true},
+		})
+		all := headersFor("report", PageRequest{Scope: ScopeAll, Format: "csv"}, PageResponse{
+			Mode: ModeStreaming, MaxRows: 10000, Truncated: true,
+		})
+
+		for _, spec := range exportHeaderSpecs {
+			Expect(page.Get(spec.name)+all.Get(spec.name)).ToNot(BeEmpty(),
+				"%s is documented but never set", spec.name)
+		}
+	})
+
+	It("exposes exactly the documented headers to a cross-origin caller", func() {
+		w := httptest.NewRecorder()
+		SetCORSHeaders(w)
+
+		Expect(w.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+		exposed := strings.Split(w.Header().Get("Access-Control-Expose-Headers"), ", ")
+		Expect(exposed).To(Equal(ExportHeaderNames()))
+	})
+
+	It("documents every header for OpenAPI with a description and a type", func() {
+		docs := ExportResponseHeaders()
+
+		Expect(docs).To(HaveLen(len(exportHeaderSpecs)))
+		for _, spec := range exportHeaderSpecs {
+			Expect(docs[spec.name]).To(Equal(ExportHeaderDoc{Description: spec.description, Type: spec.kind}))
+		}
+	})
+
+	It("always states the total relation so a missing count is not a zero one", func() {
+		header := headersFor("report", PageRequest{Scope: ScopePage, Format: "json"},
+			PageResponse{Mode: ModePage, Pageable: true})
+
+		Expect(header.Get("X-Total-Relation")).To(Equal("unknown"))
+		Expect(header).ToNot(HaveKey("X-Total-Count"))
+	})
+
+	It("reports a stated zero as a count rather than an absence", func() {
+		header := headersFor("report", PageRequest{Scope: ScopePage, Format: "json"},
+			PageResponse{Mode: ModePage, Pageable: true, Total: &Total{Value: 0, Exact: true}})
+
+		Expect(header.Get("X-Total-Count")).To(Equal("0"))
+		Expect(header.Get("X-Total-Relation")).To(Equal("eq"))
+	})
+
+	It("withholds a position that cannot be asked for when the rows are not pageable", func() {
+		header := headersFor("report", PageRequest{Scope: ScopePage, Format: "json", Offset: 100}, PageResponse{
+			Mode: ModePage, Pageable: false, HasMore: true, Next: "cursor-1",
+		})
+
+		Expect(header).ToNot(HaveKey("X-Page-Offset"))
+		Expect(header).ToNot(HaveKey("X-Next-Cursor"))
+		Expect(header.Get("X-Has-More")).To(Equal("false"))
+		Expect(header.Get("X-Page-Limit")).ToNot(BeEmpty())
+	})
+
+	It("reports the position and the next cursor when the rows are pageable", func() {
+		header := headersFor("report", PageRequest{Scope: ScopePage, Format: "json", Limit: 25, Offset: 100}, PageResponse{
+			Mode: ModePage, Pageable: true, HasMore: true, Next: "cursor-1",
+		})
+
+		Expect(header.Get("X-Page-Limit")).To(Equal("25"))
+		Expect(header.Get("X-Page-Offset")).To(Equal("100"))
+		Expect(header.Get("X-Has-More")).To(Equal("true"))
+		Expect(header.Get("X-Next-Cursor")).To(Equal("cursor-1"))
+	})
+
+	DescribeTable("declares the truncation trailer only when a ceiling might still bite",
+		func(req PageRequest, res PageResponse, expectTrailer bool) {
+			header := headersFor("report", req, res)
+			if expectTrailer {
+				Expect(header.Get("Trailer")).To(Equal("X-Truncated"))
+			} else {
+				Expect(header).ToNot(HaveKey("Trailer"))
+			}
+		},
+		Entry("a stream whose ceiling has not been reached yet",
+			PageRequest{Scope: ScopeAll, Format: "csv"},
+			PageResponse{Mode: ModeStreaming, Ceiling: 10000, MaxRows: 10000}, true),
+		Entry("a cut already known before the body needs no trailer",
+			PageRequest{Scope: ScopeAll, Format: "csv"},
+			PageResponse{Mode: ModeStreaming, Ceiling: 10000, MaxRows: 10000, Truncated: true}, false),
+		Entry("a buffered export has no ceiling left to hit",
+			PageRequest{Scope: ScopeAll, Format: "csv"},
+			PageResponse{Mode: ModeBuffered, MaxRows: 10000}, false),
+		Entry("a page is bounded by its own limit",
+			PageRequest{Scope: ScopePage, Format: "csv", Limit: 25},
+			PageResponse{Mode: ModePage, Pageable: true, Ceiling: 10000}, false),
+	)
+
+	It("reports a known cut as a header rather than a promise of one", func() {
+		header := headersFor("report", PageRequest{Scope: ScopeAll, Format: "csv"},
+			PageResponse{Mode: ModeStreaming, Ceiling: 10000, MaxRows: 10000, Truncated: true})
+
+		Expect(header.Get("X-Truncated")).To(Equal("true"))
+		Expect(header.Get("X-Max-Rows")).To(Equal("10000"))
+	})
+
+	DescribeTable("attaches a download name only when one was asked for",
+		func(req PageRequest, expected string) {
+			Expect(headersFor("invoices", req, PageResponse{Mode: ModePage}).Get("Content-Disposition")).To(Equal(expected))
+		},
+		Entry("no download and no filename", PageRequest{Scope: ScopePage, Format: "csv"}, ""),
+		Entry("_download derives the name from the operation",
+			PageRequest{Scope: ScopePage, Format: "csv", Download: true},
+			`attachment; filename="invoices.csv"; filename*=UTF-8''invoices.csv`),
+		Entry("an explicit filename wins",
+			PageRequest{Scope: ScopePage, Format: "csv", Filename: "q1.csv"},
+			`attachment; filename="q1.csv"; filename*=UTF-8''q1.csv`),
+	)
+})
+
+var _ = Describe("Content-Disposition encoding", func() {
+	It("carries a non-ASCII name as an RFC 8187 ext-value with an ASCII fallback", func() {
+		// 報告書 is E5A0B1 E5918A E69BB8 in UTF-8; the space is %20 and the dot is
+		// an attr-char, so only the three ideographs and the space are encoded.
+		Expect(ContentDisposition("報告書 2024.csv")).To(Equal(
+			`attachment; filename="___ 2024.csv"; filename*=UTF-8''%E5%A0%B1%E5%91%8A%E6%9B%B8%202024.csv`))
+	})
+
+	It("strips a path so the name can only ever be a filename", func() {
+		Expect(ContentDisposition(`../../etc/passwd`)).To(Equal(
+			`attachment; filename="passwd"; filename*=UTF-8''passwd`))
+	})
+
+	DescribeTable("neutralises what would close the header parameter",
+		func(filename, expected string) {
+			Expect(SanitizeExportFilename(filename)).To(Equal(expected))
+		},
+		Entry("a quote", `rep"ort.csv`, "rep_ort.csv"),
+		Entry("a semicolon", `rep;ort.csv`, "rep_ort.csv"),
+		Entry("a control character", "rep\x00ort.csv", "rep_ort.csv"),
+		Entry("a windows path", `C:\tmp\report.csv`, "report.csv"),
+		Entry("nothing usable left", " . ", "export.json"),
+	)
+
+	It("substitutes a usable name when the fallback would be all placeholders", func() {
+		Expect(ContentDisposition("報告書")).To(Equal(
+			`attachment; filename="export.json"; filename*=UTF-8''%E5%A0%B1%E5%91%8A%E6%9B%B8`))
+	})
+})
+
+var _ = Describe("Accept negotiation", func() {
+	DescribeTable("picks the highest-weighted representation the caller will take",
+		func(accept, expected string) {
+			format, err := AcceptedFormat(accept)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(format).To(Equal(expected))
+		},
+		Entry("no preference falls back to the default", "", DefaultExportFormat),
+		Entry("an unrecognised type falls back to the default", "text/plain", DefaultExportFormat),
+		Entry("a wildcard accepts anything, so the default is acceptable", "*/*", DefaultExportFormat),
+		Entry("a named range overrides a wildcard refusal", "*/*;q=0, text/csv", "csv"),
+		Entry("a browser's ranked wildcard does not outrank a type it named",
+			"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "html"),
+		Entry("weight beats position", "text/html;q=0.1, application/clicky+json;q=0.9", "clicky-json"),
+		Entry("a tie keeps the order the caller wrote", "text/csv, text/markdown", "csv"),
+		Entry("an unweighted entry is q=1", "text/csv;q=0.9, text/markdown", "markdown"),
+		Entry("a refusal of one format still allows another", "application/json;q=0, text/csv", "csv"),
+		Entry("refusing a format the default is not still yields the default", "text/csv;q=0", DefaultExportFormat),
+	)
+
+	DescribeTable("treats q=0 as a refusal rather than a low preference",
+		func(accept string) {
+			format, err := AcceptedFormat(accept)
+
+			Expect(format).To(BeEmpty())
+			statusErr, ok := err.(*StatusError)
+			Expect(ok).To(BeTrue(), "expected a StatusError, got %T", err)
+			Expect(statusErr.Status).To(Equal(http.StatusNotAcceptable))
+			Expect(statusErr.Code).To(Equal("not_acceptable"))
+		},
+		Entry("the default refused outright", "application/json;q=0"),
+		Entry("the default refused with nothing recognised alongside it", "application/json;q=0, text/plain"),
+		Entry("the default refused while another format is also refused", "application/json;q=0, text/csv;q=0"),
+		Entry("a wildcard refusal leaves nothing acceptable at all", "*/*;q=0"),
+		Entry("a wildcard refusal alongside an unrecognised type", "*/*;q=0, text/plain"),
+	)
+})
+
+var _ = Describe("Export format mapping", func() {
+	DescribeTable("maps a format to the content type and extension a client expects",
+		func(format, contentType, extension string, tabular bool) {
+			Expect(ExportContentType(format)).To(Equal(contentType))
+			Expect(ExportExtension(format)).To(Equal(extension))
+			Expect(IsTabularExport(format)).To(Equal(tabular))
+		},
+		Entry("json", "json", "application/json", ".json", false),
+		Entry("ndjson", "ndjson", "application/x-ndjson", ".ndjson", false),
+		Entry("yaml", "yaml", "application/yaml", ".yaml", false),
+		Entry("csv", "csv", "text/csv; charset=utf-8", ".csv", true),
+		Entry("markdown", "markdown", "text/markdown; charset=utf-8", ".md", true),
+		Entry("excel", "excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx", true),
+		Entry("pdf", "pdf", "application/pdf", ".pdf", true),
+		Entry("an unknown format", "brotli", "application/octet-stream", ".brotli", false),
+	)
+})
+
+var _ = Describe("ParsePageRequest", func() {
+	parse := func(rawQuery, accept string, limits PageLimits) (PageRequest, error) {
+		r := &http.Request{URL: &url.URL{RawQuery: rawQuery}, Header: http.Header{}}
+		if accept != "" {
+			r.Header.Set("Accept", accept)
+		}
+		return ParsePageRequest(r, limits)
+	}
+
+	It("defaults to the first page in the default format", func() {
+		req, err := parse("", "", PageLimits{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(req).To(Equal(PageRequest{
+			Scope: ScopePage, Format: DefaultExportFormat, Limit: DefaultPageSize,
+		}))
+	})
+
+	It("resolves the format from Accept when none was named", func() {
+		req, err := parse("", "text/csv", PageLimits{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(req.Format).To(Equal("csv"))
+	})
+
+	It("prefers an explicit format over Accept and canonicalises its alias", func() {
+		req, err := parse("format=xlsx", "text/csv", PageLimits{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(req.Format).To(Equal("excel"))
+	})
+
+	It("waives the total and the position for an all-rows export", func() {
+		req, err := parse("scope=all&offset=100&cursor=abc", "", PageLimits{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(req.Scope).To(Equal(ScopeAll))
+		Expect(req.Offset).To(BeZero())
+		Expect(req.Cursor).To(BeEmpty())
+		Expect(req.SkipTotal).To(BeTrue())
+	})
+
+	It("reads the download intent from either _download or filename", func() {
+		req, err := parse("_download&filename=q1.csv", "", PageLimits{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(req.Download).To(BeTrue())
+		Expect(req.Filename).To(Equal("q1.csv"))
+	})
+
+	DescribeTable("refuses a request it cannot serve",
+		func(rawQuery, accept, code string, status int) {
+			_, err := parse(rawQuery, accept, PageLimits{MaxPageSize: 500})
+
+			Expect(err).To(HaveOccurred())
+			statusErr, ok := err.(*StatusError)
+			Expect(ok).To(BeTrue(), "expected a StatusError, got %T", err)
+			Expect(statusErr.Code).To(Equal(code))
+			Expect(statusErr.Status).To(Equal(status))
+		},
+		Entry("an unknown scope", "scope=everything", "", "invalid_scope", http.StatusBadRequest),
+		Entry("an unsupported format", "format=brotli", "", "unsupported_format", http.StatusBadRequest),
+		Entry("a refused representation", "", "application/json;q=0", "not_acceptable", http.StatusNotAcceptable),
+		Entry("a limit past the maximum", "limit=501", "", "invalid_limit", http.StatusBadRequest),
+		Entry("a limit that is not a number", "limit=many", "", "invalid_limit", http.StatusBadRequest),
+		Entry("a negative offset", "offset=-1", "", "invalid_offset", http.StatusBadRequest),
+		Entry("a cursor combined with an offset", "cursor=abc&offset=10", "", "invalid_cursor", http.StatusBadRequest),
+	)
+})

--- a/entity/paging_trailer_test.go
+++ b/entity/paging_trailer_test.go
@@ -1,0 +1,53 @@
+package entity
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// SetExportHeaders declares the trailer and the transport sends it, so the two
+// have to read the same condition. A declared trailer that never arrives leaves
+// a client waiting on it; an undeclared one is dropped on the floor. The whole
+// matrix is walked because the disagreement would only ever show up in one
+// corner of it.
+func TestDeclaresTruncatedTrailer_AgreesWithSetExportHeaders(t *testing.T) {
+	for _, scope := range []string{ScopePage, ScopeAll} {
+		// More than one live ceiling: a second condition smuggled back into
+		// SetExportHeaders is most likely to be a threshold, which a single
+		// non-zero value would sit on one side of and never notice.
+		for _, ceiling := range []int{0, 1, 500} {
+			for _, truncated := range []bool{false, true} {
+				name := fmt.Sprintf("scope=%s/ceiling=%d/truncated=%t", scope, ceiling, truncated)
+				t.Run(name, func(t *testing.T) {
+					req := PageRequest{Scope: scope, Format: "csv", Limit: 100}
+					res := PageResponse{Mode: ModeStreaming, Ceiling: ceiling, Truncated: truncated}
+
+					recorder := httptest.NewRecorder()
+					SetExportHeaders(recorder, "rows", req, res)
+
+					assert.Equal(t, DeclaresTruncatedTrailer(req, res),
+						recorder.Header().Get("Trailer") == "X-Truncated",
+						"the predicate and the header it gates must not disagree")
+				})
+			}
+		}
+	}
+}
+
+// The one case the trailer exists for, stated on its own so the matrix above
+// cannot pass by agreeing on "never".
+func TestDeclaresTruncatedTrailer_OnlyForACeilingThatMightStillBite(t *testing.T) {
+	live := PageResponse{Ceiling: 500}
+	all := PageRequest{Scope: ScopeAll}
+
+	assert.True(t, DeclaresTruncatedTrailer(all, live))
+	assert.False(t, DeclaresTruncatedTrailer(PageRequest{Scope: ScopePage}, live),
+		"a page has no ceiling to discover")
+	assert.False(t, DeclaresTruncatedTrailer(all, PageResponse{}),
+		"an export with no ceiling has nothing left to find out")
+	assert.False(t, DeclaresTruncatedTrailer(all, PageResponse{Ceiling: 500, Truncated: true}),
+		"a cut already known has its answer in the headers")
+}

--- a/entity/path.go
+++ b/entity/path.go
@@ -1,0 +1,43 @@
+package entity
+
+import "strings"
+
+// PathSeparator is the wire delimiter for ClickySurface.Path. Producers split
+// their own naming convention (dots, slashes, colons — whatever the domain
+// uses) with SplitPath and emit the result joined by this, so a frontend never
+// has to know, or guess, the producer's convention.
+const PathSeparator = "/"
+
+// SplitPath breaks name into hierarchy segments on any rune in delimiters,
+// dropping empty segments so repeated or leading separators are harmless.
+// Runes outside delimiters are never separators — SplitPath("a-b.c", ".")
+// yields ["a-b", "c"], not three segments.
+//
+// A name with no delimiter yields a single segment, i.e. a root-level leaf.
+func SplitPath(name, delimiters string) []string {
+	if name == "" || delimiters == "" {
+		if name == "" {
+			return nil
+		}
+		return []string{name}
+	}
+	fields := strings.FieldsFunc(name, func(r rune) bool {
+		return strings.ContainsRune(delimiters, r)
+	})
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+// JoinPath renders segments as a ClickySurface.Path. Empty segments are
+// dropped so the output always round-trips through SplitPath(_, PathSeparator).
+func JoinPath(segments []string) string {
+	kept := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if segment != "" {
+			kept = append(kept, segment)
+		}
+	}
+	return strings.Join(kept, PathSeparator)
+}

--- a/entity/path.go
+++ b/entity/path.go
@@ -13,16 +13,18 @@ const PathSeparator = "/"
 // Runes outside delimiters are never separators — SplitPath("a-b.c", ".")
 // yields ["a-b", "c"], not three segments.
 //
+// PathSeparator is always a separator, whatever delimiters says (including when
+// it is empty): a segment containing it would be re-split by any consumer of the
+// JoinPath output, so SplitPath("jms/api.incoming", ".") yields
+// ["jms", "api", "incoming"] and the round-trip through JoinPath is stable.
+//
 // A name with no delimiter yields a single segment, i.e. a root-level leaf.
 func SplitPath(name, delimiters string) []string {
-	if name == "" || delimiters == "" {
-		if name == "" {
-			return nil
-		}
-		return []string{name}
+	if name == "" {
+		return nil
 	}
 	fields := strings.FieldsFunc(name, func(r rune) bool {
-		return strings.ContainsRune(delimiters, r)
+		return strings.ContainsRune(PathSeparator, r) || strings.ContainsRune(delimiters, r)
 	})
 	if len(fields) == 0 {
 		return nil

--- a/entity/path_test.go
+++ b/entity/path_test.go
@@ -27,6 +27,11 @@ func TestSplitPath(t *testing.T) {
 		{"empty name has no path", "", dotSlash, nil},
 		{"separator-only name has no path", "...", dotSlash, nil},
 		{"no delimiters declared means no split", "jms.incoming", "", []string{"jms.incoming"}},
+		// PathSeparator is the wire delimiter, so a producer that never declares it
+		// still cannot smuggle it inside a segment — JoinPath would emit a path the
+		// consumer splits differently.
+		{"path separator splits even when not declared", "jms/api.incoming", ".", []string{"jms", "api", "incoming"}},
+		{"path separator splits with no delimiters declared", "jms/api", "", []string{"jms", "api"}},
 	}
 
 	for _, test := range tests {
@@ -44,6 +49,19 @@ func TestJoinPath(t *testing.T) {
 }
 
 func TestSplitPathRoundTripsThroughJoinPath(t *testing.T) {
-	segments := SplitPath("jms.incoming.disbursements", "./")
-	assert.Equal(t, segments, SplitPath(JoinPath(segments), PathSeparator))
+	for _, input := range []struct {
+		name       string
+		delimiters string
+	}{
+		{"jms.incoming.disbursements", "./"},
+		// A name carrying PathSeparator under a different producer delimiter must
+		// not gain hierarchy levels on the way through JoinPath.
+		{"jms/api.incoming", "."},
+		{"jms/api", ""},
+	} {
+		t.Run(input.name, func(t *testing.T) {
+			segments := SplitPath(input.name, input.delimiters)
+			assert.Equal(t, segments, SplitPath(JoinPath(segments), PathSeparator))
+		})
+	}
 }

--- a/entity/path_test.go
+++ b/entity/path_test.go
@@ -1,0 +1,49 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitPath(t *testing.T) {
+	const dotSlash = "./"
+
+	tests := []struct {
+		name       string
+		input      string
+		delimiters string
+		want       []string
+	}{
+		{"flat name is a root leaf", "jaeger", dotSlash, []string{"jaeger"}},
+		{"dots nest", "jms.incoming.disbursements", dotSlash, []string{"jms", "incoming", "disbursements"}},
+		{"slashes nest", "logs/api", dotSlash, []string{"logs", "api"}},
+		{"mixed delimiters", "a.b/c", dotSlash, []string{"a", "b", "c"}},
+		// A hyphen is a legitimate name character, not a separator: splitting it
+		// would shatter "remote-debugger" into a bogus two-level hierarchy.
+		{"hyphen is not a separator", "remote-debugger.sql-xevent", dotSlash, []string{"remote-debugger", "sql-xevent"}},
+		{"repeated separators collapse", "a//b", dotSlash, []string{"a", "b"}},
+		{"leading and trailing separators drop", ".a.b.", dotSlash, []string{"a", "b"}},
+		{"empty name has no path", "", dotSlash, nil},
+		{"separator-only name has no path", "...", dotSlash, nil},
+		{"no delimiters declared means no split", "jms.incoming", "", []string{"jms.incoming"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, SplitPath(test.input, test.delimiters))
+		})
+	}
+}
+
+func TestJoinPath(t *testing.T) {
+	assert.Equal(t, "jms/incoming/disbursements", JoinPath([]string{"jms", "incoming", "disbursements"}))
+	assert.Equal(t, "jms", JoinPath([]string{"jms"}))
+	assert.Equal(t, "", JoinPath(nil))
+	assert.Equal(t, "a/b", JoinPath([]string{"a", "", "b"}), "empty segments are dropped")
+}
+
+func TestSplitPathRoundTripsThroughJoinPath(t *testing.T) {
+	segments := SplitPath("jms.incoming.disbursements", "./")
+	assert.Equal(t, segments, SplitPath(JoinPath(segments), PathSeparator))
+}

--- a/entity/primary_action.go
+++ b/entity/primary_action.go
@@ -1,0 +1,57 @@
+package entity
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// PrimaryActionWithContext creates the typed collection action that runs when
+// the bare entity command is invoked. Its POST route shares the entity's
+// collection path with the list operation's GET route.
+func PrimaryActionWithContext[Opts ActionFlags, R any](opts Opts, fn func(context.Context, Opts) (R, error)) *ActionSpec[R] {
+	return ActionWithFlagsAndContext("run", opts, func(ctx context.Context, _ string, flagMap map[string]string) (R, error) {
+		resolved, err := buildOpts[Opts](flagMap)
+		if err != nil {
+			var zero R
+			return zero, err
+		}
+		return fn(ctx, resolved)
+	}).WithOptionalID().WithMethod("POST")
+}
+
+func generatePrimaryAction(entityCmd *cobra.Command, action ActionInfo) {
+	op := EntityOperation{
+		Verb:            "action",
+		Method:          action.Method,
+		DataFunc:        action.DataFunc,
+		ContextDataFunc: action.ContextDataFunc,
+		FlagsType:       action.FlagsType,
+		ResponseType:    action.ResponseType,
+	}
+	entityCmd.Args = cobra.NoArgs
+	entityCmd.RunE = func(c *cobra.Command, args []string) error {
+		flagMap := make(map[string]string)
+		c.Flags().Visit(func(f *pflag.Flag) {
+			flagMap[f.Name] = flagMapValue(f)
+		})
+		result, err := runEntityOp(c, op, flagMap, args)
+		if err != nil {
+			return err
+		}
+		if result != nil {
+			return RenderResult(result)
+		}
+		return nil
+	}
+	if action.Short != "" {
+		entityCmd.Short = action.Short
+	}
+	if action.FlagsType != nil {
+		bindTypeFlags(entityCmd, action.FlagsType)
+	}
+	annotateEntityOperationCommand(entityCmd, entityCmd, "action", action.Method, "collection", action.Name, "", false, false, true, action.ToolHints)
+	storeEntityDataFuncs(entityCmd, op)
+	SetCommandResponseMeta(entityCmd, ResponseOpenAPIMeta{Type: action.ResponseType})
+}

--- a/entity/primary_action_test.go
+++ b/entity/primary_action_test.go
@@ -1,0 +1,57 @@
+package entity
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+type primaryActionItem struct {
+	ID string
+}
+
+func (i primaryActionItem) GetID() string   { return i.ID }
+func (i primaryActionItem) GetName() string { return i.ID }
+
+type primaryActionOptions struct {
+	Profile string   `flag:"profile" default:"safe"`
+	Hosts   []string `flag:"host"`
+}
+
+func (primaryActionOptions) ClickyActionFlags() {}
+
+var _ = Describe("Entity primary actions", func() {
+	It("runs the typed action at the entity root and retains list as a child", func() {
+		name := "primary-action-cli-spec"
+		var received primaryActionOptions
+		NewEntity[primaryActionItem, struct{}, primaryActionItem](name).
+			List(func(struct{}) ([]primaryActionItem, error) {
+				return []primaryActionItem{{ID: "history"}}, nil
+			}).
+			WithPrimaryAction(PrimaryActionWithContext(primaryActionOptions{}, func(_ context.Context, opts primaryActionOptions) (primaryActionItem, error) {
+				received = opts
+				return primaryActionItem{ID: "started"}, nil
+			}).WithShort("Start a run")).
+			Register()
+
+		root := &cobra.Command{Use: "test"}
+		GenerateCLI(root)
+		root.SetArgs([]string{name, "--profile", "full", "--host", "one.example.test", "--host", "two.example.test"})
+
+		Expect(root.Execute()).To(Succeed())
+		Expect(received).To(Equal(primaryActionOptions{
+			Profile: "full",
+			Hosts:   []string{"one.example.test", "two.example.test"},
+		}))
+
+		command, _, err := root.Find([]string{name})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(command.Short).To(Equal("Start a run"))
+		Expect(command.CommandPath()).To(Equal("test " + name))
+		Expect(command.Commands()).To(ContainElement(WithTransform(func(cmd *cobra.Command) string {
+			return cmd.Name()
+		}, Equal("list"))))
+	})
+})

--- a/entity/schema.go
+++ b/entity/schema.go
@@ -18,6 +18,7 @@ type jsonSchema struct {
 	Aliases    []string                   `json:"x-clicky-aliases"`
 	Parent     string                     `json:"x-clicky-parent"`
 	Icon       string                     `json:"x-clicky-icon"`
+	Path       string                     `json:"x-clicky-path"`
 	Title      string                     `json:"x-clicky-title"`
 }
 
@@ -57,6 +58,7 @@ type parsedSchema struct {
 	Aliases []string
 	Parent  string
 	Icon    string
+	Path    string
 	Title   string
 	IDKey   string
 	NameKey string
@@ -81,7 +83,7 @@ func parseSchema(raw []byte) (*parsedSchema, error) {
 	}
 	sort.Strings(names)
 
-	ps := &parsedSchema{Aliases: doc.Aliases, Parent: doc.Parent, Icon: doc.Icon, Title: doc.Title}
+	ps := &parsedSchema{Aliases: doc.Aliases, Parent: doc.Parent, Icon: doc.Icon, Path: doc.Path, Title: doc.Title}
 	seen := map[string]int{}
 	for _, name := range names {
 		p := doc.Properties[name]

--- a/entity_aliases.go
+++ b/entity_aliases.go
@@ -81,6 +81,8 @@ var (
 	GetCommandResponseMeta = entity.GetCommandResponseMeta
 	SetCommandResponseMeta = entity.SetCommandResponseMeta
 	AnnotateTool           = entity.AnnotateTool
+	MarkLocalOnly          = entity.MarkLocalOnly
+	IsLocalOnly            = entity.IsLocalOnly
 )
 
 const (

--- a/examples/enitity/go.mod
+++ b/examples/enitity/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/flanksource/captain v0.0.20
-	github.com/flanksource/clicky v1.21.53
+	github.com/flanksource/clicky v1.21.54
 	github.com/flanksource/clicky/aichat v1.21.49
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -26,21 +26,23 @@ var log = logger.GetLogger("exec")
 // NewExecf creates a new Process with formatted command string
 func NewExecf(cmd string, args ...any) *Process {
 	return &Process{
-		Cmd:  fmt.Sprintf(cmd, args...),
-		log:  log,
-		Env:  map[string]string{},
-		done: make(chan struct{}),
+		Cmd:           fmt.Sprintf(cmd, args...),
+		log:           log,
+		captureOutput: NewExecLogger(),
+		Env:           map[string]string{},
+		done:          make(chan struct{}),
 	}
 }
 
 // NewExec creates a new Process with the specified command and arguments
 func NewExec(cmd string, args ...string) *Process {
 	return &Process{
-		Cmd:  cmd,
-		log:  log,
-		Args: args,
-		Env:  map[string]string{},
-		done: make(chan struct{}),
+		Cmd:           cmd,
+		log:           log,
+		Args:          args,
+		captureOutput: NewExecLogger(),
+		Env:           map[string]string{},
+		done:          make(chan struct{}),
 	}
 }
 

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -269,6 +269,26 @@ echo line3`
 	})
 
 	Describe("Concurrent Execution", func() {
+		It("should allow result snapshots while a process starts", func() {
+			process := NewExec("/bin/sh", "-c", "printf captured")
+			Expect(process.captureOutput).ToNot(BeNil())
+			done := make(chan struct{})
+			go func() {
+				process.Run()
+				close(done)
+			}()
+
+			for {
+				select {
+				case <-done:
+					Expect(process.Result().Stdout).To(Equal("captured"))
+					return
+				default:
+					_ = process.Result()
+				}
+			}
+		})
+
 		It("should handle multiple processes running concurrently", func() {
 			processes := make([]*Process, 3)
 			results := make(chan string, 3)

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -278,11 +278,16 @@ echo line3`
 				close(done)
 			}()
 
+			// Bounded: a Result() that deadlocks against the running process must
+			// fail this spec rather than spin a core until the suite times out.
+			deadline := time.After(30 * time.Second)
 			for {
 				select {
 				case <-done:
 					Expect(process.Result().Stdout).To(Equal("captured"))
 					return
+				case <-deadline:
+					Fail("process did not finish while Result() was being snapshotted")
 				default:
 					_ = process.Result()
 				}

--- a/format.go
+++ b/format.go
@@ -82,6 +82,11 @@ func MustPrint(o any, opts ...FormatOptions) {
 		panic(err)
 	}
 
+	// Terminate the output. Without this the shell prompt lands on the last
+	// rendered line, and line-oriented consumers of a redirect drop it.
+	if result != "" && !strings.HasSuffix(result, "\n") {
+		result += "\n"
+	}
 	fmt.Print(result)
 }
 

--- a/formatters/excel.go
+++ b/formatters/excel.go
@@ -20,9 +20,22 @@ func NewExcelFormatter() *ExcelFormatter {
 	}
 }
 
-// Format is not supported for Excel as it needs to write to files
+// Format renders data as the bytes of an xlsx workbook.
+//
+// The string is binary, not text — callers write it verbatim (FormatToFile does,
+// and a --format excel sink is a file). It is a string because that is the
+// FormatterFunc contract every other format shares.
 func (f *ExcelFormatter) Format(data interface{}) (string, error) {
-	return "", fmt.Errorf("Excel formatter requires file output - use FormatToFile instead")
+	// Unwrap single-element varargs slices, as the other formatters do.
+	if slice, ok := data.([]interface{}); ok && len(slice) == 1 {
+		data = slice[0]
+	}
+
+	prettyData, err := ToPrettyData(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert data to PrettyData: %w", err)
+	}
+	return f.FormatPrettyData(prettyData)
 }
 
 // FormatToFile creates an Excel file and saves it to the specified path
@@ -41,9 +54,24 @@ func (f *ExcelFormatter) FormatToFile(data interface{}, filename string) error {
 	return f.FormatPrettyDataToFile(prettyData, filename, file)
 }
 
-// FormatPrettyDataToFile formats PrettyData to Excel file
+// FormatPrettyDataToFile formats PrettyData into file and saves it to filename.
 func (f *ExcelFormatter) FormatPrettyDataToFile(data *api.PrettyData, filename string, file *excelize.File) error {
-	if data == nil || data.Schema == nil {
+	if err := f.writeSheet(data, file); err != nil {
+		return err
+	}
+	if err := file.SaveAs(filename); err != nil {
+		return fmt.Errorf("failed to save Excel file: %w", err)
+	}
+	return nil
+}
+
+// writeSheet lays the PrettyData's first table out on a worksheet.
+//
+// The guard admits a nil Schema: every table-shaped PrettyData has one, because
+// api.TryTypedValue populates TypedValue.Table and leaves Schema alone. Rejecting
+// it turned away exactly the data this formatter exists to write.
+func (f *ExcelFormatter) writeSheet(data *api.PrettyData, file *excelize.File) error {
+	if data == nil || (data.Schema == nil && data.FirstTable() == nil) {
 		return fmt.Errorf("no data to format")
 	}
 
@@ -94,14 +122,14 @@ func (f *ExcelFormatter) FormatPrettyDataToFile(data *api.PrettyData, filename s
 	}
 	currentRow++
 
-	// Write data rows using Text.String() for formatted text
+	// Write data rows using Text.String() for formatted text. AsString resolves
+	// each header through FieldNames — rows are keyed by column name, so looking
+	// them up by header label silently blanked every column carrying a label.
 	for _, row := range table.Rows {
-		for i, fieldName := range headers {
+		for i, cell := range table.AsString(row) {
 			cellRef := f.getCellReference(i+1, currentRow)
-			if fieldValue, exists := row[fieldName]; exists {
-				if err := file.SetCellValue(sheetName, cellRef, fieldValue.String()); err != nil {
-					return fmt.Errorf("failed to set cell value: %w", err)
-				}
+			if err := file.SetCellValue(sheetName, cellRef, cell); err != nil {
+				return fmt.Errorf("failed to set cell value: %w", err)
 			}
 		}
 		currentRow++
@@ -116,11 +144,6 @@ func (f *ExcelFormatter) FormatPrettyDataToFile(data *api.PrettyData, filename s
 		}
 	}
 
-	// Save the file
-	if err := file.SaveAs(filename); err != nil {
-		return fmt.Errorf("failed to save Excel file: %w", err)
-	}
-
 	return nil
 }
 
@@ -131,7 +154,7 @@ func (f *ExcelFormatter) FormatPrettyData(data *api.PrettyData) (string, error) 
 		_ = file.Close() // ignore error on close
 	}()
 
-	if err := f.FormatPrettyDataToFile(data, "", file); err != nil {
+	if err := f.writeSheet(data, file); err != nil {
 		return "", err
 	}
 

--- a/formatters/excel_test.go
+++ b/formatters/excel_test.go
@@ -1,0 +1,75 @@
+package formatters
+
+import (
+	"bytes"
+
+	"github.com/flanksource/clicky/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/xuri/excelize/v2"
+)
+
+type excelTableRow struct {
+	ID   int
+	Name string
+}
+
+func (r excelTableRow) Columns() []api.ColumnDef {
+	return []api.ColumnDef{
+		{Name: "id", Label: "ID", Type: "number"},
+		{Name: "name", Label: "Name"},
+	}
+}
+
+func (r excelTableRow) Row() map[string]any {
+	return map[string]any{"id": r.ID, "name": r.Name}
+}
+
+var _ = Describe("Excel formatter", func() {
+	rows := []excelTableRow{{ID: 1, Name: "alpha"}, {ID: 2, Name: "beta"}}
+
+	openBook := func(output string) *excelize.File {
+		Expect(output).To(HavePrefix("PK\x03\x04"), "expected xlsx bytes")
+		book, err := excelize.OpenReader(bytes.NewReader([]byte(output)))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(book.Close)
+		return book
+	}
+
+	// --format excel used to reach ExcelFormatter.Format, which refused outright —
+	// so a format the UI offers could not be produced at all off the manager path.
+	It("renders table providers to xlsx bytes", func() {
+		output, err := NewFormatManager().FormatWithOptions(FormatOptions{Format: "excel"}, rows)
+		Expect(err).NotTo(HaveOccurred())
+
+		book := openBook(output)
+		Expect(book.GetCellValue("Sheet1", "A1")).To(Equal("ID"))
+		Expect(book.GetCellValue("Sheet1", "B1")).To(Equal("Name"))
+		Expect(book.GetCellValue("Sheet1", "A2")).To(Equal("1"))
+		Expect(book.GetCellValue("Sheet1", "B3")).To(Equal("beta"))
+	})
+
+	It("accepts the xlsx alias", func() {
+		output, err := NewFormatManager().FormatWithOptions(FormatOptions{Format: "xlsx"}, rows)
+		Expect(err).NotTo(HaveOccurred())
+		openBook(output)
+	})
+
+	// Every table-shaped PrettyData has a nil Schema (TryTypedValue sets only
+	// TypedValue.Table), which is exactly what the old guard rejected.
+	It("formats a PrettyData that carries a table but no schema", func() {
+		data, err := ToPrettyData(rows)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data.Schema).To(BeNil())
+		Expect(data.FirstTable()).NotTo(BeNil())
+
+		output, err := NewExcelFormatter().FormatPrettyData(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(openBook(output).GetCellValue("Sheet1", "A1")).To(Equal("ID"))
+	})
+
+	It("still refuses data with no table in it", func() {
+		_, err := NewExcelFormatter().FormatPrettyData(nil)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/formatters/html_react_formatter.go
+++ b/formatters/html_react_formatter.go
@@ -420,7 +420,6 @@ func convertLinkCommand(link api.LinkCommand) ClickyNode {
 func convertList(list api.List) ClickyNode {
 	node := ClickyNode{
 		Kind:     "list",
-		Plain:    list.String(),
 		Ordered:  list.Numbered || list.Ordered,
 		Unstyled: list.Unstyled,
 		Inline:   list.MaxInline > 0 && len(list.Items) <= list.MaxInline,
@@ -439,7 +438,7 @@ func convertList(list api.List) ClickyNode {
 }
 
 func convertTextList(list api.TextList) ClickyNode {
-	node := ClickyNode{Kind: "list", Plain: list.String()}
+	node := ClickyNode{Kind: "list"}
 	for _, item := range list {
 		node.Items = append(node.Items, convertTextable(item))
 	}
@@ -459,7 +458,7 @@ func convertTextMap(tm api.TextMap, schema *api.PrettyObject) ClickyNode {
 			Value: convertTextable(value),
 		})
 	}
-	return ClickyNode{Kind: "map", Plain: tm.String(), Fields: fields}
+	return ClickyNode{Kind: "map", Fields: fields}
 }
 
 func convertTypedMap(tm *api.TypedMap, schema *api.PrettyObject) ClickyNode {
@@ -479,7 +478,7 @@ func convertTypedMap(tm *api.TypedMap, schema *api.PrettyObject) ClickyNode {
 			Value: convertTypedValue(&value, nil),
 		})
 	}
-	return ClickyNode{Kind: "map", Plain: tm.String(), Fields: fields}
+	return ClickyNode{Kind: "map", Fields: fields}
 }
 
 func convertTypedList(tl *api.TypedList) ClickyNode {
@@ -487,7 +486,7 @@ func convertTypedList(tl *api.TypedList) ClickyNode {
 		return ClickyNode{Kind: "list"}
 	}
 
-	node := ClickyNode{Kind: "list", Plain: tl.String()}
+	node := ClickyNode{Kind: "list"}
 	for _, item := range *tl {
 		node.Items = append(node.Items, convertTypedValue(&item, nil))
 	}
@@ -499,7 +498,7 @@ func convertTable(table *api.TextTable) ClickyNode {
 		return ClickyNode{Kind: "table"}
 	}
 
-	node := ClickyNode{Kind: "table", Plain: table.String()}
+	node := ClickyNode{Kind: "table"}
 
 	if len(table.Headers) > 0 {
 		for i, header := range table.Headers {
@@ -525,8 +524,15 @@ func convertTable(table *api.TextTable) ClickyNode {
 				column.Label = header.String()
 			}
 
-			headerNode := convertTextable(header)
-			column.Header = &headerNode
+			// A header node that says exactly what Label already says is three
+			// copies of one string per column. It is kept only when it carries
+			// something Label cannot — styling, a tooltip, nested content.
+			headerNode := compactNode(convertTextable(header))
+			if headerNode.Kind != "text" || headerNode.Plain != "" ||
+				headerNode.Text != column.Label || headerNode.Style != nil ||
+				headerNode.Tooltip != nil || len(headerNode.Children) > 0 {
+				column.Header = &headerNode
+			}
 			node.Columns = append(node.Columns, column)
 		}
 	} else {
@@ -554,13 +560,13 @@ func convertTable(table *api.TextTable) ClickyNode {
 			if cell, ok := row[column.Name]; ok {
 				cellNode := convertTypedValue(&cell, nil)
 				cellNode.FilterValue = cell.FilterValue
-				rowNode.Cells[column.Name] = cellNode
+				rowNode.Cells[column.Name] = compactNode(cellNode)
 				continue
 			}
 			if cell, ok := row[column.Label]; ok {
 				cellNode := convertTypedValue(&cell, nil)
 				cellNode.FilterValue = cell.FilterValue
-				rowNode.Cells[column.Name] = cellNode
+				rowNode.Cells[column.Name] = compactNode(cellNode)
 				continue
 			}
 			rowNode.Cells[column.Name] = clickyTextNode("")
@@ -569,7 +575,7 @@ func convertTable(table *api.TextTable) ClickyNode {
 			if _, exists := rowNode.Cells[cellName]; exists {
 				continue
 			}
-			rowNode.Cells[cellName] = convertTypedValue(&cell, nil)
+			rowNode.Cells[cellName] = compactNode(convertTypedValue(&cell, nil))
 		}
 
 		if rowIndex < len(table.RowDetail) && table.RowDetail[rowIndex] != nil {
@@ -588,7 +594,7 @@ func convertTree(tree *api.TextTree) ClickyNode {
 		return ClickyNode{Kind: "tree"}
 	}
 
-	node := ClickyNode{Kind: "tree", Plain: tree.String()}
+	node := ClickyNode{Kind: "tree"}
 	if tree.Node == nil {
 		for index, child := range tree.Children {
 			node.Roots = append(node.Roots, convertTreeItem(&child, fmt.Sprintf("root-%d", index)))
@@ -695,7 +701,7 @@ func convertFootnote(footnote api.Footnote) ClickyNode {
 }
 
 func convertFootnotes(footnotes api.Footnotes) ClickyNode {
-	node := ClickyNode{Kind: "footnotes", Plain: footnotes.String()}
+	node := ClickyNode{Kind: "footnotes"}
 	for _, footnote := range footnotes.Items {
 		if strings.TrimSpace(footnote.ID) == "" {
 			continue
@@ -797,7 +803,7 @@ func convertButton(button api.Button) ClickyNode {
 }
 
 func convertButtonGroup(group api.ButtonGroup) ClickyNode {
-	node := ClickyNode{Kind: "button-group", Plain: group.String()}
+	node := ClickyNode{Kind: "button-group"}
 	for _, button := range group.Buttons {
 		node.Items = append(node.Items, convertButton(button))
 	}
@@ -845,7 +851,7 @@ func convertLabelBadge(b api.LabelBadge) ClickyNode {
 }
 
 func convertDescriptionList(list api.DescriptionList) ClickyNode {
-	node := ClickyNode{Kind: "map", Plain: list.String()}
+	node := ClickyNode{Kind: "map"}
 	for _, item := range list.Items {
 		if item.IsEmpty() {
 			continue
@@ -867,7 +873,76 @@ func convertAnyToNode(value any) ClickyNode {
 }
 
 func clickyTextNode(text string) ClickyNode {
-	return ClickyNode{Kind: "text", Plain: text, Text: text}
+	return ClickyNode{Kind: "text", Text: text}
+}
+
+// PlainText flattens a node to the string a reader sorts, filters and searches
+// on, following the same fallback order the clicky-ui renderer uses.
+//
+// It exists because Plain is now omitted wherever it would only repeat what is
+// already derivable: which field carries the string is an encoding detail, and
+// a consumer that reads one field directly breaks the moment the encoding gets
+// cheaper.
+func (n ClickyNode) PlainText() string {
+	if n.Plain != "" {
+		return n.Plain
+	}
+	if n.Text != "" {
+		return n.Text
+	}
+	if n.Source != "" {
+		return n.Source
+	}
+	parts := make([]string, 0, len(n.Children)+len(n.Items)+len(n.Fields))
+	for _, child := range n.Children {
+		parts = append(parts, child.PlainText())
+	}
+	for _, item := range n.Items {
+		parts = append(parts, item.PlainText())
+	}
+	for _, field := range n.Fields {
+		parts = append(parts, field.Value.PlainText())
+	}
+	joined := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			joined = append(joined, part)
+		}
+	}
+	return strings.Join(joined, " ")
+}
+
+// compactNode drops the copies of a node's text that a reader can derive.
+//
+// Plain, Text and FilterValue are three projections of the same string and are
+// usually byte-identical: for a leaf, Plain is what String() rendered and Text
+// is the content it rendered from. Sending all three triples the cost of every
+// cell in a table for no added meaning.
+//
+// Only exact duplicates are dropped. Plain survives wherever it says something
+// Text does not — a styled or composite node whose rendering differs from its
+// raw content — because it is the sort and filter key, and deriving the wrong
+// one silently reorders a table.
+func compactNode(node ClickyNode) ClickyNode {
+	// A lone text child inside a text parent adds a nesting level and repeats
+	// the same string; the parent can carry it directly.
+	if node.Kind == "text" && node.Text == "" && len(node.Children) == 1 {
+		if child := node.Children[0]; child.Kind == "text" && len(child.Children) == 0 &&
+			child.Tooltip == nil && child.Style == nil && child.Href == "" {
+			node.Text = child.Text
+			if node.Plain == "" {
+				node.Plain = child.Plain
+			}
+			node.Children = nil
+		}
+	}
+	if node.Plain == node.Text {
+		node.Plain = ""
+	}
+	if filter, ok := node.FilterValue.(string); ok && (filter == node.Plain || filter == node.Text) {
+		node.FilterValue = nil
+	}
+	return node
 }
 
 func convertTextStyle(styleStr string, class api.Class, monospace bool) *ClickyStyle {

--- a/formatters/html_react_formatter.go
+++ b/formatters/html_react_formatter.go
@@ -893,23 +893,79 @@ func (n ClickyNode) PlainText() string {
 	if n.Source != "" {
 		return n.Source
 	}
-	parts := make([]string, 0, len(n.Children)+len(n.Items)+len(n.Fields))
-	for _, child := range n.Children {
-		parts = append(parts, child.PlainText())
-	}
-	for _, item := range n.Items {
-		parts = append(parts, item.PlainText())
-	}
-	for _, field := range n.Fields {
-		parts = append(parts, field.Value.PlainText())
-	}
-	joined := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part != "" {
-			joined = append(joined, part)
+	parts := make([]string, 0, len(n.Children)+len(n.Items)+len(n.Fields)+len(n.Rows)+len(n.Roots)+2)
+	add := func(text string) {
+		if text != "" {
+			parts = append(parts, text)
 		}
 	}
-	return strings.Join(joined, " ")
+	// Label and Content carry the whole text of a collapsed, admonition or
+	// button node; Rows and Roots carry a table's and a tree's, none of which
+	// keep a second rendering in Plain.
+	if n.Label != nil {
+		add(n.Label.PlainText())
+	}
+	if n.Content != nil {
+		add(n.Content.PlainText())
+	}
+	for _, child := range n.Children {
+		add(child.PlainText())
+	}
+	for _, item := range n.Items {
+		add(item.PlainText())
+	}
+	for _, field := range n.Fields {
+		add(field.Value.PlainText())
+	}
+	for _, row := range n.Rows {
+		for _, name := range n.cellOrder(row) {
+			add(row.Cells[name].PlainText())
+		}
+		if row.Detail != nil {
+			add(row.Detail.PlainText())
+		}
+	}
+	for _, root := range n.Roots {
+		add(root.PlainText())
+	}
+	return strings.Join(parts, " ")
+}
+
+// cellOrder lists a row's cells in the order the table displays them, so a
+// flattened row reads like the row. Cells with no column follow, sorted, so the
+// result never depends on map iteration order.
+func (n ClickyNode) cellOrder(row ClickyRow) []string {
+	names := make([]string, 0, len(row.Cells))
+	extra := make([]string, 0, len(row.Cells))
+	seen := make(map[string]bool, len(row.Cells))
+	for _, column := range n.Columns {
+		if _, ok := row.Cells[column.Name]; ok && !seen[column.Name] {
+			seen[column.Name] = true
+			names = append(names, column.Name)
+		}
+	}
+	for name := range row.Cells {
+		if !seen[name] {
+			extra = append(extra, name)
+		}
+	}
+	sort.Strings(extra)
+	return append(names, extra...)
+}
+
+// PlainText flattens a tree item and its descendants to the string a reader
+// sorts, filters and searches on.
+func (i ClickyTreeItem) PlainText() string {
+	parts := make([]string, 0, len(i.Children)+1)
+	if label := i.Label.PlainText(); label != "" {
+		parts = append(parts, label)
+	}
+	for _, child := range i.Children {
+		if text := child.PlainText(); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // compactNode drops the copies of a node's text that a reader can derive.
@@ -927,8 +983,12 @@ func compactNode(node ClickyNode) ClickyNode {
 	// A lone text child inside a text parent adds a nesting level and repeats
 	// the same string; the parent can carry it directly.
 	if node.Kind == "text" && node.Text == "" && len(node.Children) == 1 {
+		// Only a bare leaf can be lifted: the parent keeps Text and Plain, so a
+		// child carrying anything else would lose it silently.
 		if child := node.Children[0]; child.Kind == "text" && len(child.Children) == 0 &&
-			child.Tooltip == nil && child.Style == nil && child.Href == "" {
+			child.Tooltip == nil && child.Style == nil && child.Href == "" &&
+			child.HTML == "" && child.FilterValue == nil &&
+			len(child.Attributes) == 0 && child.Bullet == nil {
 			node.Text = child.Text
 			if node.Plain == "" {
 				node.Plain = child.Plain

--- a/formatters/html_react_formatter_test.go
+++ b/formatters/html_react_formatter_test.go
@@ -221,11 +221,76 @@ func TestHTMLReactConvertTable(t *testing.T) {
 	if len(node.Rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(node.Rows))
 	}
-	if node.Rows[0].Cells["Name"].Plain != "svc-a" {
-		t.Errorf("expected row[0][Name]=svc-a, got %s", node.Rows[0].Cells["Name"].Plain)
+	// Asserted through the same flattening the reader does, rather than on one
+	// field: Plain is omitted when it would only repeat Text, so which field
+	// carries the string is an encoding detail and not the contract.
+	if got := node.Rows[0].Cells["Name"].PlainText(); got != "svc-a" {
+		t.Errorf("expected row[0][Name]=svc-a, got %q", got)
+	}
+	if plain := node.Rows[0].Cells["Name"].Plain; plain != "" {
+		t.Errorf("Plain=%q duplicates Text and should have been dropped", plain)
 	}
 	if node.Rows[0].Detail == nil || node.Rows[0].Detail.Kind != "code" {
 		t.Fatalf("expected row detail code node, got %#v", node.Rows[0].Detail)
+	}
+}
+
+// A table node used to carry a full box-drawing render of itself in Plain,
+// which nothing reads: the renderer takes columns and rows, and the terminal
+// view is fetched separately as text/plain. On a wide table that copy was a
+// sixth of the payload.
+func TestHTMLReactTableCarriesNoSecondRendering(t *testing.T) {
+	table := &api.TextTable{
+		Headers: api.TextList{api.Text{Content: "Name"}},
+		Columns: []api.PrettyField{{Name: "Name", Label: "Name"}},
+		Rows: []api.TableRow{
+			{"Name": api.TypedValue{Textable: api.Text{Content: "svc-a"}}},
+			{"Name": api.TypedValue{Textable: api.Text{Content: "svc-b"}}},
+		},
+	}
+	node := convertTable(table)
+	if node.Plain != "" {
+		t.Fatalf("table node carries a %d byte second rendering of itself", len(node.Plain))
+	}
+	// The rows are still there — the copy was removed, not the content.
+	if got := node.Rows[0].Cells["Name"].PlainText(); got != "svc-a" {
+		t.Fatalf("row text = %q, want svc-a", got)
+	}
+	// A header that only repeats its column's label is not sent either.
+	if node.Columns[0].Header != nil {
+		t.Fatalf("header node duplicates Label %q: %#v", node.Columns[0].Label, node.Columns[0].Header)
+	}
+}
+
+// Plain, Text and FilterValue are three projections of one string. Sending all
+// three tripled the cost of every populated cell.
+func TestHTMLReactCellDropsDuplicateProjections(t *testing.T) {
+	table := &api.TextTable{
+		Headers: api.TextList{api.Text{Content: "State"}},
+		Columns: []api.PrettyField{{Name: "State", Label: "State", FilterKey: "filter.state"}},
+		Rows: []api.TableRow{
+			{"State": api.TypedValue{Textable: api.Text{Content: "idle"}, FilterValue: "idle"}},
+			{"State": api.TypedValue{Textable: api.Text{Content: "idle"}, FilterValue: "IDLE_RAW"}},
+		},
+	}
+	node := convertTable(table)
+
+	same := node.Rows[0].Cells["State"]
+	if same.Plain != "" {
+		t.Errorf("Plain=%q repeats Text", same.Plain)
+	}
+	if same.FilterValue != nil {
+		t.Errorf("FilterValue=%v repeats the display text", same.FilterValue)
+	}
+	if same.PlainText() != "idle" {
+		t.Errorf("flattened text = %q, want idle", same.PlainText())
+	}
+
+	// A filter value that genuinely differs from what is displayed is the whole
+	// point of the field and must survive.
+	differs := node.Rows[1].Cells["State"]
+	if differs.FilterValue != "IDLE_RAW" {
+		t.Errorf("FilterValue=%v, want the distinct value to survive", differs.FilterValue)
 	}
 }
 

--- a/formatters/html_react_formatter_test.go
+++ b/formatters/html_react_formatter_test.go
@@ -593,3 +593,76 @@ func TestClickyJSONShortTagRendersPrettyShort(t *testing.T) {
 		t.Errorf("without short tag: expected Pretty's full block, got:\n%s", plain)
 	}
 }
+
+// A table and a tree keep no second rendering of themselves in Plain, and a
+// collapsed node's text lives in Label/Content, so flattening has to walk Rows,
+// Roots, Label and Content or the reader sorts and filters on an empty string.
+func TestClickyNodePlainTextWalksEveryTextCarrier(t *testing.T) {
+	table := convertTable(&api.TextTable{
+		Headers: api.TextList{api.Text{Content: "Name"}, api.Text{Content: "Status"}},
+		Columns: []api.PrettyField{{Name: "Name", Label: "Name"}, {Name: "Status", Label: "Status"}},
+		Rows: []api.TableRow{
+			{
+				"Name":   api.TypedValue{Textable: api.Text{Content: "svc-a"}},
+				"Status": api.TypedValue{Textable: api.Text{Content: "healthy"}},
+			},
+			{
+				"Name":   api.TypedValue{Textable: api.Text{Content: "svc-b"}},
+				"Status": api.TypedValue{Textable: api.Text{Content: "degraded"}},
+			},
+		},
+		RowDetail: []api.Textable{api.Text{Content: "restarted 2m ago"}, nil},
+	})
+	if got := table.PlainText(); got != "svc-a healthy restarted 2m ago svc-b degraded" {
+		t.Errorf("table PlainText = %q, want every cell in column order plus the row detail", got)
+	}
+
+	tree := convertTree(&api.TextTree{
+		Node:     api.Text{Content: "root"},
+		Children: []api.TextTree{{Node: api.Text{Content: "child"}}},
+	})
+	if got := tree.PlainText(); got != "root child" {
+		t.Errorf("tree PlainText = %q, want root child", got)
+	}
+
+	collapsed := ClickyNode{
+		Kind:    "collapsed",
+		Label:   &ClickyNode{Kind: "text", Text: "Stack trace"},
+		Content: &ClickyNode{Kind: "text", Text: "panic: boom"},
+	}
+	if got := collapsed.PlainText(); got != "Stack trace panic: boom" {
+		t.Errorf("collapsed PlainText = %q, want the label and the content", got)
+	}
+}
+
+// Flattening a single-child text node copies only Text and Plain onto the
+// parent, so anything else the child carries would disappear with it.
+func TestHTMLReactCompactNodeFlattensOnlyBareLeaves(t *testing.T) {
+	bullet := ClickyNode{Kind: "text", Text: "-"}
+	carriers := map[string]func(*ClickyNode){
+		"html":        func(n *ClickyNode) { n.HTML = "<em>idle</em>" },
+		"filterValue": func(n *ClickyNode) { n.FilterValue = "IDLE_RAW" },
+		"attributes":  func(n *ClickyNode) { n.Attributes = map[string]string{"data-state": "idle"} },
+		"bullet":      func(n *ClickyNode) { n.Bullet = &bullet },
+		"href":        func(n *ClickyNode) { n.Href = "https://example.com/idle" },
+	}
+	for name, carry := range carriers {
+		t.Run(name, func(t *testing.T) {
+			child := ClickyNode{Kind: "text", Text: "idle"}
+			carry(&child)
+			compacted := compactNode(ClickyNode{Kind: "text", Children: []ClickyNode{child}})
+			if len(compacted.Children) != 1 {
+				t.Fatalf("child carrying %s was flattened away, losing it: %#v", name, compacted)
+			}
+		})
+	}
+
+	// A child with nothing but text is still lifted — the saving is the point.
+	compacted := compactNode(ClickyNode{
+		Kind:     "text",
+		Children: []ClickyNode{{Kind: "text", Text: "idle", Plain: "idle"}},
+	})
+	if compacted.Text != "idle" || len(compacted.Children) != 0 {
+		t.Fatalf("a bare leaf should have been lifted into the parent, got %#v", compacted)
+	}
+}

--- a/formatters/json_formatter.go
+++ b/formatters/json_formatter.go
@@ -2,6 +2,8 @@ package formatters
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 
 	"github.com/flanksource/clicky/api"
 )
@@ -39,6 +41,38 @@ func (f *JSONFormatter) FormatValue(data interface{}) (string, error) {
 	} else {
 		return string(b), nil
 	}
+}
+
+// FormatLines formats data as JSON Lines (ndjson): one compact JSON value per
+// line, a slice emitting one line per element.
+//
+// The encoder is deliberately encoding/json's, configured exactly as
+// writeJSONStream's is — HTML escaping on, a trailing newline per value — so a
+// CLI `--format ndjson` and the streaming export of the same rows are the same
+// bytes rather than merely the same shape.
+func (f *JSONFormatter) FormatLines(data interface{}) (string, error) {
+	// Unwrap single-element varargs slices, as the other formatters do.
+	if slice, ok := data.([]interface{}); ok && len(slice) == 1 {
+		data = slice[0]
+	}
+
+	var out strings.Builder
+	enc := json.NewEncoder(&out)
+	value := reflect.ValueOf(data)
+	if data != nil && (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) &&
+		value.Type().Elem().Kind() != reflect.Uint8 {
+		for i := 0; i < value.Len(); i++ {
+			if err := enc.Encode(value.Index(i).Interface()); err != nil {
+				return "", err
+			}
+		}
+		return out.String(), nil
+	}
+
+	if err := enc.Encode(data); err != nil {
+		return "", err
+	}
+	return out.String(), nil
 }
 
 // FormatCompact formats data as compact JSON (no indentation)

--- a/formatters/manager.go
+++ b/formatters/manager.go
@@ -65,6 +65,15 @@ func (f *FormatManager) JSON(data interface{}) (string, error) {
 	return f.jsonFormatter.Format(data)
 }
 
+// NDJSON renders data as JSON Lines — the format the streaming export serves
+// and the --format spec has always advertised.
+func (f *FormatManager) NDJSON(data interface{}) (string, error) {
+	if f.jsonFormatter == nil {
+		f.jsonFormatter = NewJSONFormatter()
+	}
+	return f.jsonFormatter.FormatLines(data)
+}
+
 // YAML implements api.FormatManager.
 func (f *FormatManager) YAML(data interface{}) (string, error) {
 	if f.yamlFormatter == nil {
@@ -151,6 +160,8 @@ func (f *FormatManager) Format(format string, data interface{}) (string, error) 
 	switch format {
 	case "json":
 		return f.JSON(data)
+	case "ndjson":
+		return f.NDJSON(data)
 	case "yaml", "yml":
 		return f.YAML(data)
 	case "csv":
@@ -281,6 +292,9 @@ func (f *FormatManager) formatWithOptions(options FormatOptions, data ...any) (s
 	case "json":
 
 		return f.JSON(d)
+
+	case "ndjson":
+		return f.NDJSON(d)
 
 	case "yaml", "yml":
 		return f.YAML(d)

--- a/formatters/manager.go
+++ b/formatters/manager.go
@@ -2,6 +2,7 @@ package formatters
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -190,6 +191,10 @@ func (f *FormatManager) Format(format string, data interface{}) (string, error) 
 	}
 }
 
+// errTextableFormatUnsupported marks a format formatTextable does not implement,
+// so callers can fall through to the generic formatting pipeline instead of failing.
+var errTextableFormatUnsupported = errors.New("unsupported format for Textable")
+
 func formatTextable(data api.Textable, opts FormatOptions) (string, error) {
 	format := strings.ToLower(opts.ResolveFormat())
 	switch format {
@@ -216,7 +221,7 @@ func formatTextable(data api.Textable, opts FormatOptions) (string, error) {
 		slack := NewSlackFormatter()
 		return slack.Format(data, opts)
 	default:
-		return "", fmt.Errorf("unsupported format for Textable: %s", opts.Format)
+		return "", fmt.Errorf("%w: %s", errTextableFormatUnsupported, format)
 	}
 }
 
@@ -231,6 +236,21 @@ func (f *FormatManager) formatWithOptions(options FormatOptions, data ...any) (s
 	// Resolve format from boolean flags first to check for custom formatters
 	format := strings.ToLower(options.ResolveFormat())
 
+	// A single Textable renders itself for the formats formatTextable owns; any
+	// other format falls through to the generic pipeline below so Textable input
+	// can still reach csv/excel/ndjson/tree and custom formatters.
+	if len(data) == 1 {
+		if textable, ok := data[0].(api.Textable); ok {
+			output, err := formatTextable(textable, options)
+			if err == nil {
+				return output, nil
+			}
+			if !errors.Is(err, errTextableFormatUnsupported) {
+				return "", err
+			}
+		}
+	}
+
 	// Check for custom formatters BEFORE the string shortcut
 	// This allows custom formatters to process strings
 	if customFn, exists := GetCustomFormatter(format); exists {
@@ -243,8 +263,6 @@ func (f *FormatManager) formatWithOptions(options FormatOptions, data ...any) (s
 			return v, nil
 		case []byte:
 			return string(v), nil
-		case api.Textable:
-			return formatTextable(v, options)
 		}
 	}
 

--- a/formatters/manager_textable_test.go
+++ b/formatters/manager_textable_test.go
@@ -3,6 +3,7 @@ package formatters
 import (
 	"bytes"
 	"encoding/csv"
+	"regexp"
 	"strings"
 
 	"github.com/flanksource/clicky/api"
@@ -10,6 +11,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/xuri/excelize/v2"
 )
+
+var gridjsTableID = regexp.MustCompile(`gridjs-table-\d+`)
+
+func normalizeTableIDs(html string) string {
+	return gridjsTableID.ReplaceAllString(html, "gridjs-table")
+}
 
 var _ = Describe("Textable formatting", func() {
 	table := api.NewTableFrom([]excelTableRow{{ID: 1, Name: "alpha"}, {ID: 2, Name: "beta"}})
@@ -52,7 +59,9 @@ var _ = Describe("Textable formatting", func() {
 
 			output, err := NewFormatManager().FormatWithOptions(FormatOptions{Format: format}, table)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal(expected))
+			// The Grid.js mount id is deliberately unique per render, so two renders of
+			// the same table never match byte-for-byte; the rest must be identical.
+			Expect(normalizeTableIDs(output)).To(Equal(normalizeTableIDs(expected)))
 		},
 		Entry("json", "json"),
 		Entry("yaml", "yaml"),

--- a/formatters/manager_textable_test.go
+++ b/formatters/manager_textable_test.go
@@ -1,0 +1,64 @@
+package formatters
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+
+	"github.com/flanksource/clicky/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/xuri/excelize/v2"
+)
+
+var _ = Describe("Textable formatting", func() {
+	table := api.NewTableFrom([]excelTableRow{{ID: 1, Name: "alpha"}, {ID: 2, Name: "beta"}})
+
+	// api.TextTable is what every Table()/Pretty() producer hands the formatter, so
+	// a format it cannot reach is a format the caller cannot use.
+	DescribeTable("renders a TextTable in formats formatTextable does not implement",
+		func(format string, assert func(string)) {
+			output, err := NewFormatManager().FormatWithOptions(FormatOptions{Format: format}, table)
+			Expect(err).NotTo(HaveOccurred())
+			assert(output)
+		},
+		Entry("csv", "csv", func(output string) {
+			records, err := csv.NewReader(strings.NewReader(output)).ReadAll()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(records[0]).To(Equal([]string{"ID", "Name"}))
+			Expect(records[2]).To(Equal([]string{"2", "beta"}))
+		}),
+		Entry("excel", "excel", func(output string) {
+			book, err := excelize.OpenReader(bytes.NewReader([]byte(output)))
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(book.Close)
+			Expect(book.GetCellValue("Sheet1", "A1")).To(Equal("ID"))
+		}),
+		Entry("ndjson", "ndjson", func(output string) {
+			Expect(strings.Count(strings.TrimSuffix(output, "\n"), "\n")).To(Equal(0))
+			Expect(output).To(ContainSubstring("alpha"))
+		}),
+		Entry("tree", "tree", func(output string) {
+			Expect(output).NotTo(BeEmpty())
+		}),
+	)
+
+	// The formats formatTextable does implement must keep going through it, or
+	// widening the fall-through would quietly rewrite every existing output.
+	DescribeTable("leaves formats formatTextable owns untouched",
+		func(format string) {
+			expected, err := formatTextable(table, FormatOptions{Format: format})
+			Expect(err).NotTo(HaveOccurred())
+
+			output, err := NewFormatManager().FormatWithOptions(FormatOptions{Format: format}, table)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(Equal(expected))
+		},
+		Entry("json", "json"),
+		Entry("yaml", "yaml"),
+		Entry("markdown", "markdown"),
+		Entry("pretty", "pretty"),
+		Entry("html", "html"),
+		Entry("slack", "slack"),
+	)
+})

--- a/formatters/ndjson_test.go
+++ b/formatters/ndjson_test.go
@@ -1,0 +1,52 @@
+package formatters
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("ndjson", func() {
+	Formatter := NewFormatManager()
+	rows := []map[string]any{
+		{"id": 1, "name": "alpha", "note": "a<b & c"},
+		{"id": 2, "name": "beta", "note": "d>e"},
+	}
+
+	ginkgo.It("renders one compact JSON object per line", func() {
+		out, err := Formatter.FormatWithOptions(FormatOptions{Format: "ndjson"}, rows)
+		Expect(err).NotTo(HaveOccurred())
+
+		lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+		Expect(lines).To(HaveLen(len(rows)))
+		Expect(lines[0]).To(HavePrefix(`{"id":1,`))
+	})
+
+	// The CLI's --format ndjson and the server's streaming export must produce the
+	// same bytes, or "the CLI has every format the UI has" is only true by name.
+	ginkgo.It("is byte-identical to the streaming writer", func() {
+		var streamed bytes.Buffer
+		_, err := WriteTableStream(context.Background(), &streamed,
+			&sliceRowIterator{rows: rows}, StreamOptions{Format: "ndjson"})
+		Expect(err).NotTo(HaveOccurred())
+
+		out, err := Formatter.FormatWithOptions(FormatOptions{Format: "ndjson"}, rows)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal(streamed.String()))
+	})
+
+	ginkgo.It("does not silently fall back to a pretty table", func() {
+		out, err := Formatter.FormatWithOptions(FormatOptions{Format: "ndjson"}, rows)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(ContainSubstring("│"))
+	})
+
+	ginkgo.It("emits a single line for a value that is not a slice", func() {
+		out, err := Formatter.FormatWithOptions(FormatOptions{Format: "ndjson"}, rows[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Split(strings.TrimSuffix(out, "\n"), "\n")).To(HaveLen(1))
+	})
+})

--- a/formatters/stream.go
+++ b/formatters/stream.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	"io"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -14,6 +16,10 @@ import (
 	"github.com/xuri/excelize/v2"
 	"gopkg.in/yaml.v3"
 )
+
+// csvBOM makes Excel on Windows decode a downloaded export as UTF-8 instead of
+// the machine's ANSI code page, which otherwise mangles every non-ASCII cell.
+const csvBOM = "\xEF\xBB\xBF"
 
 // RowIterator is the bounded-memory table source consumed by WriteTableStream.
 // Columns may be empty; in that case the first row establishes a stable,
@@ -32,6 +38,15 @@ type RowIterator interface {
 type StreamOptions struct {
 	Format  string
 	MaxRows int64
+	// FlushEvery pushes buffered output downstream every N rows so a long
+	// running HTTP export appears as it is produced instead of arriving in one
+	// burst. Zero keeps the single flush at the end of the stream.
+	FlushEvery int
+	// CSVBOM writes a UTF-8 BOM ahead of CSV output. It exists for files that
+	// are downloaded and opened in a spreadsheet; a caller streaming CSV into a
+	// pipe or a parser must not receive bytes it did not ask for, so the same
+	// endpoint serving a plain API read leaves this false.
+	CSVBOM bool
 }
 
 // WriteTableStream writes rows incrementally in a Clicky-supported tabular
@@ -62,21 +77,21 @@ func WriteTableStream(ctx context.Context, w io.Writer, rows RowIterator, opts S
 
 	switch format {
 	case "json":
-		return writeJSONStream(ctx, w, rows, structuredColumns, first, ok, false, opts.MaxRows)
+		return writeJSONStream(ctx, w, rows, structuredColumns, first, ok, false, opts)
 	case "ndjson":
-		return writeJSONStream(ctx, w, rows, structuredColumns, first, ok, true, opts.MaxRows)
+		return writeJSONStream(ctx, w, rows, structuredColumns, first, ok, true, opts)
 	case "yaml":
-		return writeYAMLStream(ctx, w, rows, structuredColumns, first, ok, opts.MaxRows)
+		return writeYAMLStream(ctx, w, rows, structuredColumns, first, ok, opts)
 	case "csv":
-		return writeCSVStream(ctx, w, rows, columns, first, ok, opts.MaxRows)
+		return writeCSVStream(ctx, w, rows, columns, first, ok, opts)
 	case "markdown":
-		return writeMarkdownStream(ctx, w, rows, columns, first, ok, opts.MaxRows)
+		return writeMarkdownStream(ctx, w, rows, columns, first, ok, opts)
 	case "html":
-		return writeHTMLStream(ctx, w, rows, columns, first, ok, opts.MaxRows)
+		return writeHTMLStream(ctx, w, rows, columns, first, ok, opts)
 	case "excel":
-		return writeExcelStream(ctx, w, rows, columns, first, ok, opts.MaxRows)
+		return writeExcelStream(ctx, w, rows, columns, first, ok, opts)
 	case "pdf":
-		return writePDFStream(ctx, w, rows, columns, first, ok, opts.MaxRows)
+		return writePDFStream(ctx, w, rows, columns, first, ok, opts)
 	default:
 		return 0, fmt.Errorf("unsupported streaming format: %s", format)
 	}
@@ -160,7 +175,72 @@ func streamRows(ctx context.Context, rows RowIterator, first map[string]any, has
 	}
 }
 
-func writeJSONStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok, ndjson bool, maxRows int64) (int64, error) {
+// flushingEmit wraps emit so buffered bytes reach the client every n rows.
+// n <= 0 returns emit untouched, keeping the historical behaviour where an
+// export is only visible once the whole response has been produced.
+func flushingEmit(n int, flush func() error, emit func(map[string]any) error) func(map[string]any) error {
+	if n <= 0 {
+		return emit
+	}
+	written := 0
+	return func(row map[string]any) error {
+		if err := emit(row); err != nil {
+			return err
+		}
+		written++
+		if written%n != 0 {
+			return nil
+		}
+		return flush()
+	}
+}
+
+// flushStream pushes whatever w has buffered towards the client. HTTP handlers
+// need a ResponseController because net/http and any middleware wrap the
+// original writer; other writers qualify only if they expose Flush themselves,
+// and the rest (files, buffers) are unbuffered so there is nothing to push.
+func flushStream(w io.Writer) error {
+	switch target := w.(type) {
+	case http.ResponseWriter:
+		// A transport that cannot flush is not an export failure.
+		if err := http.NewResponseController(target).Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+			return err
+		}
+	case interface{ Flush() error }:
+		return target.Flush()
+	case interface{ Flush() }:
+		target.Flush()
+	}
+	return nil
+}
+
+// escapeSpreadsheetFormula neutralises a cell that Excel, LibreOffice or Sheets
+// would evaluate as a formula. Row values come from backends the operator does
+// not control, and these exports are opened as downloads; a leading single
+// quote forces the cell to be read as literal text.
+func escapeSpreadsheetFormula(text string) string {
+	if text == "" {
+		return text
+	}
+	switch text[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + text
+	}
+	return text
+}
+
+// escapeSpreadsheetCell escapes only string-shaped values. A number is emitted
+// as a number and cannot carry a formula, so quoting a value like -5 would just
+// turn it into text and break sorting and arithmetic in the sheet.
+func escapeSpreadsheetCell(value any, rendered string) string {
+	switch value.(type) {
+	case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, json.Number:
+		return rendered
+	}
+	return escapeSpreadsheetFormula(rendered)
+}
+
+func writeJSONStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok, ndjson bool, opts StreamOptions) (int64, error) {
 	enc := json.NewEncoder(w)
 	firstJSON := true
 	if !ndjson {
@@ -168,7 +248,8 @@ func writeJSONStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 			return 0, err
 		}
 	}
-	count, err := streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	flush := func() error { return flushStream(w) }
+	count, err := streamRows(ctx, rows, first, ok, opts.MaxRows, flushingEmit(opts.FlushEvery, flush, func(row map[string]any) error {
 		row = projectedStreamRow(row, columns)
 		if ndjson {
 			return enc.Encode(row)
@@ -185,7 +266,7 @@ func writeJSONStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 		}
 		_, err = w.Write(data)
 		return err
-	})
+	}))
 	if err != nil {
 		return count, err
 	}
@@ -195,12 +276,13 @@ func writeJSONStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 	return count, err
 }
 
-func writeYAMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, maxRows int64) (int64, error) {
+func writeYAMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, opts StreamOptions) (int64, error) {
 	if !ok {
 		_, err := io.WriteString(w, "[]\n")
 		return 0, err
 	}
-	return streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	flush := func() error { return flushStream(w) }
+	return streamRows(ctx, rows, first, ok, opts.MaxRows, flushingEmit(opts.FlushEvery, flush, func(row map[string]any) error {
 		data, err := yaml.Marshal(projectedStreamRow(row, columns))
 		if err != nil {
 			return err
@@ -216,25 +298,39 @@ func writeYAMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 			}
 		}
 		return nil
-	})
+	}))
 }
 
-func writeCSVStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, maxRows int64) (int64, error) {
+func writeCSVStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, opts StreamOptions) (int64, error) {
+	if opts.CSVBOM {
+		if _, err := io.WriteString(w, csvBOM); err != nil {
+			return 0, err
+		}
+	}
 	writer := csv.NewWriter(w)
 	headers := make([]string, len(columns))
 	for i, column := range columns {
-		headers[i] = column.DisplayLabel()
+		headers[i] = escapeSpreadsheetFormula(column.DisplayLabel())
 	}
 	if err := writer.Write(headers); err != nil {
 		return 0, err
 	}
-	count, err := streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	// csv.Writer holds its own 4KiB buffer, so it has to be drained before the
+	// response writer is flushed or nothing reaches the client.
+	flush := func() error {
+		writer.Flush()
+		if err := writer.Error(); err != nil {
+			return err
+		}
+		return flushStream(w)
+	}
+	count, err := streamRows(ctx, rows, first, ok, opts.MaxRows, flushingEmit(opts.FlushEvery, flush, func(row map[string]any) error {
 		values := make([]string, len(columns))
 		for i, column := range columns {
-			values[i] = streamCell(row[column.Name], column, "plain")
+			values[i] = escapeSpreadsheetCell(row[column.Name], streamCell(row[column.Name], column, "plain"))
 		}
 		return writer.Write(values)
-	})
+	}))
 	writer.Flush()
 	if err == nil {
 		err = writer.Error()
@@ -242,7 +338,7 @@ func writeCSVStream(ctx context.Context, w io.Writer, rows RowIterator, columns 
 	return count, err
 }
 
-func writeMarkdownStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, maxRows int64) (int64, error) {
+func writeMarkdownStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, opts StreamOptions) (int64, error) {
 	headers := make([]string, len(columns))
 	separators := make([]string, len(columns))
 	for i, column := range columns {
@@ -252,17 +348,18 @@ func writeMarkdownStream(ctx context.Context, w io.Writer, rows RowIterator, col
 	if _, err := fmt.Fprintf(w, "| %s |\n| %s |\n", strings.Join(headers, " | "), strings.Join(separators, " | ")); err != nil {
 		return 0, err
 	}
-	return streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	flush := func() error { return flushStream(w) }
+	return streamRows(ctx, rows, first, ok, opts.MaxRows, flushingEmit(opts.FlushEvery, flush, func(row map[string]any) error {
 		values := make([]string, len(columns))
 		for i, column := range columns {
 			values[i] = escapeMarkdownStream(streamCell(row[column.Name], column, "markdown"))
 		}
 		_, err := fmt.Fprintf(w, "| %s |\n", strings.Join(values, " | "))
 		return err
-	})
+	}))
 }
 
-func writeHTMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, maxRows int64) (int64, error) {
+func writeHTMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, opts StreamOptions) (int64, error) {
 	if _, err := io.WriteString(w, "<!doctype html><html><head><meta charset=\"utf-8\"><title>Clicky export</title><style>body{font-family:system-ui,sans-serif;margin:24px}table{border-collapse:collapse;width:100%}th,td{border:1px solid #d1d5db;padding:6px 8px;text-align:left;vertical-align:top}th{background:#f3f4f6;position:sticky;top:0}</style></head><body><table><thead><tr>"); err != nil {
 		return 0, err
 	}
@@ -274,7 +371,8 @@ func writeHTMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 	if _, err := io.WriteString(w, "</tr></thead><tbody>"); err != nil {
 		return 0, err
 	}
-	count, err := streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	flush := func() error { return flushStream(w) }
+	count, err := streamRows(ctx, rows, first, ok, opts.MaxRows, flushingEmit(opts.FlushEvery, flush, func(row map[string]any) error {
 		if _, err := io.WriteString(w, "<tr>"); err != nil {
 			return err
 		}
@@ -285,7 +383,7 @@ func writeHTMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 		}
 		_, err := io.WriteString(w, "</tr>")
 		return err
-	})
+	}))
 	if err != nil {
 		return count, err
 	}
@@ -293,7 +391,7 @@ func writeHTMLStream(ctx context.Context, w io.Writer, rows RowIterator, columns
 	return count, err
 }
 
-func writeExcelStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, maxRows int64) (int64, error) {
+func writeExcelStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, opts StreamOptions) (int64, error) {
 	file := excelize.NewFile()
 	defer file.Close()
 	stream, err := file.NewStreamWriter("Sheet1")
@@ -302,19 +400,24 @@ func writeExcelStream(ctx context.Context, w io.Writer, rows RowIterator, column
 	}
 	headers := make([]any, len(columns))
 	for i, column := range columns {
-		headers[i] = column.DisplayLabel()
+		headers[i] = escapeSpreadsheetFormula(column.DisplayLabel())
 	}
 	if err := stream.SetRow("A1", headers); err != nil {
 		return 0, err
 	}
 	rowNumber := 2
-	count, err := streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	// excelize writes strings as inline strings, which Excel does not evaluate,
+	// but the quote also survives a re-export of the sheet to CSV where it would.
+	count, err := streamRows(ctx, rows, first, ok, opts.MaxRows, func(row map[string]any) error {
 		values := make([]any, len(columns))
 		for i, column := range columns {
+			value := row[column.Name]
 			if api.IsStructuredColumnType(column.Type) {
-				values[i] = api.ColumnString(column, row[column.Name])
+				values[i] = escapeSpreadsheetFormula(api.ColumnString(column, value))
+			} else if text, isText := value.(string); isText {
+				values[i] = escapeSpreadsheetFormula(text)
 			} else {
-				values[i] = row[column.Name]
+				values[i] = value
 			}
 		}
 		cell, err := excelize.CoordinatesToCellName(1, rowNumber)
@@ -333,8 +436,8 @@ func writeExcelStream(ctx context.Context, w io.Writer, rows RowIterator, column
 	return count, file.Write(w)
 }
 
-func writePDFStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, maxRows int64) (int64, error) {
-	if maxRows <= 0 {
+func writePDFStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok bool, opts StreamOptions) (int64, error) {
+	if opts.MaxRows <= 0 {
 		return 0, fmt.Errorf("pdf streaming requires a positive row limit")
 	}
 	table := api.TextTable{}
@@ -343,7 +446,7 @@ func writePDFStream(ctx context.Context, w io.Writer, rows RowIterator, columns 
 		table.FieldNames = append(table.FieldNames, column.Name)
 		table.Columns = append(table.Columns, api.PrettyField{Name: column.Name, Label: column.DisplayLabel(), Type: column.Type, Format: column.Format, Unit: column.Unit})
 	}
-	count, err := streamRows(ctx, rows, first, ok, maxRows, func(row map[string]any) error {
+	count, err := streamRows(ctx, rows, first, ok, opts.MaxRows, func(row map[string]any) error {
 		out := api.TableRow{}
 		for _, column := range columns {
 			out[column.Name] = api.NewTypedValue(api.ColumnTextable(column, row[column.Name]))

--- a/formatters/stream.go
+++ b/formatters/stream.go
@@ -9,6 +9,7 @@ import (
 	"html"
 	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -233,11 +234,40 @@ func escapeSpreadsheetFormula(text string) string {
 // as a number and cannot carry a formula, so quoting a value like -5 would just
 // turn it into text and break sorting and arithmetic in the sheet.
 func escapeSpreadsheetCell(value any, rendered string) string {
-	switch value.(type) {
-	case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, json.Number:
+	if isSpreadsheetNumber(value) {
 		return rendered
 	}
 	return escapeSpreadsheetFormula(rendered)
+}
+
+// isSpreadsheetNumber reports whether the sheet holds the value as a number (or
+// a boolean), which no spreadsheet evaluates as a formula.
+//
+// The kind is resolved through reflection rather than matched against a list of
+// concrete types, because rows come from arbitrary backends: a *int64, a named
+// type like `type Bytes uint64`, or a pointer to one are all still numbers, and
+// listing types meant a negative number reached the sheet as the text '-5.
+// json.Number is a string kind but a number in the sheet; []byte is a slice
+// carrying text, so it stays escaped.
+func isSpreadsheetNumber(value any) bool {
+	switch value.(type) {
+	case nil, json.Number:
+		return true
+	case []byte:
+		return false
+	}
+	valueType := reflect.TypeOf(value)
+	for valueType.Kind() == reflect.Pointer {
+		valueType = valueType.Elem()
+	}
+	switch valueType.Kind() {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	}
+	return false
 }
 
 func writeJSONStream(ctx context.Context, w io.Writer, rows RowIterator, columns []api.ColumnDef, first map[string]any, ok, ndjson bool, opts StreamOptions) (int64, error) {

--- a/formatters/stream_test.go
+++ b/formatters/stream_test.go
@@ -377,6 +377,43 @@ func TestWriteTableStreamCSVEscapesSpreadsheetFormulas(t *testing.T) {
 	}
 }
 
+// Rows come from arbitrary backends, so a number reaches the exporter as a
+// pointer or a named type just as often as an int. Matching concrete types made
+// those cells text: -5 was written as '-5 and stopped sorting as a number.
+func TestEscapeSpreadsheetCellExemptsEveryNumericKind(t *testing.T) {
+	type megabytes float64
+	type revision uint16
+	negative := int64(-5)
+
+	numeric := map[string]any{
+		"int":              -5,
+		"float64":          -5.0,
+		"uint16":           uint16(5),
+		"json.Number":      json.Number("-5"),
+		"bool":             false,
+		"named float":      megabytes(-5),
+		"named uint":       revision(5),
+		"pointer to int64": &negative,
+		"nil":              nil,
+	}
+	for name, value := range numeric {
+		if got := escapeSpreadsheetCell(value, "-5"); got != "-5" {
+			t.Errorf("%s cell must stay a number, got %q", name, got)
+		}
+	}
+
+	// []byte is a slice, not a number: it carries text a sheet would evaluate.
+	textual := map[string]any{
+		"string": "-5+1",
+		"[]byte": []byte("-5+1"),
+	}
+	for name, value := range textual {
+		if got := escapeSpreadsheetCell(value, "-5+1"); got != "'-5+1" {
+			t.Errorf("%s cell was not neutralised, got %q", name, got)
+		}
+	}
+}
+
 func TestWriteTableStreamStructuredFormatsKeepFormulaText(t *testing.T) {
 	columns := []api.ColumnDef{{Name: "note"}}
 	rows := []map[string]any{{"note": "=1+1"}}

--- a/formatters/stream_test.go
+++ b/formatters/stream_test.go
@@ -1,14 +1,19 @@
 package formatters
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/flanksource/clicky/api"
 	"github.com/xuri/excelize/v2"
@@ -199,6 +204,247 @@ func TestWriteTableStreamEmptyYAMLIsSequence(t *testing.T) {
 	}
 	if output.String() != "[]\n" {
 		t.Fatalf("unexpected empty yaml: %q", output.String())
+	}
+}
+
+// flushRecordingWriter records everything received so far each time it is
+// flushed, so a test can tell what was actually observable mid-stream.
+type flushRecordingWriter struct {
+	mu       sync.Mutex
+	received bytes.Buffer
+	flushes  []string
+}
+
+func (w *flushRecordingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.received.Write(p)
+}
+
+func (w *flushRecordingWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.flushes = append(w.flushes, w.received.String())
+	return nil
+}
+
+// gatedRowIterator stalls before the second row until the consumer signals that
+// it has already seen the first one.
+type gatedRowIterator struct {
+	columns  []api.ColumnDef
+	rows     []map[string]any
+	index    int
+	gate     chan struct{}
+	timedOut bool
+}
+
+func (i *gatedRowIterator) Columns() []api.ColumnDef { return i.columns }
+func (i *gatedRowIterator) Next() bool {
+	if i.index == 1 {
+		select {
+		case <-i.gate:
+		case <-time.After(5 * time.Second):
+			i.timedOut = true
+		}
+	}
+	if i.index >= len(i.rows) {
+		return false
+	}
+	i.index++
+	return true
+}
+func (i *gatedRowIterator) Row() map[string]any { return i.rows[i.index-1] }
+func (i *gatedRowIterator) Err() error          { return nil }
+func (i *gatedRowIterator) Close() error        { return nil }
+
+func parseStreamCSV(t *testing.T, output string) [][]string {
+	t.Helper()
+	records, err := csv.NewReader(strings.NewReader(strings.TrimPrefix(output, csvBOM))).ReadAll()
+	if err != nil {
+		t.Fatalf("invalid csv %q: %v", output, err)
+	}
+	return records
+}
+
+func TestWriteTableStreamFlushEveryDrainsTheCSVBufferFirst(t *testing.T) {
+	columns := []api.ColumnDef{{Name: "name"}}
+	rows := []map[string]any{{"name": "alpha"}, {"name": "beta"}, {"name": "gamma"}}
+
+	flushed := &flushRecordingWriter{}
+	if _, err := WriteTableStream(context.Background(), flushed, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "csv", FlushEvery: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if len(flushed.flushes) != len(rows) {
+		t.Fatalf("expected one flush per row, got %d", len(flushed.flushes))
+	}
+	if !strings.Contains(flushed.flushes[0], "alpha") {
+		t.Fatalf("csv buffer was not drained before the writer flush: %q", flushed.flushes[0])
+	}
+	if strings.Contains(flushed.flushes[0], "beta") {
+		t.Fatalf("first flush leaked later rows: %q", flushed.flushes[0])
+	}
+
+	buffered := &flushRecordingWriter{}
+	if _, err := WriteTableStream(context.Background(), buffered, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "csv"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(buffered.flushes) != 0 {
+		t.Fatalf("FlushEvery=0 must not flush, got %d flushes", len(buffered.flushes))
+	}
+}
+
+func TestWriteTableStreamFlushEveryDeliversRowsBeforeTheResponseEnds(t *testing.T) {
+	iterator := &gatedRowIterator{
+		columns: []api.ColumnDef{{Name: "name"}},
+		rows:    []map[string]any{{"name": "alpha"}, {"name": "beta"}},
+		gate:    make(chan struct{}),
+	}
+	done := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := WriteTableStream(r.Context(), w, iterator, StreamOptions{Format: "csv", FlushEvery: 1})
+		done <- err
+	}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := bufio.NewReader(resp.Body)
+	if _, err := body.ReadString('\n'); err != nil {
+		t.Fatalf("header not delivered: %v", err)
+	}
+	firstRow, err := body.ReadString('\n')
+	if err != nil {
+		t.Fatalf("first row not delivered: %v", err)
+	}
+	close(iterator.gate)
+
+	rest, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if iterator.timedOut {
+		t.Fatalf("first row only reached the client once the response ended: %q", firstRow)
+	}
+	if !strings.Contains(firstRow, "alpha") || !strings.Contains(string(rest), "beta") {
+		t.Fatalf("unexpected stream: first=%q rest=%q", firstRow, rest)
+	}
+}
+
+func TestWriteTableStreamCSVEscapesSpreadsheetFormulas(t *testing.T) {
+	dangerous := map[string]string{
+		"equals": "=1+1",
+		"plus":   "+1+1",
+		"minus":  "-1+1",
+		"at":     "@SUM(A1)",
+		"tab":    "\t=cmd|'/c calc'!A0",
+		"cr":     "\r=cmd|'/c calc'!A0",
+	}
+	columns := []api.ColumnDef{
+		{Name: "equals"}, {Name: "plus"}, {Name: "minus"}, {Name: "at"}, {Name: "tab"}, {Name: "cr"},
+		{Name: "safe"}, {Name: "negative", Type: "number"},
+	}
+	row := map[string]any{"safe": "hello", "negative": -5}
+	for name, value := range dangerous {
+		row[name] = value
+	}
+
+	var output bytes.Buffer
+	if _, err := WriteTableStream(context.Background(), &output, &sliceRowIterator{columns: columns, rows: []map[string]any{row}}, StreamOptions{Format: "csv"}); err != nil {
+		t.Fatal(err)
+	}
+	records := parseStreamCSV(t, output.String())
+	cells := map[string]string{}
+	for i, column := range columns {
+		cells[column.Name] = records[1][i]
+	}
+	for name, value := range dangerous {
+		if cells[name] != "'"+value {
+			t.Fatalf("%s cell was not neutralised: %q", name, cells[name])
+		}
+	}
+	if cells["safe"] != "hello" {
+		t.Fatalf("harmless value was rewritten: %q", cells["safe"])
+	}
+	if cells["negative"] != "-5" {
+		t.Fatalf("numeric cell must stay a number, got %q", cells["negative"])
+	}
+}
+
+func TestWriteTableStreamStructuredFormatsKeepFormulaText(t *testing.T) {
+	columns := []api.ColumnDef{{Name: "note"}}
+	rows := []map[string]any{{"note": "=1+1"}}
+
+	for _, format := range []string{"json", "ndjson", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			var output bytes.Buffer
+			if _, err := WriteTableStream(context.Background(), &output, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: format}); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(output.String(), "'=1+1") {
+				t.Fatalf("%s must not spreadsheet-escape values: %s", format, output.String())
+			}
+		})
+	}
+}
+
+func TestWriteTableStreamExcelEscapesFormulasButKeepsNumbers(t *testing.T) {
+	columns := []api.ColumnDef{{Name: "note"}, {Name: "delta", Type: "number"}}
+	rows := []map[string]any{{"note": "=1+1", "delta": -5}}
+
+	var output bytes.Buffer
+	if _, err := WriteTableStream(context.Background(), &output, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "excel"}); err != nil {
+		t.Fatal(err)
+	}
+	book, err := excelize.OpenReader(bytes.NewReader(output.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer book.Close()
+	if note, _ := book.GetCellValue("Sheet1", "A2"); note != "'=1+1" {
+		t.Fatalf("formula cell was not neutralised: %q", note)
+	}
+	if delta, _ := book.GetCellValue("Sheet1", "B2"); delta != "-5" {
+		t.Fatalf("numeric cell must stay a number, got %q", delta)
+	}
+	deltaType, err := book.GetCellType("Sheet1", "B2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deltaType == excelize.CellTypeInlineString || deltaType == excelize.CellTypeSharedString {
+		t.Fatalf("negative number was written as text (%v)", deltaType)
+	}
+}
+
+func TestWriteTableStreamCSVBOM(t *testing.T) {
+	columns := []api.ColumnDef{{Name: "name"}}
+	rows := []map[string]any{{"name": "Ünicode"}}
+
+	// A plain API read is piped into cut/awk or another parser, so the first
+	// header name must not pick up three extra bytes.
+	var apiRead bytes.Buffer
+	if _, err := WriteTableStream(context.Background(), &apiRead, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "csv"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(apiRead.String(), csvBOM) {
+		t.Fatalf("csv gained a BOM the caller did not ask for: %q", apiRead.String())
+	}
+
+	var download bytes.Buffer
+	if _, err := WriteTableStream(context.Background(), &download, &sliceRowIterator{columns: columns, rows: rows}, StreamOptions{Format: "csv", CSVBOM: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(download.String(), csvBOM) {
+		t.Fatalf("CSVBOM did not emit the UTF-8 BOM: %q", download.String())
+	}
+	if strings.TrimPrefix(download.String(), csvBOM) != apiRead.String() {
+		t.Fatalf("BOM changed more than the prefix: %q vs %q", download.String(), apiRead.String())
 	}
 }
 

--- a/formatters/tree_formatter.go
+++ b/formatters/tree_formatter.go
@@ -49,6 +49,13 @@ func (f *TreeFormatter) Format(data ...any) (string, error) {
 			} else {
 				return text.ANSI(), nil
 			}
+		} else if textable, ok := data[0].(api.Textable); ok {
+			// A Textable without tree structure (a table, a badge) still renders
+			// itself; falling through to PrettyData would yield an empty tree.
+			if f.NoColor {
+				return textable.String(), nil
+			}
+			return textable.ANSI(), nil
 		}
 	}
 

--- a/rpc/action_error_wire_test.go
+++ b/rpc/action_error_wire_test.go
@@ -1,0 +1,64 @@
+package rpc
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flanksource/clicky"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type refreshResult struct {
+	ConnectionID string `json:"connectionId"`
+	Provider     string `json:"provider"`
+	Bound        int    `json:"bound"`
+}
+
+// A typed action that fails must answer with the error envelope. Before the
+// fix the failed action's zero value was boxed into a non-nil `any`, so the
+// executor's partial-data branch served `{"connectionId":"","provider":"", ...}`
+// with the error only in the X-Error header — leaving web clients that read the
+// body with nothing to show.
+func TestEntityAction_FailureServesErrorNotZeroValue(t *testing.T) {
+	const name = "rpc-action-error-wire-test"
+	clicky.NewEntity[testEntity, testListOpts, testEntity](name).
+		List(func(_ testListOpts) ([]testEntity, error) {
+			return []testEntity{{ID: "1", Name: "one"}}, nil
+		}).
+		WithAction(clicky.Action("refresh", func(string, map[string]string) (refreshResult, error) {
+			return refreshResult{}, errors.New("tenant name matches 2 companies")
+		})).
+		Register()
+
+	root := &cobra.Command{Use: "testapp"}
+	clicky.GenerateCLI(root)
+	server := NewSwaggerServer(
+		&ServeConfig{
+			Title:      "t",
+			Version:    "v",
+			SkipHealth: true,
+			Executor:   &ExecutorConfig{Enabled: true, PathPrefix: "/api/v1"},
+		},
+		root,
+		&OpenAPIConfig{Title: "t", Version: "v"},
+	)
+	mux := http.NewServeMux()
+	server.RegisterExecutionRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/"+name+"/conn-1/refresh", nil)
+	req.Header.Set("Accept", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "tenant name matches 2 companies", body["error"])
+	assert.NotContains(t, body, "connectionId", "the failed action's zero value must not be served as data")
+}

--- a/rpc/compression.go
+++ b/rpc/compression.go
@@ -1,0 +1,222 @@
+package rpc
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// The rendered table format is deliberately redundant — every cell carries its
+// own kind, and a column's styling repeats down the column — so the payload
+// compresses by more than an order of magnitude. Serving it uncompressed makes
+// the client wait on bytes that carry almost no information.
+var gzipWriters = sync.Pool{
+	New: func() any {
+		writer, err := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		if err != nil {
+			// The only error NewWriterLevel returns is an invalid level, and the
+			// level here is a constant.
+			panic(err)
+		}
+		return writer
+	},
+}
+
+// compressible reports whether a body of this media type is worth gzipping.
+//
+// An empty type is refused rather than assumed: Go sniffs an unset Content-Type
+// from the first bytes written, and those bytes would be the gzip header — so
+// compressing here would relabel the response as gzip and lose its real type.
+func compressible(contentType string) bool {
+	media := strings.TrimSpace(strings.ToLower(strings.Split(contentType, ";")[0]))
+	switch {
+	case media == "":
+		return false
+	// Already compressed; re-compressing only adds a header and CPU.
+	case media == "application/pdf",
+		media == "application/zip",
+		media == "application/gzip",
+		media == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return false
+	// An event stream is read a frame at a time by intermediaries that do not
+	// all handle a compressed one, and its frames are small enough that the
+	// saving would not pay for the risk.
+	case media == "text/event-stream":
+		return false
+	case strings.HasPrefix(media, "text/"),
+		strings.HasPrefix(media, "image/svg"):
+		return true
+	case strings.HasPrefix(media, "application/"):
+		// application/json, application/json+clicky, application/x-ndjson,
+		// application/yaml, application/javascript, ...
+		return !strings.HasPrefix(media, "application/octet-stream")
+	default:
+		return false
+	}
+}
+
+// compressingWriter gzips a response body when the caller asked for it.
+//
+// The decision is deferred to WriteHeader because that is the first moment the
+// Content-Type is known, and it is the type — not the handler — that decides
+// whether compressing is worth it.
+type compressingWriter struct {
+	http.ResponseWriter
+	gzip        *gzip.Writer
+	wroteHeader bool
+}
+
+func (c *compressingWriter) WriteHeader(status int) {
+	if c.wroteHeader {
+		return
+	}
+	c.wroteHeader = true
+	header := c.Header()
+
+	// 204 and 304 carry no body, and a handler that encoded its own body owns
+	// that decision.
+	noBody := status == http.StatusNoContent || status == http.StatusNotModified
+	if noBody || header.Get("Content-Encoding") != "" || !compressible(header.Get("Content-Type")) {
+		c.ResponseWriter.WriteHeader(status)
+		return
+	}
+
+	header.Set("Content-Encoding", "gzip")
+	// The compressed length is not known until the body has been written, and
+	// the uncompressed one would be a lie the client reads as truth.
+	header.Del("Content-Length")
+
+	writer := gzipWriters.Get().(*gzip.Writer)
+	writer.Reset(c.ResponseWriter)
+	c.gzip = writer
+	c.ResponseWriter.WriteHeader(status)
+}
+
+func (c *compressingWriter) Write(body []byte) (int, error) {
+	if !c.wroteHeader {
+		c.WriteHeader(http.StatusOK)
+	}
+	if c.gzip != nil {
+		return c.gzip.Write(body)
+	}
+	return c.ResponseWriter.Write(body)
+}
+
+// Flush keeps a stream a stream. An export writes rows as it reads them, and a
+// compressor that only drained at the end would turn that back into a wait.
+func (c *compressingWriter) Flush() {
+	if c.gzip != nil {
+		_ = c.gzip.Flush()
+	}
+	if flusher, ok := c.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// Unwrap lets http.ResponseController reach the writer underneath.
+func (c *compressingWriter) Unwrap() http.ResponseWriter { return c.ResponseWriter }
+
+// close returns the pooled writer and reports whether the gzip member was
+// finished. The error is returned rather than dropped because gzip.Close is
+// what writes the final deflate block, the CRC and the length: without it the
+// client holds a truncated member under a 200 it has every reason to trust.
+func (c *compressingWriter) close() error {
+	if c.gzip == nil {
+		return nil
+	}
+	err := c.gzip.Close()
+	// Reset clears the writer's sticky error along with the rest of its state,
+	// so a failed member does not poison the next response out of the pool.
+	c.gzip.Reset(io.Discard)
+	gzipWriters.Put(c.gzip)
+	c.gzip = nil
+	return err
+}
+
+// Compress wraps next so responses are gzipped for callers that accept it.
+//
+// The wrapper is closed after next returns and before the server writes any
+// declared trailer, so a trailing X-Truncated still lands after a complete
+// compressed body rather than inside one.
+func Compress(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Vary regardless of what this particular caller asked for: the same URL
+		// answers with and without compression, and a cache that does not know
+		// that will serve one to a client expecting the other. Only when it is
+		// not already declared, though — a second copy of the token is not a
+		// stronger instruction, it is a header caches and proxies have to
+		// normalise, and it makes the response differ from itself run to run.
+		if !variesOnAcceptEncoding(w.Header()) {
+			w.Header().Add("Vary", "Accept-Encoding")
+		}
+		if !acceptsGzip(r.Header.Get("Accept-Encoding")) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		writer := &compressingWriter{ResponseWriter: w}
+		defer func() {
+			// A panic already unwinding carries the better diagnosis, so it has
+			// to reach net/http's logger intact. Raising ErrAbortHandler over
+			// the top of it would substitute the one value net/http logs no
+			// stack for, and a real bug would leave nothing behind but a
+			// dropped connection. Re-panicking with the original value keeps
+			// the stack and still aborts, because net/http drops the connection
+			// on any unrecovered handler panic. Closing is best effort here,
+			// and cannot happen twice: re-panicking leaves the closure at once.
+			if panicked := recover(); panicked != nil {
+				_ = writer.close()
+				panic(panicked)
+			}
+			if writer.close() == nil {
+				return
+			}
+			// The status line and headers went out at WriteHeader, so the
+			// failure cannot be reported as a 5xx and the body already on the
+			// wire cannot be recalled. Breaking the connection is the only
+			// remaining way to say so: an HTTP/1.1 response ended without its
+			// terminating chunk is a transfer error that curl -f and browsers
+			// both surface, where a truncated gzip member under a 200 is read
+			// as a complete answer. Recording the error on the writer instead
+			// would be invisible: the handler has already returned and nothing
+			// is left to read it.
+			panic(http.ErrAbortHandler)
+		}()
+		next.ServeHTTP(writer, r)
+	})
+}
+
+// variesOnAcceptEncoding reports whether the response already declares that it
+// varies on Accept-Encoding. Field names are case-insensitive and a handler may
+// have packed several into one comma-separated value, so neither a string
+// compare nor a lookup of the whole value would find it.
+func variesOnAcceptEncoding(header http.Header) bool {
+	for _, value := range header.Values("Vary") {
+		for _, field := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), "Accept-Encoding") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// acceptsGzip reports whether the header offers gzip without refusing it — a
+// "gzip;q=0" is an explicit no rather than a yes with a weight.
+func acceptsGzip(accept string) bool {
+	for _, part := range strings.Split(accept, ",") {
+		fields := strings.Split(part, ";")
+		if strings.TrimSpace(strings.ToLower(fields[0])) != "gzip" {
+			continue
+		}
+		for _, parameter := range fields[1:] {
+			parameter = strings.ReplaceAll(strings.TrimSpace(strings.ToLower(parameter)), " ", "")
+			if parameter == "q=0" || strings.HasPrefix(parameter, "q=0.0") {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/rpc/compression.go
+++ b/rpc/compression.go
@@ -75,10 +75,14 @@ func (c *compressingWriter) WriteHeader(status int) {
 	c.wroteHeader = true
 	header := c.Header()
 
-	// 204 and 304 carry no body, and a handler that encoded its own body owns
-	// that decision.
-	noBody := status == http.StatusNoContent || status == http.StatusNotModified
-	if noBody || header.Get("Content-Encoding") != "" || !compressible(header.Get("Content-Type")) {
+	// 204 and 304 carry no body to compress. A 206 carries one, but it is a
+	// selected range of the representation and Content-Range describes it in the
+	// representation's own uncompressed bytes: compressing the range would leave
+	// the client reassembling the parts into a body that is neither. And a
+	// handler that encoded its own body owns that decision.
+	asIs := status == http.StatusNoContent || status == http.StatusNotModified ||
+		status == http.StatusPartialContent
+	if asIs || header.Get("Content-Encoding") != "" || !compressible(header.Get("Content-Type")) {
 		c.ResponseWriter.WriteHeader(status)
 		return
 	}
@@ -204,19 +208,34 @@ func variesOnAcceptEncoding(header http.Header) bool {
 
 // acceptsGzip reports whether the header offers gzip without refusing it — a
 // "gzip;q=0" is an explicit no rather than a yes with a weight.
+//
+// RFC 9110 gives "*" the codings not named anywhere else in the field, so a
+// caller sending it has offered gzip too and withholding compression from it
+// would be reading the wildcard as if it were absent. A gzip entry of its own is
+// the more specific rule and settles the question whichever way it points: with
+// "gzip;q=0, *" the client has named gzip precisely to refuse it.
 func acceptsGzip(accept string) bool {
+	wildcard := false
 	for _, part := range strings.Split(accept, ",") {
 		fields := strings.Split(part, ";")
-		if strings.TrimSpace(strings.ToLower(fields[0])) != "gzip" {
-			continue
+		switch strings.TrimSpace(strings.ToLower(fields[0])) {
+		case "gzip":
+			return !refusedWeight(fields[1:])
+		case "*":
+			wildcard = !refusedWeight(fields[1:])
 		}
-		for _, parameter := range fields[1:] {
-			parameter = strings.ReplaceAll(strings.TrimSpace(strings.ToLower(parameter)), " ", "")
-			if parameter == "q=0" || strings.HasPrefix(parameter, "q=0.0") {
-				return false
-			}
+	}
+	return wildcard
+}
+
+// refusedWeight reports whether a coding's parameters weight it to zero, which
+// is a refusal rather than a low preference.
+func refusedWeight(parameters []string) bool {
+	for _, parameter := range parameters {
+		parameter = strings.ReplaceAll(strings.TrimSpace(strings.ToLower(parameter)), " ", "")
+		if parameter == "q=0" || strings.HasPrefix(parameter, "q=0.0") {
+			return true
 		}
-		return true
 	}
 	return false
 }

--- a/rpc/compression_test.go
+++ b/rpc/compression_test.go
@@ -1,0 +1,355 @@
+package rpc
+
+import (
+	"compress/gzip"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCompressGzipsWhatTheCallerAccepts(t *testing.T) {
+	// Repetitive by design, like the rendered table format this exists for.
+	body := strings.Repeat(`{"kind":"text","plain":"idle","text":"idle"},`, 500)
+
+	for _, tc := range []struct {
+		name        string
+		accept      string
+		contentType string
+		wantGzip    bool
+	}{
+		{"json is compressed", "gzip", "application/json", true},
+		{"the clicky envelope is compressed", "gzip, deflate", "application/json+clicky", true},
+		{"ndjson is compressed", "gzip", "application/x-ndjson", true},
+		{"csv is compressed", "gzip", "text/csv; charset=utf-8", true},
+		{"a caller that does not ask is not given", "", "application/json", false},
+		{"gzip;q=0 is a refusal", "gzip;q=0", "application/json", false},
+		{"a pdf is already compressed", "gzip", "application/pdf", false},
+		{"a spreadsheet is already compressed", "gzip", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", false},
+		{"an event stream is left alone", "gzip", "text/event-stream", false},
+		// Go sniffs an unset type from the first bytes written; compressing
+		// would make those bytes the gzip header and relabel the response.
+		{"an unset content type is left alone", "gzip", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tc.contentType != "" {
+					w.Header().Set("Content-Type", tc.contentType)
+				}
+				_, _ = io.WriteString(w, body)
+			}))
+
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything", nil)
+			if tc.accept != "" {
+				request.Header.Set("Accept-Encoding", tc.accept)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, request)
+
+			encoding := rec.Header().Get("Content-Encoding")
+			if tc.wantGzip != (encoding == "gzip") {
+				t.Fatalf("Content-Encoding=%q for %s, wantGzip=%v", encoding, tc.contentType, tc.wantGzip)
+			}
+			// The same URL answers differently per Accept-Encoding, so a cache
+			// that ignores it would serve one client the other's response.
+			if vary := rec.Header().Get("Vary"); !strings.Contains(vary, "Accept-Encoding") {
+				t.Fatalf("Vary=%q, want it to name Accept-Encoding", vary)
+			}
+
+			if !tc.wantGzip {
+				if got := rec.Body.String(); got != body {
+					t.Fatalf("uncompressed body changed: %d bytes, want %d", len(got), len(body))
+				}
+				return
+			}
+			if rec.Header().Get("Content-Length") != "" {
+				t.Fatal("Content-Length survived compression, so it describes the wrong body")
+			}
+			reader, err := gzip.NewReader(rec.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(decoded) != body {
+				t.Fatalf("round trip changed the body: %d bytes, want %d", len(decoded), len(body))
+			}
+			if rec.Body.Len() >= len(body) {
+				t.Fatalf("compressed to %d bytes from %d, which is no saving", rec.Body.Len(), len(body))
+			}
+		})
+	}
+}
+
+// An export writes rows as it reads them. If compressing turned that into one
+// buffer that only drained at the end, a long export would look like a hang.
+//
+// The handler here does the flushing, so what this pins down is that the
+// wrapper forwards a Flush instead of swallowing it — not that any real
+// endpoint flushes. Nothing fails here if a streaming handler forgets to.
+func TestCompressPassesFlushThrough(t *testing.T) {
+	flushed := make(chan struct{}, 1)
+	handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = io.WriteString(w, `{"id":1}`+"\n")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("compressing writer is not an http.Flusher")
+			return
+		}
+		flusher.Flush()
+		flushed <- struct{}{}
+		_, _ = io.WriteString(w, `{"id":2}`+"\n")
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything?scope=all", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, request)
+
+	select {
+	case <-flushed:
+	default:
+		t.Fatal("handler never reached its flush")
+	}
+	reader, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"id":1}` + "\n" + `{"id":2}` + "\n"; string(decoded) != want {
+		t.Fatalf("streamed body = %q, want %q", decoded, want)
+	}
+}
+
+// A 204 has no body to compress, and declaring an encoding for one would
+// describe content that does not exist.
+func TestCompressLeavesEmptyResponsesAlone(t *testing.T) {
+	handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	request := httptest.NewRequest(http.MethodOptions, "/api/v1/profile/anything", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, request)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if encoding := rec.Header().Get("Content-Encoding"); encoding != "" {
+		t.Fatalf("Content-Encoding=%q on a bodiless response", encoding)
+	}
+}
+
+// Accept-Encoding must be named in Vary exactly once. A second copy is not a
+// stronger instruction — it is a header every cache in the path has to
+// normalise, and one that makes an otherwise identical response differ.
+func TestCompressDeclaresVaryOnce(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		existing []string
+		want     []string
+	}{
+		{"nothing declared yet", nil, []string{"Accept-Encoding"}},
+		{"already declared", []string{"Accept-Encoding"}, []string{"Accept-Encoding"}},
+		// Field names are case-insensitive, so a lowercase token is the same
+		// declaration and adding another would only duplicate it.
+		{"declared in another case", []string{"accept-encoding"}, []string{"accept-encoding"}},
+		// A handler is free to pack several field names into one value.
+		{"declared inside a list", []string{"Origin, accept-encoding"}, []string{"Origin, accept-encoding"}},
+		{"declared as separate values", []string{"Origin", "Accept-Encoding"}, []string{"Origin", "Accept-Encoding"}},
+		// Some other field varying the response says nothing about encoding.
+		{"a different field is declared", []string{"Origin"}, []string{"Origin", "Accept-Encoding"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"rows":[]}`)
+			}))
+
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything", nil)
+			request.Header.Set("Accept-Encoding", "gzip")
+			rec := httptest.NewRecorder()
+			for _, value := range tc.existing {
+				rec.Header().Add("Vary", value)
+			}
+			handler.ServeHTTP(rec, request)
+
+			got := rec.Header().Values("Vary")
+			if strings.Join(got, "|") != strings.Join(tc.want, "|") {
+				t.Fatalf("Vary=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// flakyResponseWriter is a connection that dies on command. failNow is flipped
+// by the handler once it has written everything it means to, which leaves the
+// gzip footer — written when the wrapper is closed — as the only thing left to
+// fail.
+type flakyResponseWriter struct {
+	*httptest.ResponseRecorder
+	failNow bool
+}
+
+func (f *flakyResponseWriter) Write(body []byte) (int, error) {
+	if f.failNow {
+		return 0, errors.New("write: connection reset by peer")
+	}
+	return f.ResponseRecorder.Write(body)
+}
+
+// A gzip member whose footer never made it is truncated, and the status line
+// promising a complete body left the server long before that could be known.
+// Aborting the connection is the only signal a client can act on, so the
+// middleware must not swallow the error and return a well-formed-looking 200.
+func TestCompressAbortsWhenTheGzipFooterFails(t *testing.T) {
+	writer := &flakyResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, strings.Repeat(`{"kind":"text","plain":"idle"},`, 200))
+		writer.failNow = true
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+
+	defer func() {
+		// http.ErrAbortHandler specifically: net/http drops the connection
+		// without a terminating chunk and without logging a stack trace, so
+		// the client sees a transfer error rather than a short body.
+		if recovered := recover(); recovered != http.ErrAbortHandler {
+			t.Fatalf("recovered %v, want http.ErrAbortHandler", recovered)
+		}
+	}()
+	handler.ServeHTTP(writer, request)
+	t.Fatal("a failed gzip Close was swallowed, leaving a truncated body under a 200")
+}
+
+// The nastiest case for the abort above: a handler panics with a real bug and
+// the connection it was writing to is gone, so closing the member fails too.
+// Raising ErrAbortHandler over the top of that would discard the bug — it is
+// the one value net/http logs no stack for — and leave nothing to debug.
+func TestCompressKeepsAnInFlightPanic(t *testing.T) {
+	sentinel := errors.New("the handler's own bug")
+	writer := &flakyResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, strings.Repeat(`{"kind":"text","plain":"idle"},`, 200))
+		writer.failNow = true
+		panic(sentinel)
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+
+	defer func() {
+		if recovered := recover(); recovered != sentinel { //nolint:errorlint // the panic value must be the same one, not merely a match
+			t.Fatalf("recovered %v, want the handler's own panic value", recovered)
+		}
+	}()
+	handler.ServeHTTP(writer, request)
+	t.Fatal("the handler's panic never made it out of the middleware")
+}
+
+// Re-panicking with the handler's own value has to leave the connection in the
+// same state ErrAbortHandler would: net/http aborts on any unrecovered handler
+// panic, so a client that already has the headers must see the response end
+// without its terminating chunk rather than read a short body as complete.
+func TestCompressPanicStillAbortsTheConnection(t *testing.T) {
+	server := httptest.NewUnstartedServer(Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = io.WriteString(w, strings.Repeat(`{"id":1}`+"\n", 200))
+		// Puts the headers and some body on the wire, so the client is left
+		// mid-response when the panic takes the connection out from under it.
+		w.(http.Flusher).Flush()
+		panic(errors.New("the handler's own bug"))
+	})))
+	// The panic is the point of the test; its stack trace is not the test's
+	// output to own.
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.Start()
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Accept-Encoding", "gzip")
+	response, err := server.Client().Do(request)
+	if err != nil {
+		// The connection died before the headers arrived, which is the same
+		// answer told earlier.
+		return
+	}
+	defer response.Body.Close()
+
+	if _, err := io.ReadAll(response.Body); err == nil {
+		t.Fatal("the body read cleanly to EOF, so the client took a panicked response as complete")
+	}
+}
+
+// The wrapper is closed after the handler returns but before net/http writes
+// the trailers it declared. Closing later would put the gzip footer after the
+// trailer — or never write it at all — and closing it inside the handler would
+// end the member before the trailer was known. This runs over a real server
+// because httptest.NewRecorder has no trailer or chunked framing to get wrong.
+func TestCompressDeliversTrailerAfterTheCompressedBody(t *testing.T) {
+	body := strings.Repeat(`{"kind":"text","plain":"idle","text":"idle"},`, 500)
+	server := httptest.NewServer(Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("Trailer", "X-Truncated")
+		_, _ = io.WriteString(w, body)
+		// Only knowable once the rows have been written, which is the whole
+		// reason it is a trailer and not a header.
+		w.Header().Set("X-Truncated", "true")
+	})))
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Asking explicitly stops the transport from decompressing for us, so the
+	// bytes asserted below are the ones that went over the wire.
+	request.Header.Set("Accept-Encoding", "gzip")
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if encoding := response.Header.Get("Content-Encoding"); encoding != "gzip" {
+		t.Fatalf("Content-Encoding=%q, want gzip", encoding)
+	}
+	reader, err := gzip.NewReader(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := io.ReadAll(reader)
+	if err != nil {
+		// An unexpected EOF here is the footer landing after the trailer, or
+		// not landing at all.
+		t.Fatalf("reading the compressed body: %v", err)
+	}
+	if string(decoded) != body {
+		t.Fatalf("round trip changed the body: %d bytes, want %d", len(decoded), len(body))
+	}
+	// Trailers are only populated once the body has been read to EOF, so this
+	// value existing proves it arrived after a complete gzip member.
+	if _, err := io.ReadAll(response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if truncated := response.Trailer.Get("X-Truncated"); truncated != "true" {
+		t.Fatalf("X-Truncated=%q after reading the body, want true", truncated)
+	}
+}

--- a/rpc/compression_test.go
+++ b/rpc/compression_test.go
@@ -1,12 +1,14 @@
 package rpc
 
 import (
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -93,40 +95,63 @@ func TestCompressGzipsWhatTheCallerAccepts(t *testing.T) {
 // wrapper forwards a Flush instead of swallowing it — not that any real
 // endpoint flushes. Nothing fails here if a streaming handler forgets to.
 func TestCompressPassesFlushThrough(t *testing.T) {
-	flushed := make(chan struct{}, 1)
+	first, second := `{"id":1}`+"\n", `{"id":2}`+"\n"
+	rec := httptest.NewRecorder()
+	// What had reached the recorder by the time the handler returned from its
+	// flush — the bytes a client would already have been able to read. Asserting
+	// on the finished response instead would prove nothing: a wrapper that never
+	// flushed at all still produces the whole body when it is closed.
+	var earlyBytes []byte
+	flushed := false
+
 	handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/x-ndjson")
-		_, _ = io.WriteString(w, `{"id":1}`+"\n")
+		_, _ = io.WriteString(w, first)
 		flusher, ok := w.(http.Flusher)
 		if !ok {
 			t.Error("compressing writer is not an http.Flusher")
 			return
 		}
 		flusher.Flush()
-		flushed <- struct{}{}
-		_, _ = io.WriteString(w, `{"id":2}`+"\n")
+		flushed = true
+		earlyBytes = append([]byte(nil), rec.Body.Bytes()...)
+		_, _ = io.WriteString(w, second)
 	}))
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything?scope=all", nil)
 	request.Header.Set("Accept-Encoding", "gzip")
-	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, request)
 
-	select {
-	case <-flushed:
-	default:
+	if !flushed {
 		t.Fatal("handler never reached its flush")
 	}
+	// A gzip header alone is what a swallowed Flush leaves behind: the row is
+	// still inside the compressor's window, so it has to be decoded rather than
+	// merely counted.
+	early, err := gzip.NewReader(bytes.NewReader(earlyBytes))
+	if err != nil {
+		t.Fatalf("nothing decodable had left the wrapper by the flush (%d bytes): %v", len(earlyBytes), err)
+	}
+	decoded, err := io.ReadAll(early)
+	// The member is deliberately unfinished here — the handler had not returned
+	// — so the stream ending early is expected and only the bytes matter.
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatal(err)
+	}
+	if string(decoded) != first {
+		t.Fatalf("flushed bytes decoded to %q, want the first row %q", decoded, first)
+	}
+
 	reader, err := gzip.NewReader(rec.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	decoded, err := io.ReadAll(reader)
+	whole, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := `{"id":1}` + "\n" + `{"id":2}` + "\n"; string(decoded) != want {
-		t.Fatalf("streamed body = %q, want %q", decoded, want)
+	if want := first + second; string(whole) != want {
+		t.Fatalf("streamed body = %q, want %q", whole, want)
 	}
 }
 
@@ -147,6 +172,94 @@ func TestCompressLeavesEmptyResponsesAlone(t *testing.T) {
 	}
 	if encoding := rec.Header().Get("Content-Encoding"); encoding != "" {
 		t.Fatalf("Content-Encoding=%q on a bodiless response", encoding)
+	}
+}
+
+// A 206 answers a range request, and Content-Range counts in the bytes of the
+// uncompressed representation. Compressing the selected range would leave those
+// two describing different things, and a client stitching the parts back
+// together would assemble a body that is neither.
+func TestCompressLeavesAPartialRangeAlone(t *testing.T) {
+	body := strings.Repeat(`{"kind":"text","plain":"idle","text":"idle"},`, 200)
+	handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Range", "bytes 0-"+strconv.Itoa(len(body)-1)+"/"+strconv.Itoa(len(body)*2))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = io.WriteString(w, body)
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+	request.Header.Set("Range", "bytes=0-"+strconv.Itoa(len(body)-1))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, request)
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if encoding := rec.Header().Get("Content-Encoding"); encoding != "" {
+		t.Fatalf("Content-Encoding=%q on a partial range", encoding)
+	}
+	if got := rec.Body.String(); got != body {
+		t.Fatalf("the range was re-encoded: %d bytes, want the %d Content-Range describes", len(got), len(body))
+	}
+}
+
+// "*" is the wildcard for every coding the field does not name, so a caller
+// sending it has offered gzip. An entry for gzip itself is more specific and
+// settles it either way.
+func TestCompressHonoursTheAcceptEncodingWildcard(t *testing.T) {
+	body := strings.Repeat(`{"kind":"text","plain":"idle","text":"idle"},`, 200)
+
+	for _, tc := range []struct {
+		name     string
+		accept   string
+		wantGzip bool
+	}{
+		{"a bare wildcard offers gzip", "*", true},
+		{"a weighted wildcard offers it too", "*;q=1", true},
+		{"a wildcard with other codings", "br, *", true},
+		{"a refused wildcard is a refusal", "*;q=0", false},
+		{"a wildcard refused with a decimal weight", "identity, *;q=0.0", false},
+		// The specific entry wins over the wildcard, whichever way it points.
+		{"gzip named to be refused beside a wildcard", "gzip;q=0, *", false},
+		{"gzip named to be accepted beside a refused wildcard", "*;q=0, gzip", true},
+		{"a wildcard the client only weighted lower", "*;q=0.5", true},
+		// Naming another coding says nothing about gzip; only "*" does.
+		{"another coding on its own", "br", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Compress(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, body)
+			}))
+
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/profile/anything", nil)
+			request.Header.Set("Accept-Encoding", tc.accept)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, request)
+
+			if gzipped := rec.Header().Get("Content-Encoding") == "gzip"; gzipped != tc.wantGzip {
+				t.Fatalf("Accept-Encoding: %s gzipped=%v, want %v", tc.accept, gzipped, tc.wantGzip)
+			}
+			if !tc.wantGzip {
+				if got := rec.Body.String(); got != body {
+					t.Fatalf("uncompressed body changed: %d bytes, want %d", len(got), len(body))
+				}
+				return
+			}
+			reader, err := gzip.NewReader(rec.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(decoded) != body {
+				t.Fatalf("round trip changed the body: %d bytes, want %d", len(decoded), len(body))
+			}
+		})
 	}
 }
 

--- a/rpc/converter.go
+++ b/rpc/converter.go
@@ -126,7 +126,7 @@ func (c *Converter) ConvertCommand(cmd *cobra.Command) (*RPCOperation, error) {
 			// generated form field, and a client that posts the pre-filled value
 			// back sends a one-element slice containing "[]". A repeatable flag
 			// with no default simply has none.
-			if flag.DefValue != "" && !(isSliceFlag(flag) && flag.DefValue == "[]") {
+			if flag.DefValue != "" && (!isSliceFlag(flag) || flag.DefValue != "[]") {
 				prop.Default = flag.DefValue
 				param.Default = flag.DefValue
 			}

--- a/rpc/converter.go
+++ b/rpc/converter.go
@@ -180,6 +180,7 @@ func (c *Converter) ConvertCommand(cmd *cobra.Command) (*RPCOperation, error) {
 		operation.Clicky.Aliases = append([]string(nil), meta.Aliases...)
 		operation.Clicky.Admin = meta.Admin
 		operation.Clicky.Icon = meta.Icon
+		operation.Clicky.Path = meta.Path
 		operation.Clicky.Title = meta.Title
 		operation.Clicky.Verb = meta.Verb
 		operation.Clicky.Scope = meta.Scope

--- a/rpc/converter.go
+++ b/rpc/converter.go
@@ -284,6 +284,13 @@ func (c *Converter) shouldConvertCommand(cmd *cobra.Command) bool {
 	if cmd.Parent() == nil || (cmd.Run == nil && cmd.RunE == nil) {
 		return false
 	}
+	// A command the author marked local-only administers the process rather than
+	// serving a resource. Publishing the CLI published these too, so an
+	// unauthenticated request could run a schema migration or start a nested
+	// server.
+	if clicky.IsLocalOnly(cmd) {
+		return false
+	}
 	// Skip an entity's `list` subcommand when its parent entity-root is itself
 	// runnable as a list shortcut (parent has RunE, an entity annotation, and
 	// no operation verb). Both produce the same GET /api/v1/<entity>, and the
@@ -330,33 +337,58 @@ func (c *Converter) inferHTTPMethod(cmd *cobra.Command, cmdPath string) string {
 		if meta.Verb == "" && meta.Entity != "" {
 			return "GET"
 		}
+		// An annotated operation states its verb, so use it rather than guessing
+		// from the command path. The guess below matches CRUD keywords anywhere
+		// in that path, which silently misreads any entity whose *name* contains
+		// one: "target update" contains "get", so it inferred GET and collided
+		// with the entity's own list route. "budget delete" and "asset set" fail
+		// the same way.
+		if method := methodForVerb(meta.Verb); method != "" {
+			return method
+		}
 	}
 
-	cmdLower := strings.ToLower(cmdPath)
+	// Match the last segment — the verb — rather than searching the whole path.
+	// A command path carries its parents' names, and matching anywhere in it
+	// reads a CRUD keyword out of a noun: "target scan" contains "get", so the
+	// action that starts a scan was published as a safe, prefetchable GET.
+	verb := strings.ToLower(cmdPath)
+	if index := strings.LastIndex(verb, " "); index != -1 {
+		verb = verb[index+1:]
+	}
 
-	// Check for common CRUD patterns
-	if strings.Contains(cmdLower, "get") || strings.Contains(cmdLower, "list") ||
-		strings.Contains(cmdLower, "show") || strings.Contains(cmdLower, "describe") {
+	switch verb {
+	case "get", "list", "show", "describe":
 		return "GET"
-	}
-
-	if strings.Contains(cmdLower, "create") || strings.Contains(cmdLower, "add") ||
-		strings.Contains(cmdLower, "new") {
+	case "create", "add", "new":
 		return "POST"
-	}
-
-	if strings.Contains(cmdLower, "update") || strings.Contains(cmdLower, "edit") ||
-		strings.Contains(cmdLower, "modify") || strings.Contains(cmdLower, "set") {
+	case "update", "edit", "modify", "set":
 		return "PUT"
-	}
-
-	if strings.Contains(cmdLower, "delete") || strings.Contains(cmdLower, "remove") ||
-		strings.Contains(cmdLower, "destroy") {
+	case "delete", "remove", "destroy":
 		return "DELETE"
 	}
 
-	// Default to configured method
+	// Anything else does something rather than returning something, so the
+	// configured default (POST) is the safe reading.
 	return c.config.DefaultMethod
+}
+
+// methodForVerb maps an entity operation verb to its HTTP method. An empty
+// result means the verb is not one of the CRUD four — a custom action, say —
+// and the caller should fall back to inferring one.
+func methodForVerb(verb string) string {
+	switch strings.ToLower(verb) {
+	case "list", "get":
+		return "GET"
+	case "create":
+		return "POST"
+	case "update":
+		return "PUT"
+	case "delete":
+		return "DELETE"
+	default:
+		return ""
+	}
 }
 
 // generateRESTPath generates a REST API path from command hierarchy

--- a/rpc/converter_method_test.go
+++ b/rpc/converter_method_test.go
@@ -1,0 +1,50 @@
+package rpc
+
+import "testing"
+
+// An entity operation states its verb. Before this was consulted, the method was
+// guessed by looking for CRUD keywords anywhere in the command path, so an
+// entity whose name happened to contain one was misrouted: "target" contains
+// "get", which made `target update` a GET on the collection path and shadowed
+// the entity's own list route.
+func TestMethodForVerb(t *testing.T) {
+	for verb, want := range map[string]string{
+		"list":   "GET",
+		"get":    "GET",
+		"create": "POST",
+		"update": "PUT",
+		"delete": "DELETE",
+		"Update": "PUT",
+		"":       "",
+		"cancel": "", // a custom action falls back to inference
+	} {
+		if got := methodForVerb(verb); got != want {
+			t.Errorf("methodForVerb(%q) = %q, want %q", verb, got, want)
+		}
+	}
+}
+
+// The guess for unannotated commands matches the verb — the last segment —
+// rather than searching the whole path. Searching the whole path read a CRUD
+// keyword out of a parent's name: "target scan" contains "get", which published
+// an action that starts a scan as a safe, prefetchable GET.
+func TestInferHTTPMethodMatchesTheVerbNotTheWholePath(t *testing.T) {
+	converter := &Converter{config: &Config{DefaultMethod: "POST"}}
+
+	for path, want := range map[string]string{
+		"target get":     "GET",
+		"target list":    "GET",
+		"target update":  "PUT",
+		"target delete":  "DELETE",
+		"target scan":    "POST", // an action, not a read
+		"target refresh": "POST",
+		"budget delete":  "DELETE",
+		"asset set":      "PUT",
+		"profile create": "POST",
+		"engine install": "POST",
+	} {
+		if got := converter.inferHTTPMethod(nil, path); got != want {
+			t.Errorf("inferHTTPMethod(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/rpc/dynamic_family_test.go
+++ b/rpc/dynamic_family_test.go
@@ -1,0 +1,233 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/flanksource/clicky/api"
+	"github.com/flanksource/clicky/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// profileSpec is the shape a consumer whose entities are database rows resolves:
+// a name that only exists because something created it a moment ago.
+func profileSpec(name string) entity.DynamicEntitySpec {
+	return entity.DynamicEntitySpec{
+		Name:     name,
+		Title:    "Profile " + name,
+		Icon:     "database",
+		ListType: reflect.TypeOf(struct{}{}),
+		ItemType: reflect.TypeOf(struct {
+			Profile string `json:"profile"`
+		}{}),
+		List: func(_ context.Context, flags map[string]string, _ []string) (any, error) {
+			return []map[string]any{{"profile": name, "env": flags["env"]}}, nil
+		},
+		Filters: []entity.DynamicFilter{{
+			Key:   "env",
+			Label: "Environment",
+			Options: func(_ context.Context, _ map[string]string, _ string, _ int) (map[string]api.Textable, int, error) {
+				return map[string]api.Textable{"prod": api.Text{Content: "Production"}}, 1, nil
+			},
+		}},
+	}
+}
+
+// profileFamily resolves only the names it was given, so an unknown one is the
+// 404 the contract requires rather than an empty spec.
+func profileFamily(names ...string) entity.DynamicEntityFamily {
+	known := make(map[string]bool, len(names))
+	for _, name := range names {
+		known[name] = true
+	}
+	return entity.DynamicEntityFamily{
+		Name:   "profile",
+		Parent: "reporting",
+		Resolve: func(_ context.Context, name string) (entity.DynamicEntitySpec, error) {
+			if !known[name] {
+				return entity.DynamicEntitySpec{}, entity.UnknownDynamicEntity("profile", name)
+			}
+			return profileSpec(name), nil
+		},
+		List: func(_ context.Context) ([]entity.DynamicEntitySpec, error) {
+			specs := make([]entity.DynamicEntitySpec, 0, len(names))
+			for _, name := range names {
+				specs = append(specs, profileSpec(name))
+			}
+			return specs, nil
+		},
+	}
+}
+
+// familyServer has no operation registered for the family's path: an instance
+// that did not exist at startup could not have one.
+func familyServer() *SwaggerServer {
+	service := &RPCService{Name: "api", Operations: []RPCOperation{{
+		Name: "config list", Path: "/api/v1/config", Method: "GET",
+		DataFunc: func(map[string]string, []string) (any, error) { return []map[string]any{}, nil },
+	}}}
+	return &SwaggerServer{
+		config:       &ServeConfig{Executor: &ExecutorConfig{Enabled: true}},
+		converterCfg: &Config{PathPrefix: "/api/v1"},
+		executor:     NewCommandExecutor(service, &ExecutorConfig{Enabled: true, SkipPreRun: true, PathPrefix: "/api/v1"}),
+	}
+}
+
+func TestDynamicFamily_ServesAnInstanceThatHasNoRegisteredOperation(t *testing.T) {
+	registerTestFamily(t, profileFamily("daily"))
+	server := familyServer()
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/profile/daily?env=prod", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	var rows []map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&rows))
+	assert.Equal(t, []map[string]any{{"profile": "daily", "env": "prod"}}, rows,
+		"the filter value reaches the instance even though no declared parameter carries it")
+}
+
+func TestDynamicFamily_UnknownNameIsANotFoundInTheSharedErrorShape(t *testing.T) {
+	registerTestFamily(t, profileFamily("daily"))
+	server := familyServer()
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/profile/missing", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	var body entity.StatusError
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	assert.Equal(t, "not_found", body.Code)
+	assert.Equal(t, `no profile named "missing"`, body.Message)
+	assert.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestDynamicFamily_LookupComesFromTheResolvedSpec(t *testing.T) {
+	registerTestFamily(t, profileFamily("daily"))
+	server := familyServer()
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/profile/daily?__lookup=filters", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "application/json+clicky", res.Header.Get("Content-Type"))
+
+	var body struct {
+		Filters map[string]struct {
+			Label   string                    `json:"label"`
+			Options map[string]map[string]any `json:"options"`
+		} `json:"filters"`
+	}
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	require.Contains(t, body.Filters, "env")
+	assert.Equal(t, "Environment", body.Filters["env"].Label)
+	assert.Contains(t, body.Filters["env"].Options, "prod")
+}
+
+func TestDynamicFamily_PagedInstanceStreamsThroughTheExportContract(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(2)}
+	family := profileFamily("daily")
+	family.Paged = func(_ context.Context, spec entity.DynamicEntitySpec, _ entity.PageRequest, _ map[string]string) (entity.PageResponse, error) {
+		require.Equal(t, "daily", spec.Name)
+		return entity.PageResponse{Rows: source, Mode: entity.ModeStreaming}, nil
+	}
+	registerTestFamily(t, family)
+	server := familyServer()
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/profile/daily?format=csv&_download", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "text/csv; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Contains(t, res.Header.Get("Content-Disposition"), `filename="daily.csv"`,
+		"the download is named after the instance, not the family")
+	assert.Equal(t, "\xEF\xBB\xBFN\nrow-0\nrow-1\n", rec.Body.String())
+	assert.Equal(t, 1, source.closes)
+}
+
+// One pattern set serves every instance the family will ever have: registering
+// per instance is impossible, because the instances do not exist yet.
+func TestDynamicFamily_RegistersOneRouteForTheWholeFamily(t *testing.T) {
+	registerTestFamily(t, profileFamily("daily", "weekly"))
+	server := familyServer()
+
+	mux := http.NewServeMux()
+	server.registerExecutionRoutes(mux)
+
+	for _, method := range []string{"GET", "POST", "OPTIONS", "HEAD"} {
+		_, pattern := mux.Handler(httptest.NewRequest(method, "/api/v1/profile/daily", nil))
+		assert.Equal(t, method+" /api/v1/profile/{name}", wildcardPattern(method, pattern),
+			"%s must resolve through the family's single pattern", method)
+	}
+
+	for _, name := range []string{"daily", "weekly"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", "/api/v1/profile/"+name, nil))
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode, "%s resolves through the same route", name)
+	}
+}
+
+// A HEAD is served by the GET pattern under Go 1.22's ServeMux, so it reports
+// the GET pattern rather than one of its own.
+func wildcardPattern(method, pattern string) string {
+	if method == "HEAD" && pattern == "GET /api/v1/profile/{name}" {
+		return "HEAD /api/v1/profile/{name}"
+	}
+	return pattern
+}
+
+func TestDynamicFamily_SpecDescribesTheInstancesThatExistNow(t *testing.T) {
+	server := NewSwaggerServer(
+		&ServeConfig{Version: "1.0.0", Executor: &ExecutorConfig{Enabled: true, PathPrefix: "/api/v1"}},
+		createTestRootCommand(),
+		&OpenAPIConfig{Title: "Test API", Version: "1.0.0"},
+	)
+
+	rec := httptest.NewRecorder()
+	server.serveSpec(rec, httptest.NewRequest("GET", "/api/openapi.json", nil), specFormatJSON, "application/json")
+	require.NotContains(t, rec.Body.String(), "/api/v1/profile/daily", "nothing is registered yet")
+
+	registerTestFamily(t, profileFamily("daily"))
+
+	rec = httptest.NewRecorder()
+	server.serveSpec(rec, httptest.NewRequest("GET", "/api/openapi.json", nil), specFormatJSON, "application/json")
+
+	var spec OpenAPISpec
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &spec))
+	require.Contains(t, spec.Paths, "/api/v1/profile/daily",
+		"an entity created after startup has to appear without the cache being invalidated")
+	assert.Contains(t, spec.Paths["/api/v1/profile/daily"], "get")
+
+	require.NotNil(t, spec.Clicky)
+	var found *ClickySurface
+	for index := range spec.Clicky.Surfaces {
+		if spec.Clicky.Surfaces[index].Entity == "daily" {
+			found = &spec.Clicky.Surfaces[index]
+		}
+	}
+	require.NotNil(t, found, "the instance carries a UI surface")
+	assert.Equal(t, "daily", found.Key)
+	assert.Equal(t, "Profile daily", found.Title)
+	assert.Equal(t, "reporting", found.Parent)
+	assert.Equal(t, "database", found.Icon)
+}
+
+// A family must not swallow a path that is not one of its instances.
+func TestDynamicFamily_LeavesUnrelatedPathsAlone(t *testing.T) {
+	registerTestFamily(t, profileFamily("daily"))
+	server := familyServer()
+
+	for _, target := range []string{"/api/v1/config", "/api/v1/profile", "/api/v1/other/daily", "/api/v1/profile/daily/extra"} {
+		_, _, matched := server.matchDynamicFamily(target)
+		assert.False(t, matched, "%s is not a family instance", target)
+	}
+}

--- a/rpc/dynamic_family_test.go
+++ b/rpc/dynamic_family_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -32,7 +33,7 @@ func profileSpec(name string) entity.DynamicEntitySpec {
 			Key:   "env",
 			Label: "Environment",
 			Options: func(_ context.Context, _ map[string]string, _ string, _ int) (map[string]api.Textable, int, error) {
-				return map[string]api.Textable{"prod": api.Text{Content: "Production"}}, 1, nil
+				return map[string]api.Textable{"prod": api.Text{}.Append("Production")}, 1, nil
 			},
 		}},
 	}
@@ -230,4 +231,78 @@ func TestDynamicFamily_LeavesUnrelatedPathsAlone(t *testing.T) {
 		_, _, matched := server.matchDynamicFamily(target)
 		assert.False(t, matched, "%s is not a family instance", target)
 	}
+}
+
+// The family matcher compares only the first segment, so a family named after a
+// registered entity would capture that entity's item route. The registered
+// operation has to win, or registering a family makes an existing entity
+// unreachable.
+func TestDynamicFamily_DoesNotCaptureARegisteredOperationsPath(t *testing.T) {
+	family := profileFamily("daily")
+	family.Name = "config"
+	registerTestFamily(t, family)
+
+	service := &RPCService{Name: "api", Operations: []RPCOperation{{
+		Name: "config get", Path: "/api/v1/config/{id}", Method: "GET",
+		DataFunc: func(flags map[string]string, args []string) (any, error) {
+			return map[string]any{"served_by": "operation"}, nil
+		},
+	}}}
+	server := &SwaggerServer{
+		config:       &ServeConfig{Executor: &ExecutorConfig{Enabled: true}},
+		converterCfg: &Config{PathPrefix: "/api/v1"},
+		executor:     NewCommandExecutor(service, &ExecutorConfig{Enabled: true, SkipPreRun: true, PathPrefix: "/api/v1"}),
+	}
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/config/daily", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Contains(t, rec.Body.String(), "operation",
+		"the registered operation serves its own path, not the colliding family")
+	assert.NotContains(t, rec.Body.String(), "profile")
+}
+
+// A family instance is read-only, so a POST must not quietly run its List and
+// answer 200 with rows.
+func TestDynamicFamily_RefusesAWriteMethod(t *testing.T) {
+	registerTestFamily(t, profileFamily("daily"))
+	server := familyServer()
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("POST", "/api/v1/profile/daily", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	assert.Equal(t, "GET, HEAD", res.Header.Get("Allow"))
+
+	var body entity.StatusError
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	assert.Equal(t, "method_not_allowed", body.Code)
+}
+
+// A family whose store is unreachable must not remove every other path from the
+// document: a broken family costs its own instances, nothing more.
+func TestDynamicFamily_ListFailureLeavesTheRestOfTheDocument(t *testing.T) {
+	family := profileFamily("daily")
+	family.List = func(context.Context) ([]entity.DynamicEntitySpec, error) {
+		return nil, errors.New("backing store is unreachable")
+	}
+	registerTestFamily(t, family)
+
+	server := NewSwaggerServer(
+		&ServeConfig{Version: "1.0.0", Executor: &ExecutorConfig{Enabled: true, PathPrefix: "/api/v1"}},
+		createTestRootCommand(),
+		&OpenAPIConfig{Title: "Test API", Version: "1.0.0"},
+	)
+
+	rec := httptest.NewRecorder()
+	server.serveSpec(rec, httptest.NewRequest("GET", "/api/openapi.json", nil), specFormatJSON, "application/json")
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	var spec OpenAPISpec
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &spec))
+	assert.NotEmpty(t, spec.Paths, "the static operations are still described")
+	assert.NotContains(t, spec.Paths, "/api/v1/profile/daily")
 }

--- a/rpc/executor.go
+++ b/rpc/executor.go
@@ -393,9 +393,23 @@ func convertValueToString(value interface{}) string {
 		return ""
 	case []interface{}:
 		return csvRecord(v)
+	case map[string]interface{}:
+		return jsonRecord(v)
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+// jsonRecord encodes a nested object as JSON. For the same reason as csvRecord:
+// without it a body's {"a":1} reaches the handler as Go's bracket form `map[a:1]`,
+// which is not valid JSON and cannot be decoded back into anything. A flag value
+// is a string, so JSON is the only lossless encoding available here.
+func jsonRecord(value map[string]interface{}) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return string(encoded)
 }
 
 // csvRecord encodes a JSON array the way the CLI encodes a repeatable flag, so

--- a/rpc/executor_value_test.go
+++ b/rpc/executor_value_test.go
@@ -1,0 +1,42 @@
+package rpc
+
+import "testing"
+
+// A flag value is a string, so every JSON type has to survive being encoded
+// into one and decoded back by the handler. Arrays already did; nested objects
+// fell through to Go's `map[a:1]` bracket form, which is not valid JSON and
+// leaves the handler nothing it can parse.
+func TestConvertValueToStringEncodesNestedObjectsAsJSON(t *testing.T) {
+	got := convertValueToString(map[string]interface{}{"tags": []interface{}{"headers"}, "rate": float64(25)})
+
+	// Key order is not guaranteed, so assert on both valid renderings rather
+	// than pinning one.
+	want := map[string]bool{
+		`{"rate":25,"tags":["headers"]}`: true,
+		`{"tags":["headers"],"rate":25}`: true,
+	}
+	if !want[got] {
+		t.Errorf("convertValueToString(nested object) = %q, want compact JSON", got)
+	}
+}
+
+func TestConvertValueToStringKeepsExistingEncodings(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"string", "plain", "plain"},
+		{"whole number", float64(25), "25"},
+		{"fractional number", 2.5, "2.5"},
+		{"true", true, "true"},
+		{"false", false, "false"},
+		{"nil", nil, ""},
+		{"array", []interface{}{"a", "b"}, "a,b"},
+	} {
+		if got := convertValueToString(test.value); got != test.want {
+			t.Errorf("%s: convertValueToString(%v) = %q, want %q",
+				test.name, test.value, got, test.want)
+		}
+	}
+}

--- a/rpc/openapi.go
+++ b/rpc/openapi.go
@@ -386,6 +386,7 @@ func (g *OpenAPIGenerator) convertOperationToOpenAPI(op RPCOperation) OpenAPIOpe
 		meta.Aliases = nil
 		meta.Admin = false
 		meta.Icon = ""
+		meta.Path = ""
 		meta.Title = ""
 		meta.Order = 0
 		openAPIOp.Clicky = &meta
@@ -682,6 +683,7 @@ func (g *OpenAPIGenerator) buildClickySpecMeta(operations []RPCOperation) *Click
 					Admin:  meta.Admin,
 					Title:  title,
 					Icon:   meta.Icon,
+					Path:   meta.Path,
 					Order:  index,
 				},
 				baseKey: baseKey,

--- a/rpc/openapi_test.go
+++ b/rpc/openapi_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 // TestOpenAPIGenerator_DynamicEntitySurfaceIcon asserts that the x-clicky-icon /
-// x-clicky-title carried by a dynamic entity propagate to the OpenAPI surface
-// (x-clicky.surfaces[].icon / .title), and that icon does NOT leak onto the
-// operation-level x-clicky.
+// x-clicky-path / x-clicky-title carried by a dynamic entity propagate to the
+// OpenAPI surface (x-clicky.surfaces[].icon / .path / .title), and that icon
+// does NOT leak onto the operation-level x-clicky.
 func TestOpenAPIGenerator_DynamicEntitySurfaceIcon(t *testing.T) {
 	const entityName = "openapi-icon-stack"
 	root := &cobra.Command{Use: "testapp"}
@@ -25,6 +25,7 @@ func TestOpenAPIGenerator_DynamicEntitySurfaceIcon(t *testing.T) {
 	clicky.RegisterDynamicEntity(clicky.DynamicEntitySpec{
 		Name:     entityName,
 		Icon:     "database",
+		Path:     "jms/incoming",
 		Title:    "My Stack",
 		ListType: reflect.StructOf(nil),
 		List: func(context.Context, map[string]string, []string) (any, error) {
@@ -47,6 +48,7 @@ func TestOpenAPIGenerator_DynamicEntitySurfaceIcon(t *testing.T) {
 	}
 	require.NotNil(t, surface, "surface for %q missing", entityName)
 	assert.Equal(t, "database", surface.Icon, "surface carries the entity icon")
+	assert.Equal(t, "jms/incoming", surface.Path, "surface carries the entity hierarchy path")
 	assert.Equal(t, "My Stack", surface.Title, "surface title overridden by x-clicky-title")
 
 	listOp := spec.Paths["/api/v1/"+entityName]["get"]

--- a/rpc/openapi_test.go
+++ b/rpc/openapi_test.go
@@ -56,6 +56,39 @@ func TestOpenAPIGenerator_DynamicEntitySurfaceIcon(t *testing.T) {
 	assert.Empty(t, listOp.Clicky.Icon, "icon must stay surface-only, not on the operation")
 }
 
+// TestOpenAPIGenerator_StaticEntitySurfacePath asserts a statically registered
+// entity can declare a hierarchy path too: the surface metadata is the frontend's
+// only source of it, so an entity that cannot state one is invisible in the tree
+// no matter where it belongs.
+func TestOpenAPIGenerator_StaticEntitySurfacePath(t *testing.T) {
+	const entityName = "openapi-path-stack"
+	root := &cobra.Command{Use: "testapp"}
+
+	clicky.NewEntity[openAPISchemaListItem, openAPISchemaOpts, openAPISchemaDetail](entityName).
+		Path("jms", "incoming").
+		List(func(openAPISchemaOpts) ([]openAPISchemaListItem, error) {
+			return nil, nil
+		}).
+		Register()
+
+	clicky.GenerateCLI(root)
+
+	spec, err := NewOpenAPIGenerator(nil).GenerateFromCobra(root)
+	require.NoError(t, err)
+	require.NotNil(t, spec.Clicky, "spec must carry x-clicky surfaces")
+
+	var surface *ClickySurface
+	for i := range spec.Clicky.Surfaces {
+		if spec.Clicky.Surfaces[i].Entity == entityName {
+			surface = &spec.Clicky.Surfaces[i]
+			break
+		}
+	}
+	require.NotNil(t, surface, "surface for %q missing", entityName)
+	assert.Equal(t, "jms/incoming", surface.Path,
+		"a static entity's path reaches the surface, as a dynamic entity's does")
+}
+
 // TestOpenAPIGenerator_SurfaceKeyNotPluralized asserts the surface route key is
 // the singular entity name (no automatic pluralization), and that the same key
 // is stamped on the list and get operations. clicky-ui builds a row-click route

--- a/rpc/paged.go
+++ b/rpc/paged.go
@@ -1,0 +1,492 @@
+package rpc
+
+// The two additive surfaces of the executor: an operation that supplies rows
+// instead of a formatted body (RPCOperation.PagedFunc), and an entity that does
+// not exist until it is asked for (entity.DynamicEntityFamily). Both are
+// unreachable for an operation that opted into neither, so the shared path in
+// serve.go is unchanged for every consumer that has not.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/flanksource/clicky/entity"
+	"github.com/flanksource/clicky/formatters"
+)
+
+// pagedFlushEvery is how often a streaming export pushes its buffer at the
+// client. Flushing every row costs a syscall — and, behind Compress, a gzip sync
+// marker that measurably worsens the ratio — for a row nobody sees any sooner;
+// flushing never turns a stream back into the wait it exists to avoid. At a few
+// hundred bytes a row this is tens of kilobytes per flush: enough work per
+// syscall to be worth making, little enough that a slow backend still shows
+// progress.
+const pagedFlushEvery = 256
+
+// streamErrorTrailer carries the reason an export stopped early. It is a trailer
+// because the failure it reports happens after the status line is already gone.
+const streamErrorTrailer = "X-Stream-Error"
+
+// handlePagedCommand answers a request whose operation supplies rows rather than
+// a formatted body. The operation says only what the rows are and what is true
+// about them; everything below — negotiation, headers, the stream, the download
+// name — is the same for every operation that opts in.
+func (s *SwaggerServer) handlePagedCommand(w http.ResponseWriter, r *http.Request, op *RPCOperation, paged entity.PagedFunc, name string) {
+	// Before the first thing that can fail: an error a browser is not allowed to
+	// read is worse than the error it describes.
+	entity.SetCORSHeaders(w)
+
+	pageReq, err := entity.ParsePageRequest(r, entity.PageLimits{})
+	if err != nil {
+		entity.WriteError(w, err)
+		return
+	}
+	flags, err := s.requestFlags(r, op)
+	if err != nil {
+		entity.WriteError(w, err)
+		return
+	}
+	res, err := paged(r.Context(), pageReq, flags)
+	if err != nil {
+		entity.WriteError(w, err)
+		return
+	}
+	if res.Rows == nil {
+		entity.WriteError(w, entity.NewStatusError(http.StatusInternalServerError, "invalid_response",
+			"the operation returned no rows to read"))
+		return
+	}
+
+	rows := peekRows(res.Rows)
+	// Every path from here closes, including the panic below: the iterator holds
+	// a cursor or a connection that nothing else will release.
+	defer rows.Close() //nolint:errcheck
+	if err := rows.PeekErr(); err != nil {
+		entity.WriteError(w, entity.NewStatusErrorf(http.StatusInternalServerError, "query_failed", "%v", err))
+		return
+	}
+	if err := streamableExport(pageReq.Format, res.Ceiling); err != nil {
+		entity.WriteError(w, err)
+		return
+	}
+
+	entity.SetExportHeaders(w, name, pageReq, res)
+
+	if strings.EqualFold(r.Method, http.MethodHead) {
+		// Every header is resolved and a HEAD asks for nothing else, so the walk
+		// is not driven just to throw its bytes away — that would charge the
+		// caller the whole query for a body it did not request. WriteHeader is
+		// called explicitly rather than left to net/http, which would write the
+		// status past any wrapper and answer without the Content-Encoding this
+		// request's GET would carry.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// X-Stream-Error rides along only where a trailer section is already being
+	// paid for. Declaring one of its own would cost every page its Content-Length
+	// and force chunked encoding — the exact price DeclaresTruncatedTrailer
+	// exists to avoid — to carry a reason that, on a real abort, Go never gets to
+	// write anyway: the connection is dropped first. The abort is the signal; the
+	// trailer is a note for the in-process callers that can still read one.
+	if entity.DeclaresTruncatedTrailer(pageReq, res) {
+		w.Header().Add("Trailer", streamErrorTrailer)
+	}
+	streamExport(w, r, rows, pageReq, res)
+}
+
+// streamExport writes the body and the answers that only reading it produces.
+func streamExport(w http.ResponseWriter, r *http.Request, rows *peekedRows, req entity.PageRequest, res entity.PageResponse) {
+	trailers := entity.DeclaresTruncatedTrailer(req, res)
+	bounded := &boundedRows{RowIterator: rows, limit: res.Ceiling}
+	var source formatters.RowIterator = rows
+	if res.Ceiling > 0 {
+		source = bounded
+	}
+
+	_, err := formatters.WriteTableStream(r.Context(), w, source, formatters.StreamOptions{
+		Format:     req.Format,
+		MaxRows:    int64(res.Ceiling),
+		CSVBOM:     req.Download,
+		FlushEvery: pagedFlushEvery,
+	})
+	if err != nil {
+		// The status line and the headers are gone and the body cannot be
+		// recalled, so the only remaining way to say the export is incomplete is
+		// to end the transfer wrong. curl -f and every browser surface an aborted
+		// transfer; a short body under a 200 they read as the whole answer.
+		// Compress re-panics with this value after finishing its member, so the
+		// connection still breaks when the response was compressed. The reason is
+		// recorded only where it was declared; setting an undeclared trailer would
+		// be dropped on the wire and misread everywhere else as one that was sent.
+		if trailers {
+			w.Header().Set(streamErrorTrailer, err.Error())
+		}
+		panic(http.ErrAbortHandler)
+	}
+	if trailers {
+		w.Header().Set("X-Truncated", strconv.FormatBool(bounded.truncated))
+	}
+}
+
+// streamableExport refuses, before any header is committed, the two shapes
+// WriteTableStream cannot even start on: a format it does not write rows in, and
+// a PDF with no ceiling to bound the document it has to buffer. Left to the
+// stream both would surface as an aborted transfer, which is reserved for a
+// failure that genuinely arrived too late to be a status.
+func streamableExport(format string, ceiling int) error {
+	switch format {
+	case "json", "ndjson", "yaml", "csv", "markdown", "html", "excel":
+		return nil
+	case "pdf":
+		if ceiling <= 0 {
+			return entity.NewStatusError(http.StatusInternalServerError, "unbounded_pdf",
+				"a pdf export has to state the ceiling it is bounded by")
+		}
+		return nil
+	default:
+		return entity.NewStatusErrorf(http.StatusNotAcceptable, "not_acceptable",
+			"%s is not a representation this operation can stream as rows", format)
+	}
+}
+
+// requestFlags reads the operation's declared parameters and then forwards every
+// undeclared query parameter alongside them, exactly as handleLookupCommand
+// does: an entity resolved at runtime carries filters the operation was
+// generated without, and dropping them would silently ignore what the caller
+// asked to filter on. The transport's own parameters travel with them — an
+// operation that declares a parameter named "limit" means it.
+func (s *SwaggerServer) requestFlags(r *http.Request, op *RPCOperation) (map[string]string, error) {
+	req, err := s.executor.ExtractRequestFromHTTP(r, op)
+	if err != nil {
+		return nil, entity.NewStatusErrorf(http.StatusBadRequest, "invalid_parameters", "%v", err)
+	}
+	for key, values := range r.URL.Query() {
+		if strings.HasPrefix(key, "__") || len(values) == 0 {
+			continue
+		}
+		if _, declared := req.Flags[key]; !declared {
+			req.Flags[key] = values[0]
+		}
+	}
+	return req.Flags, nil
+}
+
+// exportName is the base a download filename is derived from.
+func exportName(op *RPCOperation) string {
+	if op.Clicky != nil && op.Clicky.Entity != "" {
+		return op.Clicky.Entity
+	}
+	if op.Name != "" {
+		return strings.ReplaceAll(op.Name, " ", "-")
+	}
+	return "export"
+}
+
+// pagedOperation resolves the paged operation a request addresses, or nil when
+// it addresses none. A HEAD has no operation of its own — it asks for the
+// headers the GET beside it would answer with — so it resolves against that one.
+func (s *SwaggerServer) pagedOperation(r *http.Request, op *RPCOperation) *RPCOperation {
+	if op == nil && strings.EqualFold(r.Method, http.MethodHead) {
+		op = s.executor.FindOperation(http.MethodGet, r.URL.Path)
+	}
+	if op == nil || op.PagedFunc == nil {
+		return nil
+	}
+	return op
+}
+
+// explicitLookup reports a request that asked for filter metadata by name.
+// isLookupRequest also reads a bare HEAD as a lookup, which a paged operation
+// answers with its export headers instead.
+func explicitLookup(r *http.Request) bool {
+	return r.URL.Query().Get("__lookup") == "filters"
+}
+
+// peekedRows reads the first row eagerly and replays it into the stream.
+//
+// The first row is the last moment a backend failure is still reportable as one.
+// Past it the status is committed, so a query that dies on its first read
+// otherwise produces a short, well-formed CSV under a 200 that no client can
+// tell apart from an empty result. Pulling the row here moves that failure back
+// in front of the headers; replaying it keeps the row the caller asked for,
+// which is why this is a wrapper and not a discarded read.
+//
+// Close is idempotent because two owners call it: WriteTableStream closes the
+// iterator it is handed, and the handler closes it on every path that never
+// reaches WriteTableStream.
+type peekedRows struct {
+	formatters.RowIterator
+	peeked    map[string]any
+	pending   bool
+	replaying bool
+	peekErr   error
+	closed    bool
+	closeErr  error
+}
+
+func peekRows(rows formatters.RowIterator) *peekedRows {
+	peeked := &peekedRows{RowIterator: rows}
+	if rows.Next() {
+		peeked.peeked, peeked.pending = rows.Row(), true
+		return peeked
+	}
+	peeked.peekErr = rows.Err()
+	return peeked
+}
+
+// PeekErr is what the first read failed with, if it failed. It is distinct from
+// Err, which also reports a failure found later in the walk — by which time the
+// status can no longer be changed.
+func (p *peekedRows) PeekErr() error { return p.peekErr }
+
+func (p *peekedRows) Next() bool {
+	if p.pending {
+		p.pending, p.replaying = false, true
+		return true
+	}
+	p.replaying = false
+	return p.RowIterator.Next()
+}
+
+func (p *peekedRows) Row() map[string]any {
+	if p.replaying {
+		return p.peeked
+	}
+	return p.RowIterator.Row()
+}
+
+func (p *peekedRows) Err() error {
+	if p.peekErr != nil {
+		return p.peekErr
+	}
+	return p.RowIterator.Err()
+}
+
+func (p *peekedRows) Close() error {
+	if p.closed {
+		return p.closeErr
+	}
+	p.closed, p.closeErr = true, p.RowIterator.Close()
+	return p.closeErr
+}
+
+// boundedRows stops a walk at the export's ceiling and reports whether stopping
+// cut anything off.
+//
+// The cut is discovered by asking for one row past the ceiling, which is the
+// only way to tell a result that ended exactly on it from one that was
+// truncated — and X-Truncated is a trailer precisely because that answer does
+// not exist until the walk is over.
+type boundedRows struct {
+	formatters.RowIterator
+	limit     int
+	delivered int
+	truncated bool
+}
+
+func (b *boundedRows) Next() bool {
+	if b.delivered >= b.limit {
+		b.truncated = b.RowIterator.Next()
+		return false
+	}
+	if !b.RowIterator.Next() {
+		return false
+	}
+	b.delivered++
+	return true
+}
+
+// matchDynamicFamily resolves {prefix}/{family}/{name} to the family that owns
+// it. It reads the path itself rather than the startup route table because a
+// family's instances are not in that table — being absent from it is the whole
+// reason a family exists.
+func (s *SwaggerServer) matchDynamicFamily(path string) (entity.DynamicEntityFamily, string, bool) {
+	families := entity.GetDynamicEntityFamilies()
+	if len(families) == 0 {
+		return entity.DynamicEntityFamily{}, "", false
+	}
+	relative := strings.Trim(strings.TrimPrefix(strings.TrimSuffix(path, "/"), s.pathPrefix()), "/")
+	segment, name, found := strings.Cut(relative, "/")
+	if !found || name == "" || strings.Contains(name, "/") {
+		return entity.DynamicEntityFamily{}, "", false
+	}
+	for _, family := range families {
+		if family.Name == segment {
+			return family, name, true
+		}
+	}
+	return entity.DynamicEntityFamily{}, "", false
+}
+
+func (s *SwaggerServer) pathPrefix() string {
+	if s.converterCfg != nil && s.converterCfg.PathPrefix != "" {
+		return s.converterCfg.PathPrefix
+	}
+	return entity.DefaultConfig().PathPrefix
+}
+
+// handleDynamicFamily serves one instance of a family, resolved now rather than
+// at startup.
+func (s *SwaggerServer) handleDynamicFamily(w http.ResponseWriter, r *http.Request, family entity.DynamicEntityFamily, name string) {
+	spec, err := family.Resolve(r.Context(), name)
+	if err != nil {
+		entity.SetCORSHeaders(w)
+		entity.WriteError(w, err)
+		return
+	}
+	op := familyOperation(family, spec, r.URL.Path)
+
+	if explicitLookup(r) {
+		s.handleDynamicFamilyLookup(w, r, spec, op)
+		return
+	}
+	if family.Paged != nil {
+		paged := func(ctx context.Context, req entity.PageRequest, flags map[string]string) (entity.PageResponse, error) {
+			return family.Paged(ctx, spec, req, flags)
+		}
+		s.handlePagedCommand(w, r, op, paged, instanceName(spec, name))
+		return
+	}
+	data, metadata, statusCode, _ := s.executeOperation(r, op)
+	s.writeExecutionResult(w, r, data, metadata, statusCode)
+}
+
+// handleDynamicFamilyLookup answers ?__lookup=filters from the filters of the
+// instance that was just resolved. A family instance never enters the registry,
+// so the operation's own LookupFunc — which the registry would have built —
+// does not exist to be called.
+func (s *SwaggerServer) handleDynamicFamilyLookup(w http.ResponseWriter, r *http.Request, spec entity.DynamicEntitySpec, op *RPCOperation) {
+	flags, err := s.requestFlags(r, op)
+	if err != nil {
+		entity.WriteError(w, err)
+		return
+	}
+	// Forwarded verbatim, as handleLookupCommand does: they are not declared
+	// parameters, so nothing else carries them to the filter that searches on
+	// them.
+	for _, key := range []string{"__lookup_filter", "__lookup_q"} {
+		if value := r.URL.Query().Get(key); value != "" {
+			flags[key] = value
+		}
+	}
+
+	data, err := entity.ResolveDynamicLookup(r.Context(), spec, flags)
+	if err != nil {
+		entity.WriteError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json+clicky")
+	w.WriteHeader(http.StatusOK)
+	if strings.EqualFold(r.Method, http.MethodHead) {
+		return
+	}
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode lookup response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// familyOperation adapts a resolved instance to the RPCOperation shape the rest
+// of the executor speaks. It is built per request and never registered: the
+// instance it describes may be gone by the next one.
+func familyOperation(family entity.DynamicEntityFamily, spec entity.DynamicEntitySpec, path string) *RPCOperation {
+	name := instanceName(spec, family.Name)
+	parent := spec.Parent
+	if parent == "" {
+		parent = family.Parent
+	}
+	op := &RPCOperation{
+		Name:            family.Name + " " + name,
+		Description:     spec.Title,
+		Path:            path,
+		Method:          http.MethodGet,
+		ContextDataFunc: spec.List,
+		ResponseArray:   true,
+		Clicky: &entity.ClickyOperationMeta{
+			SurfaceID:      family.Name + "/" + name,
+			Entity:         name,
+			Parent:         parent,
+			Verb:           "list",
+			Icon:           spec.Icon,
+			Path:           spec.Path,
+			Title:          spec.Title,
+			SupportsLookup: len(spec.Filters) > 0,
+		},
+	}
+	if spec.ItemType != nil {
+		op.ResponseType = spec.ItemType
+		op.ResponseEntityID = true
+	}
+	for _, filter := range spec.Filters {
+		parameterType := "string"
+		if filter.Multi {
+			parameterType = "array"
+		}
+		op.Parameters = append(op.Parameters, entity.RPCParameter{
+			Name: filter.Key, Type: parameterType, In: "query", Description: filter.Label,
+		})
+	}
+	return op
+}
+
+func instanceName(spec entity.DynamicEntitySpec, fallback string) string {
+	if spec.Name != "" {
+		return spec.Name
+	}
+	return fallback
+}
+
+// addFamilyPaths describes the instances that exist as this document is read.
+func (s *SwaggerServer) addFamilyPaths(ctx context.Context, spec *OpenAPISpec, families []entity.DynamicEntityFamily) error {
+	prefix := s.pathPrefix()
+	for _, family := range families {
+		if family.List == nil {
+			continue
+		}
+		instances, err := family.List(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list %s entities: %w", family.Name, err)
+		}
+		for _, instance := range instances {
+			if instance.Name == "" {
+				continue
+			}
+			path := prefix + "/" + family.Name + "/" + instance.Name
+			op := familyOperation(family, instance, path)
+			if spec.Paths == nil {
+				spec.Paths = make(map[string]OpenAPIPath, len(instances))
+			}
+			spec.Paths[path] = OpenAPIPath{"get": s.generator.convertOperationToOpenAPI(*op)}
+			spec.Clicky = appendFamilySurface(spec.Clicky, op.Clicky, instance)
+		}
+	}
+	return nil
+}
+
+// appendFamilySurface adds the instance's UI surface to the document's own list,
+// keyed by the instance name so the frontend's /<surface>/<id> route resolves
+// against the same segment the API path uses.
+func appendFamilySurface(meta *ClickySpecMeta, op *entity.ClickyOperationMeta, instance entity.DynamicEntitySpec) *ClickySpecMeta {
+	if meta == nil {
+		meta = &ClickySpecMeta{}
+	}
+	title := instance.Title
+	if title == "" {
+		title = op.Entity
+	}
+	op.Surface = op.Entity
+	meta.Surfaces = append(meta.Surfaces, ClickySurface{
+		Key:    op.Entity,
+		Entity: op.Entity,
+		Parent: op.Parent,
+		Title:  title,
+		Icon:   instance.Icon,
+		Path:   instance.Path,
+	})
+	return meta
+}

--- a/rpc/paged.go
+++ b/rpc/paged.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/flanksource/clicky"
 	"github.com/flanksource/clicky/entity"
 	"github.com/flanksource/clicky/formatters"
 )
@@ -330,9 +331,33 @@ func (s *SwaggerServer) pathPrefix() string {
 	return entity.DefaultConfig().PathPrefix
 }
 
+// familyReadMethods are the methods a family instance answers. OPTIONS never
+// reaches here — the CORS preflight is answered before dispatch.
+var familyReadMethods = []string{http.MethodGet, http.MethodHead}
+
+func isFamilyReadMethod(method string) bool {
+	for _, allowed := range familyReadMethods {
+		if strings.EqualFold(method, allowed) {
+			return true
+		}
+	}
+	return false
+}
+
 // handleDynamicFamily serves one instance of a family, resolved now rather than
 // at startup.
 func (s *SwaggerServer) handleDynamicFamily(w http.ResponseWriter, r *http.Request, family entity.DynamicEntityFamily, name string) {
+	// A family instance is read-only: it is served by the spec's List, whatever
+	// the request method. Running that read for a POST would answer a write with
+	// 200 and rows, so a method the instance cannot serve is refused outright.
+	if !isFamilyReadMethod(r.Method) {
+		entity.SetCORSHeaders(w)
+		w.Header().Set("Allow", strings.Join(familyReadMethods, ", "))
+		entity.NewStatusErrorf(http.StatusMethodNotAllowed, "method_not_allowed",
+			"%s is not supported for %s instances", r.Method, family.Name).Write(w)
+		return
+	}
+
 	spec, err := family.Resolve(r.Context(), name)
 	if err != nil {
 		entity.SetCORSHeaders(w)
@@ -450,7 +475,11 @@ func (s *SwaggerServer) addFamilyPaths(ctx context.Context, spec *OpenAPISpec, f
 		}
 		instances, err := family.List(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to list %s entities: %w", family.Name, err)
+			// One unreachable backing store must not take the whole document with
+			// it: the static operations are still described, and this family's
+			// instances reappear as soon as its store answers again.
+			clicky.Errorf("Omitting %s entities from the OpenAPI document: %v", family.Name, err)
+			continue
 		}
 		for _, instance := range instances {
 			if instance.Name == "" {

--- a/rpc/paged_regression_test.go
+++ b/rpc/paged_regression_test.go
@@ -1,0 +1,213 @@
+package rpc
+
+import (
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/clicky/api"
+	"github.com/flanksource/clicky/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The paging and dynamic-family work grafted two new branches onto
+// handleExecuteCommand, which every clicky consumer's executor routes run
+// through. Neither branch may be reachable by an operation that opted into
+// neither feature, so the responses below are recorded verbatim: status, every
+// header, and the exact bytes. They were captured from the handler before the
+// branches existed, so a diff here is a regression in the shared path rather
+// than a restatement of whatever the code now does.
+
+// dumpResponse renders a response as a stable, diffable transcript. Header order
+// is not part of the contract, so it is sorted; everything else is byte-exact.
+func dumpResponse(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	res := rec.Result()
+	defer res.Body.Close() //nolint:errcheck
+
+	names := make([]string, 0, len(res.Header))
+	for name := range res.Header {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", res.StatusCode)
+	for _, name := range names {
+		fmt.Fprintf(&out, "%s: %s\n", name, strings.Join(res.Header[name], ", "))
+	}
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	fmt.Fprintf(&out, "\n%s", body)
+	return out.String()
+}
+
+// legacyServer builds the executor shape a plain consumer has: one DataFunc
+// list operation, one operation that also answers a filter lookup, and nothing
+// paged or family-backed anywhere.
+func legacyServer() *SwaggerServer {
+	list := RPCOperation{
+		Name:   "config list",
+		Path:   "/api/v1/config",
+		Method: "GET",
+		Parameters: []RPCParameter{
+			{Name: "env", Type: "string", In: "query", Description: "Environment"},
+		},
+		DataFunc: func(flags map[string]string, _ []string) (any, error) {
+			return []map[string]any{{"name": "dev", "env": flags["env"]}}, nil
+		},
+	}
+	lookup := RPCOperation{
+		Name:   "widget list",
+		Path:   "/api/v1/widget",
+		Method: "GET",
+		DataFunc: func(_ map[string]string, _ []string) (any, error) {
+			return []map[string]any{{"name": "left"}}, nil
+		},
+		LookupFunc: func(_ map[string]string, _ []string) (any, error) {
+			return map[string]any{"filters": map[string]any{
+				"env": map[string]any{"label": "Environment"},
+			}}, nil
+		},
+	}
+	service := &RPCService{Name: "api", Operations: []RPCOperation{list, lookup}}
+	return &SwaggerServer{
+		config:       &ServeConfig{Executor: &ExecutorConfig{Enabled: true}},
+		converterCfg: &Config{PathPrefix: "/api/v1"},
+		executor:     NewCommandExecutor(service, &ExecutorConfig{Enabled: true, SkipPreRun: true, PathPrefix: "/api/v1"}),
+	}
+}
+
+func TestHandleExecuteCommand_LegacyResponsesAreUnchanged(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		target string
+		accept string
+		want   string
+	}{
+		{
+			name:   "json list",
+			method: "GET",
+			target: "/api/v1/config?env=prod",
+			accept: "application/json",
+			want: "200\n" +
+				"Access-Control-Allow-Headers: Content-Type, Accept\n" +
+				"Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS\n" +
+				"Access-Control-Allow-Origin: *\n" +
+				"Content-Type: application/json\n" +
+				"X-Cli-Command: \n" +
+				"X-Execution-Success: true\n" +
+				"X-Exit-Code: 0\n" +
+				"\n[\n  {\n    \"env\": \"prod\",\n    \"name\": \"dev\"\n  }\n]",
+		},
+		{
+			name:   "preflight",
+			method: "OPTIONS",
+			target: "/api/v1/config",
+			want: "200\n" +
+				"Access-Control-Allow-Headers: Content-Type, Accept\n" +
+				"Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS\n" +
+				"Access-Control-Allow-Origin: *\n" +
+				"\n",
+		},
+		{
+			name:   "unknown path",
+			method: "GET",
+			target: "/api/v1/nothing",
+			want: "404\n" +
+				"Access-Control-Allow-Headers: Content-Type, Accept\n" +
+				"Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS\n" +
+				"Access-Control-Allow-Origin: *\n" +
+				"Content-Type: text/plain; charset=utf-8\n" +
+				"X-Content-Type-Options: nosniff\n" +
+				"\nNo operation found for GET /api/v1/nothing\n",
+		},
+		{
+			name:   "filter lookup",
+			method: "GET",
+			target: "/api/v1/widget?__lookup=filters",
+			want: "200\n" +
+				"Access-Control-Allow-Headers: Content-Type, Accept\n" +
+				"Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS\n" +
+				"Access-Control-Allow-Origin: *\n" +
+				"Content-Type: application/json+clicky\n" +
+				"\n{\"filters\":{\"env\":{\"label\":\"Environment\"}}}\n",
+		},
+		{
+			name:   "head is a lookup",
+			method: "HEAD",
+			target: "/api/v1/widget",
+			want: "200\n" +
+				"Access-Control-Allow-Headers: Content-Type, Accept\n" +
+				"Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS\n" +
+				"Access-Control-Allow-Origin: *\n" +
+				"Content-Type: application/json+clicky\n" +
+				"\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := legacyServer()
+			req := httptest.NewRequest(test.method, test.target, nil)
+			if test.accept != "" {
+				req.Header.Set("Accept", test.accept)
+			}
+			rec := httptest.NewRecorder()
+
+			server.handleExecuteCommand(rec, req)
+
+			assert.Equal(t, test.want, dumpResponse(t, rec))
+		})
+	}
+}
+
+// registerTestFamily keeps the process-wide family registry as it found it, so
+// one test's family cannot leak into another's routes or OpenAPI document.
+func registerTestFamily(t *testing.T, family entity.DynamicEntityFamily) {
+	t.Helper()
+	entity.RegisterDynamicEntityFamily(family)
+	t.Cleanup(func() { entity.UnregisterDynamicEntityFamily(family.Name) })
+}
+
+// staticRows is a RowIterator over a fixed slice, optionally failing at a
+// chosen position, and recording that it was closed.
+type staticRows struct {
+	columns  []api.ColumnDef
+	rows     []map[string]any
+	failAt   int
+	index    int
+	err      error
+	closes   int
+	closeErr error
+}
+
+func (s *staticRows) Columns() []api.ColumnDef { return s.columns }
+
+func (s *staticRows) Next() bool {
+	if s.err != nil {
+		return false
+	}
+	if s.failAt > 0 && s.index == s.failAt-1 {
+		s.err = fmt.Errorf("backend failed at row %d", s.index)
+		return false
+	}
+	if s.index >= len(s.rows) {
+		return false
+	}
+	s.index++
+	return true
+}
+
+func (s *staticRows) Row() map[string]any { return s.rows[s.index-1] }
+func (s *staticRows) Err() error          { return s.err }
+
+func (s *staticRows) Close() error {
+	s.closes++
+	return s.closeErr
+}

--- a/rpc/paged_test.go
+++ b/rpc/paged_test.go
@@ -1,0 +1,371 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/clicky/api"
+	"github.com/flanksource/clicky/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func numberedRows(count int) []map[string]any {
+	rows := make([]map[string]any, count)
+	for index := range rows {
+		rows[index] = map[string]any{"n": fmt.Sprintf("row-%d", index)}
+	}
+	return rows
+}
+
+func drain(rows *peekedRows) []map[string]any {
+	out := []map[string]any{}
+	for rows.Next() {
+		out = append(out, rows.Row())
+	}
+	return out
+}
+
+// A peeked row that is dropped is a row the caller paid for and never saw, and a
+// peeked row replayed twice is a row that never existed. Both are silent, so the
+// wrapper is exercised on its own rather than only through an export.
+func TestPeekedRows_ReplaysEveryRowExactlyOnce(t *testing.T) {
+	for _, count := range []int{0, 1, 5} {
+		source := &staticRows{rows: numberedRows(count)}
+		rows := peekRows(source)
+
+		require.NoError(t, rows.PeekErr())
+		assert.Equal(t, source.rows, drain(rows), "%d rows must arrive in order, none lost or repeated", count)
+		assert.NoError(t, rows.Err())
+	}
+}
+
+func TestPeekedRows_ReportsFirstReadFailureBeforeAnyRow(t *testing.T) {
+	rows := peekRows(&staticRows{rows: numberedRows(3), failAt: 1})
+
+	require.EqualError(t, rows.PeekErr(), "backend failed at row 0")
+	assert.Empty(t, drain(rows), "a failed first read yields no rows")
+}
+
+// A failure past the first row is deliberately NOT a PeekErr: by then the status
+// is committed and the only honest answer is an aborted transfer.
+func TestPeekedRows_LaterFailureIsNotAPeekError(t *testing.T) {
+	rows := peekRows(&staticRows{rows: numberedRows(4), failAt: 3})
+
+	require.NoError(t, rows.PeekErr())
+	assert.Len(t, drain(rows), 2)
+	assert.EqualError(t, rows.Err(), "backend failed at row 2")
+}
+
+// WriteTableStream closes the iterator it is handed and the handler closes it on
+// every path that never reaches WriteTableStream, so a double close is normal.
+func TestPeekedRows_CloseIsIdempotent(t *testing.T) {
+	source := &staticRows{rows: numberedRows(2)}
+	rows := peekRows(source)
+
+	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Close())
+	assert.Equal(t, 1, source.closes)
+}
+
+func TestBoundedRows_ReportsWhetherTheCeilingCutAnything(t *testing.T) {
+	tests := []struct {
+		name          string
+		rows          int
+		limit         int
+		wantDelivered int
+		wantTruncated bool
+	}{
+		{name: "under the ceiling", rows: 2, limit: 5, wantDelivered: 2},
+		{name: "exactly on the ceiling", rows: 3, limit: 3, wantDelivered: 3},
+		{name: "past the ceiling", rows: 6, limit: 3, wantDelivered: 3, wantTruncated: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bounded := &boundedRows{RowIterator: peekRows(&staticRows{rows: numberedRows(test.rows)}), limit: test.limit}
+			delivered := 0
+			for bounded.Next() {
+				delivered++
+			}
+			assert.Equal(t, test.wantDelivered, delivered)
+			assert.Equal(t, test.wantTruncated, bounded.truncated)
+		})
+	}
+}
+
+// pagedServer serves one paged operation at /api/v1/config.
+func pagedServer(paged entity.PagedFunc) *SwaggerServer {
+	op := RPCOperation{
+		Name:      "config list",
+		Path:      "/api/v1/config",
+		Method:    "GET",
+		PagedFunc: paged,
+		Clicky:    &entity.ClickyOperationMeta{Entity: "config"},
+	}
+	service := &RPCService{Name: "api", Operations: []RPCOperation{op}}
+	return &SwaggerServer{
+		config:       &ServeConfig{Executor: &ExecutorConfig{Enabled: true}},
+		converterCfg: &Config{PathPrefix: "/api/v1"},
+		executor:     NewCommandExecutor(service, &ExecutorConfig{Enabled: true, SkipPreRun: true, PathPrefix: "/api/v1"}),
+	}
+}
+
+func staticPaged(rows *staticRows, res entity.PageResponse) entity.PagedFunc {
+	return func(_ context.Context, _ entity.PageRequest, _ map[string]string) (entity.PageResponse, error) {
+		res.Rows = rows
+		return res, nil
+	}
+}
+
+func TestHandlePaged_StreamsWithExportHeaders(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(3)}
+	server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming, Pageable: true}))
+
+	req := httptest.NewRequest("GET", "/api/v1/config?format=csv&_download", nil)
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "text/csv; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Equal(t, entity.ModeStreaming, res.Header.Get("X-Export-Mode"))
+	assert.Equal(t, "unknown", res.Header.Get("X-Total-Relation"))
+	assert.Contains(t, res.Header.Get("Content-Disposition"), `filename="config.csv"`)
+	assert.Contains(t, res.Header.Get("Access-Control-Expose-Headers"), "X-Export-Mode")
+	assert.Equal(t, "\xEF\xBB\xBFN\nrow-0\nrow-1\nrow-2\n", rec.Body.String(), "every row, once, behind the download BOM")
+	assert.Equal(t, 1, source.closes)
+}
+
+// C1: a query that dies on its first read must be a status, not a short body
+// under a 200 that reads as "no results".
+func TestHandlePaged_FirstRowFailureIsAStatus(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(3), failAt: 1}
+	server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming}))
+
+	req := httptest.NewRequest("GET", "/api/v1/config?format=csv", nil)
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	assert.Empty(t, res.Header.Get("Content-Disposition"), "no export header is committed before the first row is known")
+
+	var body entity.StatusError
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	assert.Equal(t, "query_failed", body.Code)
+	// H2: the failing path still releases the cursor.
+	assert.Equal(t, 1, source.closes)
+	// An error body a browser cannot read is worse than the error it describes.
+	assert.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+}
+
+// C1: past the first row the status is spent, so the transfer is broken instead.
+// A plain page declares no trailer section, so the abort is the whole signal.
+func TestHandlePaged_MidStreamFailureAbortsTheTransfer(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(6), failAt: 3}
+	server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming}))
+
+	req := httptest.NewRequest("GET", "/api/v1/config?format=csv", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		assert.Equal(t, http.ErrAbortHandler, recover(), "an aborted transfer is the only failure a client detects here")
+		assert.Empty(t, rec.Header().Values("Trailer"), "a page does not buy a trailer section to report this in")
+		assert.Empty(t, rec.Header().Get(streamErrorTrailer), "an undeclared trailer is dropped, so setting one only misleads")
+		assert.Equal(t, 1, source.closes, "the panic path still closes")
+	}()
+	server.handleExecuteCommand(rec, req)
+	t.Fatal("expected the handler to abort")
+}
+
+// Where a trailer section is already declared it costs nothing to say why the
+// stream stopped, so the reason rides along with X-Truncated.
+func TestHandlePaged_MidStreamFailureRidesADeclaredTrailer(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(9), failAt: 3}
+	server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming, Ceiling: 5, MaxRows: 5}))
+
+	req := httptest.NewRequest("GET", "/api/v1/config?format=csv&scope=all", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		assert.Equal(t, http.ErrAbortHandler, recover())
+		assert.Contains(t, rec.Header().Values("Trailer"), streamErrorTrailer,
+			"a trailer nobody declared is a trailer nobody reads")
+		assert.Equal(t, "backend failed at row 2", rec.Header().Get(streamErrorTrailer))
+		assert.Equal(t, 1, source.closes)
+	}()
+	server.handleExecuteCommand(rec, req)
+	t.Fatal("expected the handler to abort")
+}
+
+// A page must keep the Content-Length an unconditional trailer declaration would
+// have cost it. Only a real server computes one, so this goes over a socket.
+func TestHandlePaged_PageKeepsItsContentLength(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(3)}
+	server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModePage, Pageable: true}))
+
+	backend := httptest.NewServer(http.HandlerFunc(server.handleExecuteCommand))
+	defer backend.Close()
+
+	res, err := backend.Client().Get(backend.URL + "/api/v1/config?format=csv")
+	require.NoError(t, err)
+	defer res.Body.Close() //nolint:errcheck
+
+	assert.Empty(t, res.Header.Values("Trailer"), "a page declares no trailer")
+	assert.Empty(t, res.TransferEncoding, "and so is not forced into chunked encoding")
+	assert.Equal(t, int64(len("N\nrow-0\nrow-1\nrow-2\n")), res.ContentLength,
+		"the length is knowable and has to be stated")
+}
+
+// M3: a HEAD resolves every header and stops. Driving the walk to throw its
+// bytes away would charge the caller the whole query for a body it did not ask
+// for.
+func TestHandlePaged_HeadResolvesHeadersWithoutWalking(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(50)}
+	server := pagedServer(staticPaged(source, entity.PageResponse{
+		Mode: entity.ModeStreaming, Total: &entity.Total{Value: 50, Exact: true},
+	}))
+
+	req := httptest.NewRequest("HEAD", "/api/v1/config?format=csv&scope=all", nil)
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "text/csv; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Equal(t, "50", res.Header.Get("X-Total-Count"))
+	assert.Equal(t, "eq", res.Header.Get("X-Total-Relation"))
+	assert.Empty(t, rec.Body.String())
+	assert.Equal(t, 1, source.index, "only the peek is read; the other 49 rows are never fetched")
+	assert.Equal(t, 1, source.closes)
+}
+
+// L1: the HEAD and the GET have to agree about how the body would have been
+// encoded, which they only do if both reach the compressor's WriteHeader.
+func TestHandlePaged_HeadAndGetAgreeOnContentEncoding(t *testing.T) {
+	encodings := map[string]string{}
+	for _, method := range []string{"GET", "HEAD"} {
+		source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(3)}
+		server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming}))
+
+		req := httptest.NewRequest(method, "/api/v1/config?format=csv", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+		Compress(http.HandlerFunc(server.handleExecuteCommand)).ServeHTTP(rec, req)
+
+		encodings[method] = rec.Result().Header.Get("Content-Encoding")
+	}
+
+	require.Equal(t, "gzip", encodings["GET"], "a csv export is worth compressing")
+	assert.Equal(t, encodings["GET"], encodings["HEAD"])
+}
+
+func TestHandlePaged_TruncationIsReportedAsTheDeclaredTrailer(t *testing.T) {
+	tests := []struct {
+		name string
+		rows int
+		want string
+	}{
+		{name: "ceiling not reached", rows: 2, want: "false"},
+		{name: "ceiling bit", rows: 9, want: "true"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(test.rows)}
+			server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming, Ceiling: 3, MaxRows: 3}))
+
+			req := httptest.NewRequest("GET", "/api/v1/config?format=csv&scope=all", nil)
+			rec := httptest.NewRecorder()
+			server.handleExecuteCommand(rec, req)
+
+			res := rec.Result()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			assert.Contains(t, res.Header.Values("Trailer"), "X-Truncated")
+			assert.Equal(t, test.want, rec.Header().Get("X-Truncated"))
+			assert.Equal(t, min(test.rows, 3), strings.Count(rec.Body.String(), "\n")-1, "the ceiling bounds the body")
+		})
+	}
+}
+
+func TestHandlePaged_RefusesWhatItCannotStream(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		accept string
+		status int
+		code   string
+	}{
+		{name: "refused representation", target: "/api/v1/config", accept: "application/json;q=0", status: http.StatusNotAcceptable, code: "not_acceptable"},
+		{name: "unstreamable format", target: "/api/v1/config?format=clicky-json", status: http.StatusNotAcceptable, code: "not_acceptable"},
+		{name: "unbounded pdf", target: "/api/v1/config?format=pdf", status: http.StatusInternalServerError, code: "unbounded_pdf"},
+		{name: "invalid scope", target: "/api/v1/config?scope=some", status: http.StatusBadRequest, code: "invalid_scope"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(3)}
+			server := pagedServer(staticPaged(source, entity.PageResponse{Mode: entity.ModeStreaming}))
+
+			req := httptest.NewRequest("GET", test.target, nil)
+			if test.accept != "" {
+				req.Header.Set("Accept", test.accept)
+			}
+			rec := httptest.NewRecorder()
+			server.handleExecuteCommand(rec, req)
+
+			res := rec.Result()
+			require.Equal(t, test.status, res.StatusCode)
+			var body entity.StatusError
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+			assert.Equal(t, test.code, body.Code)
+		})
+	}
+}
+
+// The provider's own failure is a status too, and it must not leak the iterator
+// it never returned.
+func TestHandlePaged_ProviderErrorIsWrittenInTheSharedErrorShape(t *testing.T) {
+	server := pagedServer(func(_ context.Context, _ entity.PageRequest, _ map[string]string) (entity.PageResponse, error) {
+		return entity.PageResponse{}, entity.NewStatusError(http.StatusForbidden, "no_access", "this connection is not yours")
+	})
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/config", nil))
+
+	res := rec.Result()
+	require.Equal(t, http.StatusForbidden, res.StatusCode)
+	var body entity.StatusError
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	assert.Equal(t, "no_access", body.Code)
+}
+
+// A paged operation still answers an explicit lookup through the ordinary lookup
+// path — only the bare HEAD is reinterpreted.
+func TestHandlePaged_ExplicitLookupStillReachesTheLookup(t *testing.T) {
+	op := RPCOperation{
+		Name:   "config list",
+		Path:   "/api/v1/config",
+		Method: "GET",
+		PagedFunc: func(_ context.Context, _ entity.PageRequest, _ map[string]string) (entity.PageResponse, error) {
+			return entity.PageResponse{Rows: &staticRows{}}, nil
+		},
+		LookupFunc: func(_ map[string]string, _ []string) (any, error) {
+			return map[string]any{"filters": map[string]any{}}, nil
+		},
+	}
+	service := &RPCService{Name: "api", Operations: []RPCOperation{op}}
+	server := &SwaggerServer{
+		config:       &ServeConfig{Executor: &ExecutorConfig{Enabled: true}},
+		converterCfg: &Config{PathPrefix: "/api/v1"},
+		executor:     NewCommandExecutor(service, &ExecutorConfig{Enabled: true, SkipPreRun: true, PathPrefix: "/api/v1"}),
+	}
+
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, httptest.NewRequest("GET", "/api/v1/config?__lookup=filters", nil))
+
+	assert.Equal(t, "application/json+clicky", rec.Result().Header.Get("Content-Type"))
+}

--- a/rpc/paged_test.go
+++ b/rpc/paged_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -139,6 +140,31 @@ func TestHandlePaged_StreamsWithExportHeaders(t *testing.T) {
 	assert.Contains(t, res.Header.Get("Access-Control-Expose-Headers"), "X-Export-Mode")
 	assert.Equal(t, "\xEF\xBB\xBFN\nrow-0\nrow-1\nrow-2\n", rec.Body.String(), "every row, once, behind the download BOM")
 	assert.Equal(t, 1, source.closes)
+}
+
+// An operation with no total order serves its first page and refuses every page
+// after it. Reporting an offset or a cursor would be true and useless: both name
+// a position whose only use is a request this server answers 400, so they are
+// withheld and X-Has-More is false whatever the provider believes.
+func TestHandlePaged_UnpageableWithholdsThePositionHeaders(t *testing.T) {
+	source := &staticRows{columns: []api.ColumnDef{{Name: "n"}}, rows: numberedRows(3)}
+	server := pagedServer(staticPaged(source, entity.PageResponse{
+		Mode: entity.ModeStreaming, Pageable: false, HasMore: true, Next: "after-row-2",
+	}))
+
+	req := httptest.NewRequest("GET", "/api/v1/config?format=csv&offset=0", nil)
+	rec := httptest.NewRecorder()
+	server.handleExecuteCommand(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Empty(t, res.Header.Get("X-Page-Offset"), "an offset that cannot be asked for is not a position to report")
+	assert.Empty(t, res.Header.Get("X-Next-Cursor"), "nor is a cursor to resume from")
+	assert.Equal(t, "false", res.Header.Get("X-Has-More"), "even though the provider reported more")
+	// The page it did serve is still described: the limit is the size of this
+	// answer, not an invitation to ask for the next one.
+	assert.Equal(t, strconv.Itoa(entity.DefaultPageSize), res.Header.Get("X-Page-Limit"))
+	assert.Equal(t, "N\nrow-0\nrow-1\nrow-2\n", rec.Body.String())
 }
 
 // C1: a query that dies on its first read must be a status, not a short body

--- a/rpc/primary_action_test.go
+++ b/rpc/primary_action_test.go
@@ -1,0 +1,79 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/clicky/entity"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type primaryRPCItem struct {
+	ID string `json:"id"`
+}
+
+func (i primaryRPCItem) GetID() string   { return i.ID }
+func (i primaryRPCItem) GetName() string { return i.ID }
+
+type primaryRPCOptions struct {
+	Profile string   `flag:"profile" default:"safe"`
+	Hosts   []string `flag:"host"`
+}
+
+func (primaryRPCOptions) ClickyActionFlags() {}
+
+func TestPrimaryActionSharesCollectionPathWithList(t *testing.T) {
+	name := "primary-action-rpc-spec"
+	var received primaryRPCOptions
+	clicky.NewEntity[primaryRPCItem, struct{}, primaryRPCItem](name).
+		List(func(struct{}) ([]primaryRPCItem, error) {
+			return []primaryRPCItem{{ID: "history"}}, nil
+		}).
+		WithPrimaryAction(entity.PrimaryActionWithContext(primaryRPCOptions{}, func(_ context.Context, opts primaryRPCOptions) (primaryRPCItem, error) {
+			received = opts
+			return primaryRPCItem{ID: "started"}, nil
+		})).
+		Register()
+
+	root := &cobra.Command{Use: "test"}
+	clicky.GenerateCLI(root)
+	service, err := NewConverter(DefaultConfig()).ConvertCommandTree(root)
+	require.NoError(t, err)
+
+	var methods []string
+	for _, operation := range service.Operations {
+		if operation.Path == "/api/v1/"+name {
+			methods = append(methods, operation.Method)
+		}
+	}
+	assert.ElementsMatch(t, []string{http.MethodGet, http.MethodPost}, methods)
+
+	var post *RPCOperation
+	for i := range service.Operations {
+		operation := &service.Operations[i]
+		if operation.Method == http.MethodPost && operation.Path == "/api/v1/"+name {
+			post = operation
+			break
+		}
+	}
+	require.NotNil(t, post)
+	assert.Equal(t, name, post.Name)
+	assert.Contains(t, post.Parameters, RPCParameter{Name: "profile", In: "query", Type: "string", Required: false, Default: "safe"})
+
+	executor := NewCommandExecutor(service, &ExecutorConfig{Enabled: true, SkipPreRun: true, PathPrefix: "/api/v1"})
+	request := httptest.NewRequest(http.MethodPost, post.Path, strings.NewReader(`{"profile":"full","host":["one.example.test","two.example.test"]}`))
+	request.Header.Set("Content-Type", "application/json")
+	execution, err := executor.ExtractRequestFromHTTP(request, post)
+	require.NoError(t, err)
+	require.NoError(t, executor.ValidateParameters(execution, post))
+	data, _, err := executor.ExecuteCommand(post, execution)
+	require.NoError(t, err)
+	assert.Equal(t, primaryRPCItem{ID: "started"}, data)
+	assert.Equal(t, primaryRPCOptions{Profile: "full", Hosts: []string{"one.example.test", "two.example.test"}}, received)
+}

--- a/rpc/serve.go
+++ b/rpc/serve.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"maps"
 	"net/http"
 	"os/exec"
 	"path"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -62,6 +64,11 @@ type SwaggerServer struct {
 	// reflected — register the whole tree before serving.
 	specMu   sync.Mutex
 	specDocs map[specFormat]*specDocument
+	// specBase is the same document before any family path is added. A consumer
+	// with families cannot memoize the encoded rendering, but the static portion
+	// it is built from is still a pure function of rootCmd and converterCfg, so
+	// only the family paths are re-derived per request.
+	specBase *OpenAPISpec
 }
 
 // specFormat identifies a rendering of the OpenAPI document. Each rendering is
@@ -344,14 +351,49 @@ func (s *SwaggerServer) specDocument(r *http.Request, format specFormat) (*specD
 		return s.renderSpec(format)
 	}
 
-	spec, err := s.generator.GenerateFromCobraWithConfig(s.rootCmd, s.converterCfg)
+	base, err := s.baseSpec()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate OpenAPI spec: %w", err)
+		return nil, err
 	}
+	spec := cloneSpecForFamilies(base)
 	if err := s.addFamilyPaths(r.Context(), spec, families); err != nil {
 		return nil, err
 	}
 	return encodeSpec(spec, format)
+}
+
+// baseSpec renders the family-independent document once and keeps it, so a
+// consumer with families pays the command-tree walk on the first request only.
+func (s *SwaggerServer) baseSpec() (*OpenAPISpec, error) {
+	s.specMu.Lock()
+	defer s.specMu.Unlock()
+
+	if s.specBase != nil {
+		return s.specBase, nil
+	}
+	spec, err := s.generator.GenerateFromCobraWithConfig(s.rootCmd, s.converterCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OpenAPI spec: %w", err)
+	}
+	s.specBase = spec
+	return spec, nil
+}
+
+// cloneSpecForFamilies copies exactly what addFamilyPaths writes to — the path
+// map and the surface list — so a request's instances never reach the cached
+// base. Everything else is shared: nothing on this path mutates it.
+func cloneSpecForFamilies(base *OpenAPISpec) *OpenAPISpec {
+	spec := *base
+	spec.Paths = maps.Clone(base.Paths)
+	if spec.Paths == nil {
+		spec.Paths = make(map[string]OpenAPIPath)
+	}
+	if base.Clicky != nil {
+		meta := *base.Clicky
+		meta.Surfaces = slices.Clone(base.Clicky.Surfaces)
+		spec.Clicky = &meta
+	}
+	return &spec
 }
 
 // serveSpec writes a rendered OpenAPI document, answering a matching
@@ -743,16 +785,22 @@ func (s *SwaggerServer) handleExecuteCommand(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	lookupRequested := isLookupRequest(r)
+	op := s.executor.FindOperation(r.Method, r.URL.Path)
+
 	// A family's instances come into being while the server runs, so they are not
 	// in the route table this handler was reached through. Reading the path is
 	// what lets an entity that did not exist at startup be served at all.
-	if family, name, matched := s.matchDynamicFamily(r.URL.Path); matched {
-		s.handleDynamicFamily(w, r, family, name)
-		return
+	//
+	// A registered operation wins: the family matcher compares only the first
+	// segment, so a family named after an existing entity would otherwise swallow
+	// that entity's item routes and make them unreachable.
+	if op == nil {
+		if family, name, matched := s.matchDynamicFamily(r.URL.Path); matched {
+			s.handleDynamicFamily(w, r, family, name)
+			return
+		}
 	}
-
-	lookupRequested := isLookupRequest(r)
-	op := s.executor.FindOperation(r.Method, r.URL.Path)
 	// A paged operation owns its own response. A bare HEAD against one asks for
 	// that response's headers rather than for the filter metadata HEAD means
 	// everywhere else; an explicit ?__lookup=filters still reaches the lookup.

--- a/rpc/serve.go
+++ b/rpc/serve.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/flanksource/clicky"
+	"github.com/flanksource/clicky/entity"
 	"github.com/flanksource/clicky/formatters"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -303,7 +304,21 @@ func (s *SwaggerServer) renderSpec(format specFormat) (*specDocument, error) {
 		return nil, fmt.Errorf("failed to generate OpenAPI spec: %w", err)
 	}
 
+	doc, err := encodeSpec(spec, format)
+	if err != nil {
+		return nil, err
+	}
+	if s.specDocs == nil {
+		s.specDocs = make(map[specFormat]*specDocument, 2)
+	}
+	s.specDocs[format] = doc
+	return doc, nil
+}
+
+// encodeSpec renders a document and its content validator.
+func encodeSpec(spec *OpenAPISpec, format specFormat) (*specDocument, error) {
 	var body []byte
+	var err error
 	if format == specFormatYAML {
 		body, err = yaml.Marshal(spec)
 	} else {
@@ -312,13 +327,31 @@ func (s *SwaggerServer) renderSpec(format specFormat) (*specDocument, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode OpenAPI spec as %s: %w", format, err)
 	}
+	return &specDocument{body: body, etag: contentETag(body)}, nil
+}
 
-	doc := &specDocument{body: body, etag: contentETag(body)}
-	if s.specDocs == nil {
-		s.specDocs = make(map[specFormat]*specDocument, 2)
+// specDocument returns the document to serve this request.
+//
+// The memoized rendering is a pure function of the command tree, which a
+// dynamic-entity family is not part of: its instances come and go while the
+// server runs, so a document that described them would be stale the moment it
+// was cached. A consumer with no families therefore never leaves the cache,
+// and one with families pays a rendering per request for a document that is
+// true when it is read — which is the point of registering a family at all.
+func (s *SwaggerServer) specDocument(r *http.Request, format specFormat) (*specDocument, error) {
+	families := entity.GetDynamicEntityFamilies()
+	if len(families) == 0 {
+		return s.renderSpec(format)
 	}
-	s.specDocs[format] = doc
-	return doc, nil
+
+	spec, err := s.generator.GenerateFromCobraWithConfig(s.rootCmd, s.converterCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OpenAPI spec: %w", err)
+	}
+	if err := s.addFamilyPaths(r.Context(), spec, families); err != nil {
+		return nil, err
+	}
+	return encodeSpec(spec, format)
 }
 
 // serveSpec writes a rendered OpenAPI document, answering a matching
@@ -333,7 +366,7 @@ func (s *SwaggerServer) serveSpec(w http.ResponseWriter, r *http.Request, format
 		return
 	}
 
-	doc, err := s.renderSpec(format)
+	doc, err := s.specDocument(r, format)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -581,6 +614,17 @@ func (s *SwaggerServer) registerExecutionRoutes(mux *http.ServeMux) {
 			registerRoute(http.MethodGet, path, op.Name+" lookup")
 		}
 	}
+
+	// A family registers one route for a shape, not one per instance: its
+	// instances are created after this has run and could never be enumerated
+	// here. Go 1.22's ServeMux routes HEAD to the GET pattern, so these three are
+	// every method a family answers.
+	for _, family := range entity.GetDynamicEntityFamilies() {
+		path := s.pathPrefix() + "/" + family.Name + "/{name}"
+		for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodOptions} {
+			registerRoute(method, path, family.Name+" family")
+		}
+	}
 	clicky.Infof("Registered %d executor routes", routeCount)
 }
 
@@ -648,7 +692,13 @@ func (s *SwaggerServer) executeCommandCore(r *http.Request) (any, *ExecutionResp
 		}
 		return resp, resp, http.StatusNotFound, fmt.Errorf("operation not found")
 	}
+	return s.executeOperation(r, op)
+}
 
+// executeOperation is executeCommandCore against an operation the caller already
+// has. A dynamic-family instance is resolved per request and never enters the
+// route table, so it can only be executed by being handed over directly.
+func (s *SwaggerServer) executeOperation(r *http.Request, op *RPCOperation) (any, *ExecutionResponse, int, error) {
 	// Extract request parameters
 	req, err := s.executor.ExtractRequestFromHTTP(r, op)
 	if err != nil {
@@ -693,8 +743,23 @@ func (s *SwaggerServer) handleExecuteCommand(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// A family's instances come into being while the server runs, so they are not
+	// in the route table this handler was reached through. Reading the path is
+	// what lets an entity that did not exist at startup be served at all.
+	if family, name, matched := s.matchDynamicFamily(r.URL.Path); matched {
+		s.handleDynamicFamily(w, r, family, name)
+		return
+	}
+
 	lookupRequested := isLookupRequest(r)
 	op := s.executor.FindOperation(r.Method, r.URL.Path)
+	// A paged operation owns its own response. A bare HEAD against one asks for
+	// that response's headers rather than for the filter metadata HEAD means
+	// everywhere else; an explicit ?__lookup=filters still reaches the lookup.
+	if paged := s.pagedOperation(r, op); paged != nil && !explicitLookup(r) {
+		s.handlePagedCommand(w, r, paged, paged.PagedFunc, exportName(paged))
+		return
+	}
 	if lookupRequested {
 		if !hasLookup(op) {
 			op = s.executor.FindLookupOperation(r.Method, r.URL.Path)
@@ -714,7 +779,12 @@ func (s *SwaggerServer) handleExecuteCommand(w http.ResponseWriter, r *http.Requ
 
 	// Execute command and get data + metadata
 	data, metadata, statusCode, _ := s.executeCommandCore(r)
+	s.writeExecutionResult(w, r, data, metadata, statusCode)
+}
 
+// writeExecutionResult writes the metadata headers and the formatted body of an
+// executed operation.
+func (s *SwaggerServer) writeExecutionResult(w http.ResponseWriter, r *http.Request, data any, metadata *ExecutionResponse, statusCode int) {
 	// Add execution metadata headers
 	if metadata != nil {
 		w.Header().Set("X-CLI-Command", metadata.CLI)

--- a/shutdown/shutdown.go
+++ b/shutdown/shutdown.go
@@ -3,6 +3,7 @@ package shutdown
 import (
 	"container/heap"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"sync"
@@ -61,6 +62,7 @@ var (
 	once                sync.Once
 	terminalRestoreFunc func()
 	terminalRestoreMu   sync.Mutex
+	terminalWriter      io.Writer = os.Stderr
 )
 
 // SetTerminalRestoreFunc registers a callback that performs full terminal
@@ -70,6 +72,21 @@ func SetTerminalRestoreFunc(fn func()) {
 	terminalRestoreMu.Lock()
 	defer terminalRestoreMu.Unlock()
 	terminalRestoreFunc = fn
+}
+
+// SetTerminalWriter points the terminal reset at the writer that owns the
+// terminal, so the sequence serializes with everything else clicky prints
+// there. It must be a writer that reaches the terminal synchronously: the reset
+// is terminal control, not log output, and a writer that defers or drops it
+// leaves the cursor hidden after exit. Defaults to os.Stderr — the writer this
+// package can reach without depending on the renderer that sits above it.
+func SetTerminalWriter(w io.Writer) {
+	terminalRestoreMu.Lock()
+	defer terminalRestoreMu.Unlock()
+	if w == nil {
+		w = os.Stderr
+	}
+	terminalWriter = w
 }
 
 // restoreTerminal ensures terminal is in a clean state before exit.
@@ -86,12 +103,14 @@ func SetTerminalRestoreFunc(fn func()) {
 // alternate screen restores it through SetTerminalRestoreFunc, which knows it
 // entered.
 func restoreTerminal() {
-	if term.IsTerminal(int(os.Stderr.Fd())) {
-		fmt.Fprint(os.Stderr, "\x1b[?25h\x1b[0m")
-	}
 	terminalRestoreMu.Lock()
+	writer := terminalWriter
 	fn := terminalRestoreFunc
 	terminalRestoreMu.Unlock()
+
+	if term.IsTerminal(int(os.Stderr.Fd())) {
+		fmt.Fprint(writer, "\x1b[?25h\x1b[0m")
+	}
 	if fn != nil {
 		fn()
 	}

--- a/shutdown/shutdown.go
+++ b/shutdown/shutdown.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flanksource/commons/logger"
+	"golang.org/x/term"
 )
 
 const (
@@ -74,8 +75,20 @@ func SetTerminalRestoreFunc(fn func()) {
 // restoreTerminal ensures terminal is in a clean state before exit.
 // Uses raw ANSI escapes as a safety net, then calls the registered
 // restore callback for full term.Restore if available.
+//
+// The escapes are only meaningful to a terminal; writing them to a redirected
+// stderr appends junk bytes to whatever the user captured.
+//
+// Deliberately no "\x1b[?1049l": nothing here ever enters the alternate screen,
+// and asking a terminal to leave a buffer it was never in is not a no-op
+// everywhere — terminals that honour it restore the primary buffer and discard
+// the output the command just finished printing. A consumer that does use the
+// alternate screen restores it through SetTerminalRestoreFunc, which knows it
+// entered.
 func restoreTerminal() {
-	fmt.Fprint(os.Stderr, "\x1b[?1049l\x1b[?25h\x1b[0m")
+	if term.IsTerminal(int(os.Stderr.Fd())) {
+		fmt.Fprint(os.Stderr, "\x1b[?25h\x1b[0m")
+	}
 	terminalRestoreMu.Lock()
 	fn := terminalRestoreFunc
 	terminalRestoreMu.Unlock()
@@ -115,7 +128,7 @@ func AddHookWithPriority(label string, priority int, fn func()) {
 
 // Shutdown executes all registered hooks in priority order
 func Shutdown() {
-	logger.Infof("Starting graceful shutdown with %d hooks", len(hooks))
+	logger.Debugf("Starting graceful shutdown with %d hooks", len(hooks))
 	hooksMux.Lock()
 	defer hooksMux.Unlock()
 
@@ -126,7 +139,7 @@ func Shutdown() {
 		return
 	}
 
-	logger.Infof("Executing %d shutdown hooks", len(hooks))
+	logger.Debugf("Executing %d shutdown hooks", len(hooks))
 
 	// Execute hooks in priority order (lowest priority first)
 	for hooks.Len() > 0 {
@@ -143,8 +156,8 @@ func Shutdown() {
 		}()
 	}
 
-	logger.Infof("All shutdown hooks executed")
-	restoreTerminal()
+	// The deferred restoreTerminal above already covers every return path.
+	logger.Debugf("All shutdown hooks executed")
 }
 
 // WaitForSignal waits for interrupt signals and triggers shutdown

--- a/task/manager.go
+++ b/task/manager.go
@@ -296,7 +296,7 @@ func newManagerWithConcurrency(maxConcurrent int) *Manager {
 		select {
 		case success := <-done:
 			if success {
-				logger.Infof("All tasks completed gracefully")
+				logger.Debugf("All tasks completed gracefully")
 			} else {
 				logger.Warnf("Task shutdown timeout reached")
 			}


### PR DESCRIPTION
## What
- Expose producer-defined entity hierarchy paths through annotations, dynamic entities, and OpenAPI.
- Omit zero-value typed handler data from failed RPC error envelopes.

## Why
- Let clients render nested groups reliably and avoid misleading failed-action payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated and streaming exports with format negotiation, totals, truncation indicators, downloads, and configurable lookup limits.
  * Added dynamic entity families with runtime discovery, routing, lookup, and OpenAPI support.
  * Added primary entity actions and local-only command controls.
  * Added NDJSON and in-memory Excel formatting, plus optional CSV streaming enhancements.
  * Added gzip response compression and terminal resize handling.

* **Bug Fixes**
  * Improved error responses, HTTP method detection, ANSI styling isolation, terminal sizing fallbacks, and nested JSON serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->